### PR TITLE
Add JWT auth token resolver to finp2p-client

### DIFF
--- a/finp2p-client/package.json
+++ b/finp2p-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "description": "FinP2P API Client",
   "homepage": "https://ownera.io/",
   "main": "./dist/index.js",

--- a/finp2p-client/src/auth.ts
+++ b/finp2p-client/src/auth.ts
@@ -1,0 +1,57 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+
+export interface FinP2PAuthConfig {
+  orgId: string;
+  finApiUrl: string;
+  finApiOssUrl: string;
+  auth: {
+    key: string;
+    private: { raw: string };
+    secret: { raw: string; type: number };
+  };
+}
+
+/**
+ * Create a JWT token resolver for FinP2P API authentication.
+ *
+ * The FinP2P API expects: { alg } header + { aud, apiKey, nonce, iat, exp } payload.
+ * Secret type 2 = RSA (RS256), type 1 = HMAC (HS256).
+ */
+export function createAuthTokenResolver(orgId: string, auth: FinP2PAuthConfig['auth']): () => string {
+  const apiKey = auth.key;
+  const secretType = auth.secret?.type ?? 1;
+  const signingKey = secretType === 2 ? auth.private.raw : (auth.secret?.raw ?? auth.private.raw);
+  const algorithm = secretType === 2 ? 'RS256' : 'HS256';
+
+  return () => {
+    const now = Math.floor(Date.now() / 1000);
+
+    // Nonce: 24 random bytes + 8-byte timestamp
+    const nonceBuf = Buffer.alloc(32);
+    nonceBuf.fill(crypto.randomBytes(24), 0, 24);
+    nonceBuf.writeBigInt64BE(BigInt(now), 24);
+    const nonce = nonceBuf.toString('hex');
+
+    const header = JSON.stringify({ alg: algorithm });
+    const payload = JSON.stringify({ aud: orgId, apiKey, nonce, iat: now, exp: now + 30 });
+    const body = `${Buffer.from(header).toString('base64url')}.${Buffer.from(payload).toString('base64url')}`;
+
+    let signature: string;
+    if (algorithm === 'RS256') {
+      signature = crypto.createSign('RSA-SHA256').update(body).sign(signingKey).toString('base64url');
+    } else {
+      signature = crypto.createHmac('sha256', signingKey).update(body).digest('base64url');
+    }
+    return `${body}.${signature}`;
+  };
+}
+
+export function loadAuthFile(filePath: string): FinP2PAuthConfig {
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const config = JSON.parse(content) as FinP2PAuthConfig;
+  if (!config.auth?.key || !config.auth?.private?.raw) {
+    throw new Error(`Auth file ${filePath}: incomplete (missing key or private key)`);
+  }
+  return config;
+}

--- a/finp2p-client/src/index.ts
+++ b/finp2p-client/src/index.ts
@@ -1,3 +1,4 @@
 export * from './finapi';
 export * from './oss';
 export * from './client';
+export * from './auth';


### PR DESCRIPTION
Closes #110

## Summary
- Add `createAuthTokenResolver()` and `loadAuthFile()` as standalone exports
- Supports HMAC (HS256) and RSA (RS256) JWT signing for FinP2P router auth
- Bump finp2p-client to 0.27.2

## Usage
```typescript
import { createAuthTokenResolver, loadAuthFile, FinP2PClient } from '@owneraio/finp2p-client';

const config = loadAuthFile('/path/to/auth.json');
const resolver = createAuthTokenResolver(config.orgId, config.auth);
const client = new FinP2PClient(config.finApiUrl, config.finApiOssUrl, resolver);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)