### PR TITLE
Add CLAUDE.md documentation for all subprojects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,121 @@
+# FinP2P Node.js Skeleton Adapter &mdash; Monorepo
+
+## What is this
+
+A monorepo for building **FinP2P ledger adapters** in Node.js. The FinP2P protocol enables cross-organization orchestration of financial operations (DvP, Repo, collateral mobility, etc.) through a **router** (node) that decomposes high-level business operations into simple executable instructions. An **adapter** translates those instructions into ledger-specific operations (e.g., Ethereum ERC-20 movements, Canton CIP-56 movements, Hyperledger Fabric chaincode calls).
+
+This skeleton provides the boilerplate so adapter developers only need to implement **service interfaces** corresponding to their ledger's capabilities.
+
+## How the FinP2P adapter fits in
+
+```
+  FinP2P Router (Node)
+       |
+       | DLT Adapter API (OpenAPI)
+       v
+  ┌─────────────────────────────────┐
+  │  skeleton (Express routes,      │
+  │  mapping, workflow persistence) │
+  │         |                       │
+  │    Service interfaces           │
+  │    (from adapter-models)        │
+  │         |                       │
+  │  YOUR IMPLEMENTATION            │
+  │  (e.g. Ethereum, Canton, etc.)  │
+  └─────────────────────────────────┘
+```
+
+The router is responsible for cross-organization orchestration. It defines the API spec (`dlt-adapter-api.yaml`). The adapter implements that API, translating FinP2P instructions into ledger-specific calls.
+
+## Service capabilities
+
+Each adapter implements a subset of these service interfaces (defined in `finp2p-adapter-models`):
+
+| Service | Ledger capability | Operations |
+|---------|------------------|------------|
+| **TokenService** | Token lifecycle | createAsset, issue (mint), transfer, redeem (burn), balance |
+| **EscrowService** | Escrow / holds | hold, release, rollback |
+| **PaymentService** | Fiat/crypto payments | deposit instruction, payout |
+| **PlanApprovalService** | Execution plan control | approve plan, propose cancel/reset/instruction, proposal status |
+| **CommonService** | Cross-cutting | get receipt, operation status |
+
+Plan approval is not mandatory but gives the adapter context about the orchestration plan, an extra preparation step, and a way to stop the orchestration before execution begins.
+
+## Subprojects
+
+| Package | npm name | Purpose | CLAUDE.md |
+|---------|----------|---------|-----------|
+| [finp2p-adapter-models](finp2p-adapter-models/) | `@owneraio/finp2p-adapter-models` | Domain types and service interfaces &mdash; the contract every adapter implements | [CLAUDE.md](finp2p-adapter-models/CLAUDE.md) |
+| [skeleton](skeleton/) | `@owneraio/finp2p-nodejs-skeleton-adapter` | Express routes, API mapping, async workflow persistence, plugin system, default service implementations | [CLAUDE.md](skeleton/CLAUDE.md) |
+| [finp2p-client](finp2p-client/) | `@owneraio/finp2p-client` | TypeScript client for the FinP2P router (REST + GraphQL) | [CLAUDE.md](finp2p-client/CLAUDE.md) |
+| [adapter-tests](adapter-tests/) | `@owneraio/adapter-tests` | Reusable integration test suite for any adapter | [CLAUDE.md](adapter-tests/CLAUDE.md) |
+| [sample-adapter](sample-adapter/) | `@owneraio/sample-adapter` | Reference implementation with in-memory storage | [CLAUDE.md](sample-adapter/CLAUDE.md) |
+
+## Dependency graph
+
+```
+finp2p-adapter-models  (domain types, interfaces)
+    |
+    +---> skeleton  (framework: routes, workflows, plugins)
+    |        |
+    |        +---> finp2p-client  (router communication)
+    |
+    +---> adapter-tests  (integration tests)
+    |        |
+    |        +---> skeleton
+    |
+    +---> sample-adapter  (reference implementation)
+             |
+             +---> skeleton
+             +---> adapter-tests  (dev dependency)
+             +---> finp2p-client
+```
+
+## Versioning strategy
+
+**Major.minor** version is correlated with the FinP2P router (node) version. For example, adapter packages at `0.27.x` are compatible with router `0.27.x`. Patch versions are for adapter-side changes that don't require router changes.
+
+When the router releases a new version:
+1. Update API specs in `skeleton/apis/` and `finp2p-client/apis/` from the router repo
+2. Regenerate types (`npm run api-generate` in both)
+3. Update interfaces in `finp2p-adapter-models` if needed
+4. Bump versions and propagate dependencies
+
+## Publishing
+
+Each subproject has its own GitHub Actions workflow triggered by git tags:
+
+| Tag pattern | Package published | Registry |
+|-------------|------------------|----------|
+| `finp2p-adapter-models-v*` | `@owneraio/finp2p-adapter-models` | npm public + GitHub Packages |
+| `skeleton-v*` | `@owneraio/finp2p-nodejs-skeleton-adapter` | GitHub Packages |
+| `finp2p-client-v*` | `@owneraio/finp2p-client` | GitHub Packages |
+| `adapter-tests-v*` | `@owneraio/adapter-tests` | GitHub Packages |
+
+**Publish order matters** due to dependencies: adapter-models first, then skeleton and finp2p-client, then adapter-tests, then sample-adapter.
+
+## CI
+
+The CI workflow (`.github/workflows/ci.yml`) runs on every PR and push to master. It builds and tests all subprojects in dependency order:
+1. finp2p-client &rarr; build
+2. finp2p-adapter-models &rarr; build
+3. adapter-tests &rarr; build
+4. skeleton &rarr; build + test (requires PostgreSQL via testcontainers + goose)
+5. sample-adapter &rarr; build + test (requires PostgreSQL via testcontainers + goose)
+
+## Development setup
+
+Each subproject has its own `package.json` and `node_modules`. There is no workspace-level package manager &mdash; install and build each subproject independently.
+
+```bash
+# Build adapter-models (no external deps)
+cd finp2p-adapter-models && npm install && npm run build
+
+# Build skeleton (depends on published adapter-models + finp2p-client)
+cd skeleton && npm install && npm run build
+
+# Build and test sample-adapter (depends on all of the above)
+cd sample-adapter && npm install && npm run build && npm test
+```
+
+For local development across subprojects, you can temporarily `npm install ../finp2p-adapter-models` etc., but **remember to restore the version range** in `package.json` before committing (the `file:` protocol breaks CI).

