### PR TITLE
Add plan lifecycle methods: onPlanCompleted / onPlanFailed

### DIFF
--- a/finp2p-client/package-lock.json
+++ b/finp2p-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.27.7",
+  "version": "0.27.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-client",
-      "version": "0.27.7",
+      "version": "0.27.8",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.12.2",

--- a/finp2p-client/package.json
+++ b/finp2p-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.27.7",
+  "version": "0.27.8",
   "description": "FinP2P API Client",
   "homepage": "https://ownera.io/",
   "main": "./dist/index.js",

--- a/finp2p-client/src/oss/graphql/assets.graphql
+++ b/finp2p-client/src/oss/graphql/assets.graphql
@@ -91,6 +91,9 @@ fragment proofInfo on ProofPolicy {
 
 fragment assetInfo on LedgerAssetInfo {
     tokenId
+    ledgerBinding {
+        name
+    }
     ledgerReference {
         ... on ContractDetails {
             network

--- a/finp2p-client/src/oss/model.ts
+++ b/finp2p-client/src/oss/model.ts
@@ -1,5 +1,6 @@
 export type LedgerAssetInfo = {
   tokenId: string
+  ledgerBinding?: { name: string }
   ledgerReference?: LedgerReference
 };
 

--- a/sample-adapter/src/plugins/delayed-approvals.ts
+++ b/sample-adapter/src/plugins/delayed-approvals.ts
@@ -1,6 +1,9 @@
 import {
   PlanApprovalPlugin,
   PlanApprovalStatus,
+  PlanFailureReason,
+  PlanContract,
+  IntentType,
   approvedPlan,
   Asset,
   DestinationAccount,
@@ -38,6 +41,14 @@ export class DelayedApprovals implements PlanApprovalPlugin {
     this.logger.debug(`Approving transfer of ${amount} ${asset.assetId} from ${source.finId}`);
     await sleep(defaultDelay);
     return approvedPlan();
+  }
+
+  async onPlanCompleted(planId: string, intentType: IntentType | undefined, contract: PlanContract): Promise<void> {
+    this.logger.info(`Plan completed: ${planId}, intent=${intentType}`);
+  }
+
+  async onPlanFailed(planId: string, intentType: IntentType | undefined, contract: PlanContract, status: string, reason: PlanFailureReason | undefined): Promise<void> {
+    this.logger.info(`Plan failed: ${planId}, intent=${intentType}, status=${status}, reason=${reason?.message ?? 'unknown'}`);
   }
 
 }

--- a/skeleton/package-lock.json
+++ b/skeleton/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-  "version": "0.27.16",
+  "version": "0.27.17-rc.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-      "version": "0.27.16",
+      "version": "0.27.17-rc.2",
       "license": "TBD",
       "dependencies": {
         "@owneraio/finp2p-client": "^0.27.0",

--- a/skeleton/package-lock.json
+++ b/skeleton/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-  "version": "0.27.17-rc.2",
+  "version": "0.27.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-      "version": "0.27.17-rc.2",
+      "version": "0.27.17",
       "license": "TBD",
       "dependencies": {
         "@owneraio/finp2p-client": "^0.27.0",

--- a/skeleton/package.json
+++ b/skeleton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-  "version": "0.27.16",
+  "version": "0.27.17-rc.2",
   "description": "",
   "homepage": "https://ownera.io/",
   "main": "dist/index.js",

--- a/skeleton/package.json
+++ b/skeleton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-  "version": "0.27.17-rc.2",
+  "version": "0.27.17",
   "description": "",
   "homepage": "https://ownera.io/",
   "main": "dist/index.js",

--- a/skeleton/src/models/plugins/interfaces.ts
+++ b/skeleton/src/models/plugins/interfaces.ts
@@ -2,7 +2,7 @@
 import {
   Account, Asset, DepositAsset,
   DepositOperation,
-  DestinationAccount, ExecutionPlan,
+  DestinationAccount, ExecutionPlan, IntentType, PlanContract,
   FinIdAccount,
   OperationStatus, PlanApprovalStatus, ReceiptOperation, Signature,
 } from '../model';
@@ -15,12 +15,22 @@ export interface AssetCreationPlugin {
 //------------------------------------------------------------
 
 
+export type PlanFailureReason = {
+  instructionSequence: number;
+  code: number;
+  message: string;
+};
+
 export interface PlanApprovalPlugin {
   validateIssuance(destination: FinIdAccount, asset: Asset, amount: string): Promise<PlanApprovalStatus>;
 
   validateTransfer(source: FinIdAccount, destination: DestinationAccount, asset: Asset, amount: string): Promise<PlanApprovalStatus>;
 
   validateRedemption(source: FinIdAccount, destination: DestinationAccount | undefined, asset: Asset, amount: string): Promise<PlanApprovalStatus>;
+
+  onPlanCompleted(planId: string, intentType: IntentType | undefined, contract: PlanContract): Promise<void>;
+
+  onPlanFailed(planId: string, intentType: IntentType | undefined, contract: PlanContract, status: string, reason: PlanFailureReason | undefined): Promise<void>;
 }
 
 //------------------------------------------------------------

--- a/skeleton/src/services/plan/service.ts
+++ b/skeleton/src/services/plan/service.ts
@@ -1,7 +1,7 @@
 import {
   approvedPlan, Asset, DestinationAccount,
   ExecutionPlan,
-  FinIdAccount, InstructionResult,
+  FinIdAccount, InstructionResult, PlanFailureReason,
   PlanApprovalService, PlanProposal, InboundTransferHook,
   PlanApprovalStatus, rejectedPlan,
 } from '../../models';
@@ -124,6 +124,45 @@ export class PlanApprovalServiceImpl implements PlanApprovalService {
 
   public async proposalStatus(planId: string, proposal: PlanProposal, status: 'approved' | 'rejected'): Promise<void> {
     logger.info(`Got plan proposal status: planId=${planId}, type=${proposal.proposalType}, status=${status}`);
+
+    const plugin = this.pluginManager?.getPlanApprovalPlugin();
+    if (!plugin || !this.finP2P) return;
+
+    const execution = await this.fetchExecution(planId);
+    if (!execution) return;
+
+    const planStatus = execution.executionPlanStatus;
+    const terminalStatuses = ['completed', 'failed', 'halted', 'canceled'];
+    if (!terminalStatuses.includes(planStatus)) return;
+
+    const plan = executionFromAPI(execution.plan);
+
+    try {
+      if (planStatus === 'completed') {
+        logger.info(`Plan completed: ${planId}`);
+        await plugin.onPlanCompleted(planId, plan.intentType, plan.contract);
+      } else {
+        const reason = this.extractFailureReason(execution);
+        logger.info(`Plan failed: ${planId}, status=${planStatus}`, { reason });
+        await plugin.onPlanFailed(planId, plan.intentType, plan.contract, planStatus, reason);
+      }
+    } catch (e: any) {
+      logger.error('Plan lifecycle callback failed', { planId, planStatus, error: e.message });
+    }
+  }
+
+  private extractFailureReason(execution: OpComponents['schemas']['execution']): PlanFailureReason | undefined {
+    const events = execution.instructionsCompletionEvents ?? [];
+    for (const event of events) {
+      if (event.output?.type === 'error') {
+        return {
+          instructionSequence: event.instructionSequenceNumber,
+          code: event.output.code,
+          message: event.output.message,
+        };
+      }
+    }
+    return undefined;
   }
 
   private async validatePlan(idempotencyKey: string, planId: string, plan: ExecutionPlan): Promise<PlanApprovalStatus> {


### PR DESCRIPTION
## Summary

`PlanApprovalPlugin` now requires two lifecycle methods:
- `onPlanCompleted(planId)` — called when plan reaches `completed` status
- `onPlanFailed(planId, status, reason)` — called on `failed`/`halted`/`canceled`

`proposalStatus` now fetches the execution plan, detects terminal states, extracts failure reason from completion events, and calls the plugin directly.

```typescript
type PlanFailureReason = {
  instructionSequence: number;
  code: number;
  message: string;
};
```

**Breaking change** — existing `PlanApprovalPlugin` implementations must add the two new methods.

RC published as `skeleton@0.27.17-rc.1`. Sample-adapter update in follow-up.

## Test plan

- [x] Skeleton: 26/26 tests passed
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)