### PR TITLE
Simplify AssetStore: key by id only, drop type

### DIFF
--- a/skeleton/migrations/20260417180000_drop_asset_type.sql
+++ b/skeleton/migrations/20260417180000_drop_asset_type.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE ledger_adapter.assets DROP CONSTRAINT assets_pkey;
+ALTER TABLE ledger_adapter.assets DROP COLUMN type;
+ALTER TABLE ledger_adapter.assets ADD PRIMARY KEY (id);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE ledger_adapter.assets DROP CONSTRAINT assets_pkey;
+ALTER TABLE ledger_adapter.assets ADD COLUMN type VARCHAR(255) NOT NULL DEFAULT 'finp2p';
+ALTER TABLE ledger_adapter.assets ADD PRIMARY KEY (type, id);
+-- +goose StatementEnd

--- a/skeleton/package-lock.json
+++ b/skeleton/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-  "version": "0.28.3",
+  "version": "0.28.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-      "version": "0.28.3",
+      "version": "0.28.5",
       "license": "TBD",
       "dependencies": {
         "axios": "1.11.0",

--- a/skeleton/package.json
+++ b/skeleton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-  "version": "0.28.4",
+  "version": "0.28.5",
   "description": "",
   "homepage": "https://ownera.io/",
   "main": "dist/index.js",

--- a/skeleton/src/storage/assets.ts
+++ b/skeleton/src/storage/assets.ts
@@ -4,20 +4,20 @@ import { Asset, AssetStore } from './interfaces';
 export class PgAssetStore implements AssetStore {
   constructor(private pool: Pool) {}
 
-  async getAsset(asset: { id: string; type: string }): Promise<Asset | undefined> {
+  async getAsset(assetId: string): Promise<Asset | undefined> {
     const result = await this.pool.query(
-      'SELECT * FROM ledger_adapter.assets WHERE id = $1 AND type = $2',
-      [asset.id, asset.type],
+      'SELECT * FROM ledger_adapter.assets WHERE id = $1',
+      [assetId],
     );
     return result.rows.at(0);
   }
 
   async saveAsset(asset: Omit<Asset, 'created_at' | 'updated_at'>): Promise<Asset> {
     const result = await this.pool.query(
-      `INSERT INTO ledger_adapter.assets (id, type, contract_address, decimals, token_standard)
-       VALUES ($1, $2, $3, $4, $5)
+      `INSERT INTO ledger_adapter.assets (id, contract_address, decimals, token_standard)
+       VALUES ($1, $2, $3, $4)
        RETURNING *;`,
-      [asset.id, asset.type, asset.contract_address, asset.decimals, asset.token_standard],
+      [asset.id, asset.contract_address, asset.decimals, asset.token_standard],
     );
     if (result.rows.length === 0) throw new Error('Failed to save asset to DB');
     return result.rows.at(0);

--- a/skeleton/src/storage/interfaces.ts
+++ b/skeleton/src/storage/interfaces.ts
@@ -5,7 +5,6 @@ export interface Account {
 
 export interface Asset {
   id: string;
-  type: string;
   token_standard: string;
   contract_address: string;
   decimals: number;
@@ -21,6 +20,6 @@ export interface AccountStore {
 }
 
 export interface AssetStore {
-  getAsset(asset: { id: string; type: string }): Promise<Asset | undefined>;
+  getAsset(assetId: string): Promise<Asset | undefined>;
   saveAsset(asset: Omit<Asset, 'created_at' | 'updated_at'>): Promise<Asset>;
 }

--- a/skeleton/tests/workflows/storage.globals.test.ts
+++ b/skeleton/tests/workflows/storage.globals.test.ts
@@ -28,11 +28,11 @@ describe("storage instance methods", () => {
   });
 
   test("inserting and querying assets via asset store", async () => {
-    const asset = { type: "cryptocurrency", id: "usdc" }
-    await expect(assetStore.getAsset(asset)).resolves.toBeUndefined()
+    const assetId = "usdc"
+    await expect(assetStore.getAsset(assetId)).resolves.toBeUndefined()
 
-    const savedAsset = await assetStore.saveAsset({ ...asset, contract_address: "", decimals: 6, token_standard: 'ERC20' })
-    await expect(assetStore.getAsset(asset)).resolves.toEqual(savedAsset)
+    const savedAsset = await assetStore.saveAsset({ id: assetId, contract_address: "", decimals: 6, token_standard: 'ERC20' })
+    await expect(assetStore.getAsset(assetId)).resolves.toEqual(savedAsset)
   })
 
   test("querying special receipt objects via workflow storage", async () => {


### PR DESCRIPTION
## Summary

- Drop `type` from `Asset` storage type and from the `assets` table
- `AssetStore.getAsset(assetId: string)` instead of `({ id, type })`
- Migration `20260417180000_drop_asset_type.sql` changes the primary key from `(type, id)` to `(id)` and drops the `type` column

AssetType isn't a meaningful distinction for storage — assetId is globally unique within FinP2P.

Bumps skeleton to 0.28.5.

## Test plan

- [x] `npm run build` passes
- [ ] CI green (migration must apply cleanly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)