--- a/adapter-tests/CLAUDE.md
+++ b/adapter-tests/CLAUDE.md
@@ -1,0 +1,78 @@
+# adapter-tests
+
+> `@owneraio/adapter-tests` &mdash; Published to **GitHub Packages**
+
+## Purpose
+
+Reusable **integration test suite** for FinP2P ledger adapters. Any adapter built on the skeleton can import this package and run the full test suite against its implementation to verify correctness. This ensures all adapters conform to the same behavioral contract.
+
+## How it works
+
+The test suite is published as an npm package. An adapter project (like `sample-adapter`) imports and invokes it in a single line:
+
+```typescript
+// tests/adapter.test.ts
+import { runAdapterTests } from "@owneraio/adapter-tests";
+runAdapterTests();
+```
+
+The test environment (provided by the adapter project, not this package) is responsible for:
+1. Starting a database (typically PostgreSQL via testcontainers)
+2. Creating and starting the adapter Express app
+3. Exposing `global.serverAddress` for the test client to connect to
+
+## Test suites
+
+### Token lifecycle (`src/token-lifecycle.test.ts`)
+End-to-end flow: create asset, issue tokens, transfer between accounts, verify balances.
+
+### Business logic (`src/business-logic.test.ts`)
+Comprehensive tests including:
+- Issue and redeem flows
+- Escrow operations (hold, release, rollback)
+- Negative tests: rollback of released holds, double operations, wrong actor scenarios
+- Partial release of held funds
+
+### Insufficient balance (`src/insufficient-balance.test.ts`)
+Validates error handling when operations exceed available balances.
+
+## Test infrastructure
+
+### API client (`src/api/`)
+
+- **`api.ts`** &mdash; Typed HTTP client classes mirroring the DLT adapter API:
+  - `TokensLedgerAPI` &mdash; create, issue, redeem, transfer
+  - `EscrowLedgerAPI` &mdash; hold, release, rollback
+  - `PaymentsLedgerAPI` &mdash; deposit instruction, payout
+  - `PlanLedgerAPI` &mdash; approve, proposal, proposal status
+  - `CommonLedgerAPI` &mdash; receipts, operation status, balance
+  - `LedgerAPIClient` &mdash; unified facade with helper methods like `expectBalance()`
+- **`base.ts`** &mdash; `ClientBase` with axios HTTP methods and optional OpenAPI validation
+- **`mapper.ts`** &mdash; Test data mapping utilities
+
+### Test utilities (`src/utils/`)
+
+- **`test-builders.ts`** &mdash; `TestDataBuilder` for constructing signed requests (uses secp256k1)
+- **`test-fixtures.ts`** &mdash; `TestFixtures` for common setup scenarios (issued tokens, held funds)
+- **`test-assertions.ts`** &mdash; `ReceiptAssertions` for validating receipt structure
+- **`test-constants.ts`** &mdash; Addresses, amounts, scenario parameters
+- **`openapi-validator.ts`** &mdash; Optional request/response validation against the OpenAPI spec
+
+### Callback server (`src/callback-server/`)
+
+Mock callback server for testing async operation flows (callback response strategy).
+
+## Build & publish
+
+```bash
+npm run build   # tsc
+```
+
+Publish is triggered by git tag `adapter-tests-v*`.
+
+## See also
+
+- [Top-level CLAUDE.md](../CLAUDE.md) &mdash; monorepo overview
+- [sample-adapter/CLAUDE.md](../sample-adapter/CLAUDE.md) &mdash; uses this test suite
+- [skeleton/CLAUDE.md](../skeleton/CLAUDE.md) &mdash; the framework these tests validate
+- [finp2p-adapter-models/CLAUDE.md](../finp2p-adapter-models/CLAUDE.md) &mdash; types used by the API client

