### PR TITLE
Fixed minor issue with build/test configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "finp2p-nodejs-skeleton-adapter",
   "version": "0.1",
   "description": "",
-  "main": "dist/src/index.js",
+  "main": "dist/index.js",
   "homepage": "https://ownera.io/",
   "scripts": {
     "clean": "rm -rf dist",
     "api-generate": "dtsgen -o ./src/services/model-gen.ts dlt-adapter-api.yaml",
     "prebuild": "eslint ./src --ext .ts --fix",
-    "build": "tsc",
+    "build": "tsc -P tsconfig.build.json",
     "test": "jest",
     "start": "node ."
   },

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["tests"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,6 @@
   },
   "include": [
     "src/**/*.ts",
-    "test/**/*.ts",
+    "tests/**/*.ts",
   ]
 }


### PR DESCRIPTION
Build/tests configuration had minor flaws that needed fixing to run the application properly and have full TypeScript support for unit tests.

The `tsconfig.json` had a misspelled "include" setting for tests, leading to:
- Language errors in tests in the IDE.
- `package.json` main referencing an incorrect directory (since tests are not in the build, the JavaScript generated from the `src` folder ended up in the `dist` root).

To fix this and prevent tests from build, I suggest having two separate TypeScript configurations:
- `tsconfig.json` - same as before, with the spelling fixed.
- `tsconfig.build.json` - extending `tsconfig.json` and excluding the `tests` folder from the build.