### PR TITLE
Add logging to workflow proxy ready gate and crash recovery

### DIFF
--- a/skeleton/src/workflows/service.ts
+++ b/skeleton/src/workflows/service.ts
@@ -141,22 +141,29 @@ export function createServiceProxy<T extends object>(
 ): T {
   const opMetadata: OperationMetadata | undefined = finP2PClient ? { responseStrategy: 'callback' } : undefined;
 
-  // Wait for migrations, then replay pending operations (crash recovery).
+  // Wait for migrations only. Crash recovery runs in the background after
+  // migration completes and does NOT block the ready gate — incoming requests
+  // can proceed as soon as the DB schema is up to date.
   const ready = migrationJob().then(() => {
-    methodsToProxy.forEach((m) => {
+    logger.debug('Migration complete, scheduling crash recovery', { methods: methodsToProxy.map(String) });
+    // Crash recovery: fire-and-forget per method. Does not block ready.
+    for (const m of methodsToProxy) {
       const raw = service[m];
-      if (typeof raw !== 'function') return;
+      if (typeof raw !== 'function') continue;
       const method = raw.bind(service);
 
       storage.getPendingOperations(String(m)).then(
         (operations) => {
+          if (operations.length > 0) {
+            logger.info(`Crash recovery: replaying ${operations.length} pending operation(s) for ${String(m)}`);
+          }
           for (const op of operations) {
             executeAndFinalize(method, op.inputs, op.method, op.cid, opMetadata, storage, finP2PClient);
           }
         },
-        (error) => logger.error('Failed to fetch pending operations', { error }),
+        (error) => logger.error('Failed to fetch pending operations', { method: String(m), error }),
       );
-    });
+    }
   });
 
   const getOperationStatusMethod: keyof CommonService = 'operationStatus';


### PR DESCRIPTION
## Summary

- Add debug/info logging to `createServiceProxy` so operators can see when migration completes, when crash recovery starts, and how many pending operations are being replayed per method
- Include method name in error logs for failed pending operation fetches
- Clarify in code comments that crash recovery is fire-and-forget and does NOT block the ready gate

## Context

When migration hangs (DB unreachable, lock contention), the proxy's `await ready` blocks all incoming requests silently. Operators only see 90s timeouts from the router with no indication of what's stuck on the adapter side. These logs make the proxy lifecycle observable.

No timeout is added — workflow execution must not be time-limited.

## Test plan

- [x] `npm run build` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)