--- a/finp2p-adapter-models/CLAUDE.md
+++ b/finp2p-adapter-models/CLAUDE.md
@@ -1,0 +1,74 @@
+# finp2p-adapter-models
+
+> `@owneraio/finp2p-adapter-models` &mdash; Published to both **npm public** and **GitHub Packages**
+
+## Purpose
+
+Domain model and service interfaces for FinP2P ledger adapters. This is the **contract layer** that every adapter must implement. It decouples the adapter skeleton (HTTP routing, workflow persistence) from the ledger-specific logic, so that building a new adapter boils down to implementing a handful of service interfaces.
+
+## What's inside
+
+### Domain types (`src/model.ts`)
+
+Platform-neutral types that mirror the FinP2P protocol concepts without leaking OpenAPI specifics:
+
+- **Asset model** &mdash; `Asset`, `AssetType`, `DepositAsset`, identifiers (ISIN, CUSIP, DTI, etc.), denominations
+- **Accounts** &mdash; `FinIdAccount`, `CryptocurrencyWallet`, `IbanIdentifier`, `Source`, `Destination`
+- **Execution plans** &mdash; `ExecutionPlan`, `ExecutionInstruction`, `ExecutionPlanOperation` (hold, release, issue, transfer, await, revertHold, redeem) and plan investor/contract types
+- **Plan proposals** &mdash; `PlanProposal` discriminated union: `cancel`, `reset` (to a specific instruction), `instruction` (per-instruction approval)
+- **Operation results** &mdash; Each operation category has a success/failure/pending tri-state:
+  - `ReceiptOperation` &mdash; for issue, transfer, redeem, hold, release, rollback, payout
+  - `AssetCreationStatus` &mdash; for createAsset
+  - `PlanApprovalStatus` &mdash; approved/rejected/pending for plan operations
+  - `DepositOperation` &mdash; for payment deposits
+- **Signatures & Proofs** &mdash; `Signature`, `SignatureTemplate` (hashList or EIP712), `ProofPolicy`
+- **Receipts** &mdash; `Receipt` with full transaction/trade details and proof
+
+### Service interfaces (`src/interfaces.ts`)
+
+These are the interfaces adapter developers implement. Each maps to a ledger capability:
+
+| Interface | Capability | Methods |
+|-----------|-----------|---------|
+| `TokenService` | Token lifecycle | `createAsset`, `issue`, `transfer`, `redeem`, `balance`, `getBalance` |
+| `EscrowService` | Escrow operations | `hold`, `release`, `rollback` |
+| `PaymentService` | Fiat/crypto payments | `getDepositInstruction`, `payout` |
+| `PlanApprovalService` | Execution plan control | `approvePlan`, `proposeCancelPlan`, `proposeResetPlan`, `proposeInstructionApproval`, `proposalStatus` |
+| `CommonService` | Cross-cutting | `getReceipt`, `operationStatus` |
+| `HealthService` | Health checks | `liveness`, `readiness` |
+
+### Plugin interfaces (`src/plugins/`)
+
+Extension points for cross-cutting concerns (sync and async variants):
+
+- `PlanApprovalPlugin` / `AsyncPlanApprovalPlugin` &mdash; validate issuance/transfer/redemption within a plan
+- `PaymentsPlugin` / `AsyncPaymentsPlugin` &mdash; deposit/payout logic
+- `AssetCreationPlugin` / `AsyncAssetCreationPlugin` &mdash; post-creation validation
+- `TransactionHook` &mdash; pre/post transaction hooks
+- `LedgerCallbackService` &mdash; async operation result delivery
+
+### Utilities
+
+- `src/eip712.ts` &mdash; EIP-712 typed data structures
+- `src/hashList.ts` &mdash; Hash list signature computation
+- `src/utils.ts` &mdash; Correlation ID generation, helpers
+- `src/errors.ts` &mdash; `BusinessError`, `ConfigurationError`, `ValidationError`
+- `src/logger.ts` &mdash; Logger interface
+
+## Versioning
+
+Major.minor version is correlated with the FinP2P router (node) version (e.g. adapter-models 0.27.x is for router 0.27.x). Patch versions are for adapter-side changes that don't require router changes.
+
+## Build & publish
+
+```bash
+npm run build   # tsc
+```
+
+Publish is triggered by git tag `finp2p-adapter-models-v*`. Publishes to **both** public npm (`@owneraio/finp2p-adapter-models`) and GitHub Packages.
+
+## See also
+
+- [Top-level CLAUDE.md](../CLAUDE.md) &mdash; monorepo overview and dependency graph
+- [skeleton/CLAUDE.md](../skeleton/CLAUDE.md) &mdash; consumes these interfaces for HTTP routing and workflow persistence
+- [sample-adapter/CLAUDE.md](../sample-adapter/CLAUDE.md) &mdash; reference implementation of these interfaces

