### PR TITLE
Bump vanilla-service to 0.28.1: single asset on outboundTransfer

### DIFF
--- a/vanilla-service/package-lock.json
+++ b/vanilla-service/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@owneraio/finp2p-vanilla-service",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-vanilla-service",
-      "version": "0.28.0",
+      "version": "0.28.1",
       "license": "TBD",
       "dependencies": {
-        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.0",
+        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.4",
         "bs58": "^6.0.0",
         "pg": "^8.15.6",
         "winston": "^3.18.3"
@@ -1420,9 +1420,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-nodejs-skeleton-adapter": {
-      "version": "0.28.0",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.0/54f339504e134c810d57924ded569ffbc0f818e5",
-      "integrity": "sha512-dUQjKDCSOFUph5s4nDyKj22EQi46dBcIWLo50/VvYv697A1Uk+GxYdiTDLpauXCiC2nsI87HewBmA49hCPyI/A==",
+      "version": "0.28.4",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.4/7d02e779c0e5bd788b6e98cd8d7dff40f6a1400c",
+      "integrity": "sha512-f7KTkKaZNtZwk//TjIfK+xjopo+NVBdcep3J1Vp/+xyFeizrjul5lJQef8flJARhSux8U7bt+/4JBiWw1fWPPg==",
       "license": "TBD",
       "dependencies": {
         "axios": "1.11.0",
@@ -1436,7 +1436,7 @@
         "winston": "^3.18.3"
       },
       "peerDependencies": {
-        "@owneraio/finp2p-client": "^0.28.0-custody-native.7",
+        "@owneraio/finp2p-client": "^0.28.0",
         "pg": "^8.15.6"
       }
     },
@@ -2998,9 +2998,9 @@
       }
     },
     "node_modules/bare-url": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
-      "integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.1.tgz",
+      "integrity": "sha512-fZapLWNB25gS+etK27NV9KgBNXgo2yeYHuj+OyPblQd6GYAE3JVy6aKxszMV5jhGGFwraXQKA5fldvf3lMyEqw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3035,9 +3035,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
-      "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
+      "version": "2.10.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
+      "integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4172,9 +4172,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.339",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.339.tgz",
-      "integrity": "sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg==",
+      "version": "1.5.340",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
+      "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5875,9 +5875,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"

--- a/vanilla-service/package.json
+++ b/vanilla-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-vanilla-service",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "description": "Vanilla DB ledger service for FinP2P adapters — per-investor balance segregation in PostgreSQL",
   "main": "./dist/index.js",
   "types": "dist/index.d.ts",
@@ -20,7 +20,7 @@
   "author": "",
   "license": "TBD",
   "dependencies": {
-    "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.0",
+    "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.4",
     "bs58": "^6.0.0",
     "pg": "^8.15.6",
     "winston": "^3.18.3"


### PR DESCRIPTION
## Summary

- Bump vanilla-service to 0.28.1
- Update skeleton dep to `^0.28.4`
- Published 0.28.0 still had `outboundTransfer(... sourceAsset, destinationAsset, ...)` in its interface. The skeleton simplified transfer to single asset, and vanilla-service code was updated to match. This publishes the bump so consumers can adopt the simplified delegate.

## Test plan

- [x] `npm run build` passes, no `file:` refs in lockfile
- [ ] CI green, then tag `vanilla-service-v0.28.1` to publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)