### PR TITLE
finp2p-client: rename assetIdentifier to financialIdentifier

### DIFF
--- a/finp2p-client/package.json
+++ b/finp2p-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "description": "FinP2P API Client",
   "homepage": "https://ownera.io/",
   "main": "./dist/index.js",

--- a/finp2p-client/src/oss/graphql/assets.graphql
+++ b/finp2p-client/src/oss/graphql/assets.graphql
@@ -11,7 +11,7 @@ query GetAssets($filter: [Filter!]) {
             issuerId
             config
             allowedIntents
-            assetIdentifier {
+            financialIdentifier {
                 type,
                 value
             }

--- a/finp2p-client/src/oss/model.ts
+++ b/finp2p-client/src/oss/model.ts
@@ -17,7 +17,7 @@ export type LedgerReference = {
   };
 };
 
-export type AssetIdentifier = {
+export type FinancialIdentifier = {
   type: string
   value: string
 };
@@ -88,7 +88,7 @@ export type OssAsset = {
   },
   issuerId: string,
   config: string,
-  assetIdentifier: AssetIdentifier;
+  financialIdentifier: FinancialIdentifier;
   allowedIntents: string[],
   regulationVerifiers: {
     id: string,


### PR DESCRIPTION
## Summary

- OSS API now returns `financialIdentifier` (typed `FinancialIdentifier`) instead of `assetIdentifier`
- Update GraphQL query to request `financialIdentifier`
- Regenerate GraphQL types
- Rename `AssetIdentifier` type to `FinancialIdentifier` in `oss/model.ts`
- Rename `OssAsset.assetIdentifier` field to `financialIdentifier`
- Bump finp2p-client to 0.28.1

## Test plan

- [x] `npm run build` passes
- [ ] CI green, then tag `finp2p-client-v0.28.1` to publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)