--- a/finp2p-client/CLAUDE.md
+++ b/finp2p-client/CLAUDE.md
@@ -1,0 +1,73 @@
+# finp2p-client
+
+> `@owneraio/finp2p-client` &mdash; Published to **GitHub Packages**
+
+## Purpose
+
+TypeScript client for communicating with the **FinP2P router (node)**. Used by the adapter skeleton and adapter implementations to:
+
+- Fetch execution plans for validation during plan approval
+- Send async operation callbacks to the router
+- Query assets, profiles, organizations, and proof policies from the node's OSS (Object Storage Service)
+- Import transactions
+- Wait for operation completion (polling)
+
+## Architecture
+
+### FinAPI client (`src/finapi/`)
+
+REST client for the FinP2P router's application and operational APIs:
+
+- **`model-gen.ts`** &mdash; Types generated from the router's `application-api.base.yaml` OpenAPI spec
+- **`op-model-gen.ts`** &mdash; Types generated from the router's `operational-api.yaml` OpenAPI spec (includes the `operationStatus` type used for callbacks)
+- **`finapi.client.ts`** &mdash; `FinAPIClient` &mdash; HTTP client using `openapi-fetch`. Key methods: `createAsset`, `shareProfile`, `getOperationStatus`, `sendCallback`, `importTransactions`, `getExecutionPlan`, `waitForOperationCompletion`
+
+### OSS client (`src/oss/`)
+
+GraphQL client for the router's Object Storage Service:
+
+- **`oss.client.ts`** &mdash; `OssClient` &mdash; queries assets, payment assets, owners, organizations, balances
+- **`model.ts`** &mdash; Domain types for OSS responses (assets, proof policies, proof domains)
+- **`graphql.d.ts`** &mdash; Generated GraphQL type definitions
+
+### Unified client (`src/client.ts`)
+
+`FinP2PClient` &mdash; combines both FinAPI and OSS clients into a single facade. This is what adapter code typically imports:
+
+```typescript
+const client = new FinP2PClient(finAPIUrl, ossUrl);
+await client.getExecutionPlan(planId);
+await client.sendCallback(cid, operationStatus);
+await client.getAssetProofPolicy(assetCode, assetType, paymentOrgId);
+```
+
+## API spec management
+
+Specs are sourced from the FinP2P router repo (`apis/` directory):
+
+```bash
+npm run api-generate       # application API types
+npm run op-api-generate    # operational API types (with post-processing)
+npm run graphql-gen        # GraphQL types from .graphql schema files
+npm run generate-all       # all of the above
+```
+
+The operational API post-processor (`scripts/postprocess-model-gen.ts`) handles the same circular reference and export issues as the skeleton's post-processor.
+
+## Build & publish
+
+```bash
+npm run build   # tsc + copy .graphql files to dist/
+```
+
+Publish is triggered by git tag `finp2p-client-v*`.
+
+## Versioning
+
+Major.minor correlates with the FinP2P router version. The client's API types must match the router version it communicates with.
+
+## See also
+
+- [Top-level CLAUDE.md](../CLAUDE.md) &mdash; monorepo overview
+- [skeleton/CLAUDE.md](../skeleton/CLAUDE.md) &mdash; uses this client for plan approval, proof generation, and callbacks
+- [finp2p-adapter-models/CLAUDE.md](../finp2p-adapter-models/CLAUDE.md) &mdash; domain model (the client provides router-side types, adapter-models provides adapter-side types)

