### PR TITLE
Fix finp2p-client: include .graphql files in published package

### DIFF
--- a/finp2p-client/package.json
+++ b/finp2p-client/package.json
@@ -12,6 +12,7 @@
     "prebuild": "eslint ./src --ext .ts --fix",
     "build": "tsc",
     "postbuild": "cpx 'src/oss/graphql/*.graphql' dist/oss/graphql/",
+    "prepublishOnly": "npm run build",
     "api-generate": "npx openapi-typescript ./apis/application-api.base.yaml -o src/finapi/model-gen.ts",
     "op-api-generate": "npx openapi-typescript ./apis/operational-api.yaml -o src/finapi/op-model-gen.ts",
     "graphql-gen": "graphql-codegen --config grahpqlgen.ts",


### PR DESCRIPTION
## Summary
- Add prepublishOnly script to finp2p-client/package.json to ensure npm run build (including postbuild cpx step) runs before npm publish
- The postbuild step copies .graphql files from src/oss/graphql/ to dist/oss/graphql/, but npm publish does not trigger build/postbuild lifecycle hooks automatically
- Without prepublishOnly, publishing outside CI produces a package missing the .graphql files required by graphql-import-node at runtime

## Problem
The published @owneraio/finp2p-client package is missing .graphql files in dist/oss/graphql/. At runtime, graphql-import-node tries to require('./graphql/owners.graphql') and fails with Cannot find module.

The CI workflow (publish-client.yml) runs npm run build before npm publish, which should copy the files. However, the standard npm safety net (prepublishOnly) is missing — if the package is ever published manually or via a different pipeline, the .graphql files won't be included.

## Fix
Add "prepublishOnly": "npm run build" — the standard npm pattern for ensuring the build runs before every publish, regardless of how publish is triggered.

## Test plan
- [ ] rm -rf dist && npm run build — verify .graphql files in dist/oss/graphql/
- [ ] npm pack --dry-run — verify .graphql files listed in tarball contents
- [ ] Publish a patch release and verify the package includes .graphql files