--- a/sample-adapter/CLAUDE.md
+++ b/sample-adapter/CLAUDE.md
@@ -1,0 +1,78 @@
+# sample-adapter
+
+> `@owneraio/sample-adapter` &mdash; Published to **GitHub Packages**
+
+## Purpose
+
+**Reference implementation** of a FinP2P ledger adapter using the skeleton framework. Demonstrates how to build an adapter by implementing the service interfaces with in-memory storage. Serves as both a template for new adapters and a testbed for the skeleton + adapter-tests packages.
+
+This is **not** a production adapter. It emulates ledger functionality in memory. For real deployments, replace the in-memory services with actual ledger integrations (e.g., Ethereum ERC-20, Canton CIP-56, Hyperledger Fabric).
+
+## Architecture
+
+### Entry point (`src/index.ts`)
+
+Reads configuration from environment variables, optionally creates a `FinP2PClient`, and starts the Express server.
+
+**Environment variables:**
+- `PORT` &mdash; Server port (default: 3000)
+- `ORGANIZATION_ID` &mdash; Required. The adapter's organization ID in the FinP2P network.
+- `FINP2P_ADDRESS` &mdash; Optional. FinP2P router API URL (enables plan approval via router).
+- `OSS_URL` &mdash; Optional. OSS GraphQL URL (enables proof generation).
+- `SIGNER_PRIVATE_KEY` &mdash; Optional. Private key for receipt proofs.
+
+### App setup (`src/app.ts`)
+
+Creates the Express app and wires everything together:
+
+```typescript
+const tokenService = new TokenServiceImpl(storage, proofProvider);
+const escrowService = new EscrowServiceImpl(storage, proofProvider);
+const paymentsService = new PaymentsServiceImpl(pluginManager);
+const planApprovalService = new PlanApprovalServiceImpl(orgId, pluginManager, finP2PClient);
+
+routes.register(app, tokenService, escrowService, tokenService, tokenService, paymentsService, planApprovalService, pluginManager, migrationsConfig);
+```
+
+Note: `tokenService` implements both `TokenService`, `CommonService`, and `HealthService` in this sample (via `CommonServiceImpl` base class).
+
+### In-memory services (`src/services/inmemory/`)
+
+- **`storage.ts`** &mdash; `Storage` &mdash; in-memory maps for assets, accounts, and hold operations. Tracks balances per (finId, assetId) pair.
+- **`accounts.ts`** &mdash; `Account` &mdash; balance tracking with credit/debit operations.
+- **`tokens.ts`** &mdash; `TokenServiceImpl` implements `TokenService`: create asset, issue (mint), transfer, redeem (burn), balance queries. Generates receipts with optional ledger proofs.
+- **`escrow.ts`** &mdash; `EscrowServiceImpl` implements `EscrowService`: hold (escrow funds), release (to destination), rollback (return to source).
+- **`common.ts`** &mdash; `CommonServiceImpl` &mdash; base class providing receipt storage, health checks, and `getReceipt`/`operationStatus` from in-memory transaction log.
+- **`model.ts`** &mdash; `Transaction`, `HoldOperation` &mdash; internal models for building receipts.
+
+### Plugins (`src/plugins/`)
+
+- **`delayed-approvals.ts`** &mdash; `DelayedApprovals` implements `AsyncPlanApprovalPlugin`. Demonstrates async plan approval: validates via the FinP2P router and sends callback when done. Only active when `FinP2PClient` is configured.
+
+## Tests
+
+Tests use the shared `@owneraio/adapter-tests` suite:
+
+```typescript
+// tests/adapter.test.ts
+import { runAdapterTests } from "@owneraio/adapter-tests";
+runAdapterTests();
+```
+
+The test environment (`tests/test-environment.ts`) starts a PostgreSQL container via testcontainers, runs goose migrations, and starts the sample adapter app.
+
+## Build & run
+
+```bash
+npm run build        # tsc
+npm test             # jest (requires Docker for testcontainers + goose)
+npm run start        # node . (production)
+npm run start-debug  # ts-node (development)
+```
+
+## See also
+
+- [Top-level CLAUDE.md](../CLAUDE.md) &mdash; monorepo overview
+- [skeleton/CLAUDE.md](../skeleton/CLAUDE.md) &mdash; the framework this adapter is built on
+- [finp2p-adapter-models/CLAUDE.md](../finp2p-adapter-models/CLAUDE.md) &mdash; interfaces implemented here
+- [adapter-tests/CLAUDE.md](../adapter-tests/CLAUDE.md) &mdash; test suite used here

--- a/skeleton/CLAUDE.md
+++ b/skeleton/CLAUDE.md
@@ -1,0 +1,109 @@
+# skeleton
+
+> `@owneraio/finp2p-nodejs-skeleton-adapter` &mdash; Published to **GitHub Packages**
+
+## Purpose
+
+The skeleton is the **main framework** for building FinP2P ledger adapters in Node.js. It provides everything except the ledger-specific logic: HTTP route handlers, request/response mapping, async workflow persistence, plugin management, and default service implementations.
+
+The goal is to narrow the scope of building a new adapter to **just implementing the service interfaces** (and optionally plugins) defined in `finp2p-adapter-models`. A developer wiring up an Ethereum adapter only writes ERC-20 logic; a Canton adapter only writes CIP-56 logic. The skeleton handles the rest.
+
+## Architecture
+
+### Route layer (`src/routes/`)
+
+- **`model-gen.ts`** &mdash; TypeScript types auto-generated from the DLT adapter API OpenAPI spec (`apis/dlt-adapter-api.yaml`). Generated via `npm run api-generate` using `openapi-typescript`, then post-processed by `scripts/postprocess-model-gen.ts` to handle circular references and export recursive types.
+- **`routes.ts`** &mdash; Express route handlers for all DLT adapter API endpoints. The `register()` function is the main entry point: it takes service implementations and wires them to HTTP endpoints. Endpoints:
+  - **Plan**: `POST /api/plan/approve`, `POST /api/plan/proposal`, `POST /api/plan/proposal/status`
+  - **Tokens**: `POST /api/assets/create`, `POST /api/assets/issue`, `POST /api/assets/transfer`, `POST /api/assets/redeem`, `POST /api/assets/getBalance`, `POST /api/asset/balance`
+  - **Escrow**: `POST /api/assets/hold`, `POST /api/assets/release`, `POST /api/assets/rollback`
+  - **Payments**: `POST /api/payments/depositInstruction`, `POST /api/payments/payout`
+  - **Common**: `GET /api/assets/receipts/:transactionId`, `GET /api/operations/status/:cid`
+  - **Health**: `GET /health`, `GET /health/liveness`, `GET /health/readiness`
+- **`mapping.ts`** &mdash; Bidirectional mapping functions between OpenAPI-generated types and domain model types from `finp2p-adapter-models`. Converts API request payloads into service method arguments and service results back into API responses.
+
+### Workflow layer (`src/workflows/`)
+
+Provides **idempotent async operation persistence** backed by PostgreSQL:
+
+- **`config.ts`** &mdash; Configuration interfaces: `MigrationConfig`, `StorageConfig`, `ProxyConfig` (callback support), `Config`
+- **`storage.ts`** &mdash; PostgreSQL-based operation store. Tracks operations by correlation ID (`cid`), with status (`in_progress` / `succeeded` / `failed`), inputs (for idempotency), and outputs. Also provides asset storage for adapters that need it.
+- **`service.ts`** &mdash; `createServiceProxy()` &mdash; the key abstraction. Wraps any service interface in a `Proxy` that:
+  1. Generates a correlation ID for each new operation
+  2. Stores the pending operation in PostgreSQL (deduplicates by input hash)
+  3. Returns a `pending` response immediately to the router
+  4. Executes the actual service method asynchronously
+  5. Updates the operation status on completion
+  6. Optionally sends a callback to the router via `FinP2PClient.sendCallback`
+  7. On restart, replays all `in_progress` operations
+- **`migrator.ts`** &mdash; Runs database migrations using [goose](https://github.com/pressly/goose) (Go-based migration tool). Migrations are in `migrations/*.sql`.
+
+### Service defaults (`src/services/`)
+
+Default implementations that adapter developers can extend or replace:
+
+- **`plan/service.ts`** &mdash; `PlanApprovalServiceImpl` &mdash; default plan approval that auto-approves if no FinP2P client is configured. When a client is available, fetches the execution plan from the router and validates instructions via plugins. Proposal endpoints (cancel/reset/instruction) default to auto-approve.
+- **`payments/payments.ts`** &mdash; `PaymentsServiceImpl` &mdash; delegates deposit/payout to plugins (sync or async variants). Returns failure if no plugin is registered.
+- **`proof/provider.ts`** &mdash; `ProofProvider` &mdash; generates cryptographic proofs (EIP-712 or hash-list) for receipts, fetching proof policies from the FinP2P node.
+- **`verify.ts`** &mdash; Signature verification utilities.
+
+### Plugin system (`src/plugins/`)
+
+- **`manager.ts`** &mdash; `PluginManager` &mdash; registry for optional plugins: asset creation, plan approval, payments, and transaction hooks. Each plugin slot supports sync or async variants via `Plugin<S, A>`.
+
+### Helpers (`src/helpers/`)
+
+- Logger, EIP-712 hashing, hash list computation utilities. Re-exported from `src/index.ts`.
+
+## How to build a new adapter
+
+1. Create a new project (or copy `sample-adapter`)
+2. Depend on `@owneraio/finp2p-nodejs-skeleton-adapter` and `@owneraio/finp2p-adapter-models`
+3. Implement the service interfaces that match your ledger's capabilities:
+   - `TokenService` for token issue/transfer/redeem (most adapters need this)
+   - `EscrowService` for hold/release/rollback
+   - Optionally register plugins for payments, plan approval, transaction hooks
+4. Call `routes.register(app, tokenService, escrowService, ...)` with your implementations
+5. Pass a `Config` if you want PostgreSQL-backed async workflows (recommended for production)
+
+## API spec management
+
+The OpenAPI spec `apis/dlt-adapter-api.yaml` is sourced from the FinP2P router (node) repo. To regenerate types:
+
+```bash
+npm run api-generate   # generates model-gen.ts from the YAML spec
+```
+
+A post-processor (`scripts/postprocess-model-gen.ts`) handles:
+- Circular type references that `openapi-typescript` can't resolve
+- Exporting recursive types for `.d.ts` declaration files
+- Quoting member names that contain hyphens
+
+## Database
+
+When workflow persistence is enabled, the skeleton uses PostgreSQL with a `ledger_adapter` schema. Migrations:
+- `20251020114833_initial_tables.sql` &mdash; `operations` table (cid, method, status, inputs, outputs)
+- `20260105064721_add_assets_table.sql` &mdash; `assets` table (id, type, contract_address, decimals)
+
+Migrations run automatically on startup via goose.
+
+## Build & publish
+
+```bash
+npm run build          # tsc
+npm run api-generate   # regenerate model-gen.ts from OpenAPI spec
+npm test               # jest (requires PostgreSQL via testcontainers + goose)
+```
+
+Publish is triggered by git tag `skeleton-v*`.
+
+## Versioning
+
+Major.minor correlates with the FinP2P router version (e.g. skeleton 0.27.x works with router 0.27.x).
+
+## See also
+
+- [Top-level CLAUDE.md](../CLAUDE.md) &mdash; monorepo overview and dependency graph
+- [finp2p-adapter-models/CLAUDE.md](../finp2p-adapter-models/CLAUDE.md) &mdash; service interfaces and domain types this skeleton consumes
+- [sample-adapter/CLAUDE.md](../sample-adapter/CLAUDE.md) &mdash; reference implementation using this skeleton
+- [adapter-tests/CLAUDE.md](../adapter-tests/CLAUDE.md) &mdash; integration test suite for adapters built with this skeleton


### PR DESCRIPTION
## Summary
- Added `CLAUDE.md` files to each subproject documenting purpose, architecture, and key files
- Added top-level `CLAUDE.md` with monorepo overview, dependency graph, versioning strategy, and publish workflow
- All files cross-reference each other via relative links

## Files
- `CLAUDE.md` — top-level monorepo overview
- `finp2p-adapter-models/CLAUDE.md` — domain types and service interfaces
- `skeleton/CLAUDE.md` — framework architecture and "how to build an adapter" guide
- `finp2p-client/CLAUDE.md` — router client (REST + GraphQL)
- `adapter-tests/CLAUDE.md` — reusable integration test suite
- `sample-adapter/CLAUDE.md` — reference implementation walkthrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)