### PR TITLE
finp2p-client: sync OSS GraphQL schema with owneraio/oss master

### DIFF
--- a/finp2p-client/apis/ownership.graphql
+++ b/finp2p-client/apis/ownership.graphql
@@ -185,6 +185,146 @@ type CustodyProvider {
     singleRequestTimeout: String!
 }
 
+"Identifier type for asset data"
+enum AssetDataIdentifierType {
+    ISIN
+    CAIP19
+}
+
+"Financial data types provided by data providers"
+enum DataType {
+    assetHeader
+    pricing
+    fundamentals
+    ratings
+    corporateActions
+    marketData
+    referenceData
+}
+
+"Represents financial data for an asset from a data provider"
+type AssetDataItem {
+    id: String!
+    "Type of identifier used (ISIN or CAIP19)"
+    identifierType: AssetDataIdentifierType!
+    "The identifier value (e.g., US0378331005 for ISIN)"
+    identifierValue: String!
+    "Type of financial data"
+    dataType: DataType!
+    "The actual data as JSON string"
+    data: String!
+    "Data provider source identifier"
+    source: String
+    "Provider timestamp (epoch ms)"
+    providerTimestamp: Int
+    "When the record was created"
+    createdAt: Int!
+    "When the record was last updated"
+    updatedAt: Int!
+}
+
+"Results for asset data query."
+type AssetDatas {
+    "Collection of AssetDataItem Objects, conforms to the Filter input if provided."
+    nodes: [AssetDataItem!]
+
+    "Keeps pagination info in-case limit input was provided"
+    pageInfo: PageInfo
+}
+
+"Represents a data provider binding configuration"
+type DataProviderBinding {
+    "Unique identifier (UUID) for the data provider"
+    id: ID!
+    name: String!
+    "Type of data provider: adapter (external HTTP) or finp2p (internal P2P)"
+    providerType: String!
+    endpoint: String!
+    displayName: String
+    requestTimeout: String!
+    backoff: String!
+    "JSON array of data type strings this provider serves"
+    dataTypes: [String!]
+    "JSON string of per-data-type fetch configuration"
+    dataTypeConfig: String
+    createdAt: Int!
+    updatedAt: Int!
+}
+
+"Results for data provider query."
+type DataProviderBindings {
+    "Collection of DataProviderBinding Objects, conforms to the Filter input if provided."
+    nodes: [DataProviderBinding!]
+
+    "Keeps pagination info in-case limit input was provided"
+    pageInfo: PageInfo
+}
+
+"Aggregated view of a financial asset identified by ISIN"
+type FinancialAsset {
+    "ISIN identifier value (e.g., US0378331005)"
+    isin: String!
+    "Financial data items from data adapters for this ISIN"
+    dataItems(dataTypes: [DataType!]): [AssetDataItem!]!
+    "Refresh configurations for this ISIN"
+    refreshConfigs: [AssetRefreshConfigItem!]!
+    "CAIP19 identifiers — asset instances on different networks/blockchains (from assetHeader data)"
+    caip19Identifiers: [String!]!
+    "FinP2P assets linked by matching ISIN identifier (may be empty)"
+    linkedAssets: [Asset!]!
+}
+
+"Results for financial asset query."
+type FinancialAssets {
+    nodes: [FinancialAsset!]
+    pageInfo: PageInfo
+}
+
+"Refresh configuration for an asset's data from a provider"
+type AssetRefreshConfigItem {
+    id: String!
+    identifierType: AssetDataIdentifierType!
+    identifierValue: String!
+    dataType: String!
+    refreshInterval: String!
+    lastRefreshAt: Int
+    nextRefreshAt: Int
+    "UUID of the data provider"
+    providerId: String
+    enabled: Boolean!
+    createdAt: Int!
+    updatedAt: Int!
+}
+
+"Represents a data rule mapping an asset identifier to a data provider"
+type DataRuleItem {
+    id: String!
+    "Type of identifier (e.g., ISIN)"
+    identifierType: String!
+    "The identifier value (e.g., US0378331005)"
+    identifierValue: String!
+    "UUID of the data provider"
+    providerId: String!
+    "The data type this rule covers"
+    dataType: String!
+    "Refresh interval for this rule (e.g., 1h, 24h, RT)"
+    refreshInterval: String
+    "Whether this rule is active"
+    enabled: Boolean!
+    "When the rule was created (epoch seconds)"
+    createdAt: Int!
+    "When the rule was last updated (epoch seconds)"
+    updatedAt: Int!
+}
+
+"Results for data rules query."
+type DataRules {
+    "Collection of DataRuleItem Objects, conforms to the Filter input if provided."
+    nodes: [DataRuleItem!]
+
+    "Keeps pagination info in-case limit input was provided"
+    pageInfo: PageInfo
+}
 
 union LedgerReference = ContractDetails
 
@@ -1130,27 +1270,34 @@ type PrivateOfferIntent{
 }
 
 type RequestForTransferIntent{
-    "resource id of the creditor"
-    creditor: String
+    "resource id of the sender"
+    sender: String
 
-    "resource id of the debitor"
-    debitor: String
+    "resource id of the receiver"
+    receiver: String
 
-    "Asset term specifies the asset information and amount of the intent"
-    assetTerm: AssetTerm!
-
-    "Source account - used when actionType is SEND"
-    source: FinP2PAssetAccount
-
-    "Destination account - used when actionType is REQUEST"
-    destination: FinP2PAssetAccount
-
-    "Signature policy type"
-    signaturePolicyType: SignaturePolicyType!
+    asset: RequestForTransferIntentAsset!
     signaturePolicy: RequestForTransferSignaturePolicy!
+    signaturePolicyType: SignaturePolicyType!
+}
 
-    "Action type of the intent"
-    actionType: ActionType!
+type RequestForTransferIntentAsset {
+    assetTerm: AssetTerm!
+    assetInstruction: RequestForTransferAssetInstruction!
+}
+
+union RequestForTransferAssetInstruction = RequestForTransferSendInstruction | RequestForTransferRequestInstruction
+
+type RequestForTransferSendInstruction {
+    "Action type - always 'send'"
+    action: String!
+    senderAccount: FinP2PAssetAccount
+}
+
+type RequestForTransferRequestInstruction {
+    "Action type - always 'request'"
+    action: String!
+    receiverAccount: FinP2PAssetAccount
 }
 
 type LoanIntent{
@@ -1437,6 +1584,18 @@ type Query {
     approvalConfigs(paginate: PaginateInput = {}): ApprovalConfigs!
 
     pinningConfig: PinningConfigs
+
+    "Look up Asset Data, Optional provide Filter."
+    assetDatas(filter: [Filter!], paginate: PaginateInput = {}): AssetDatas!
+
+    "Look up Data Provider bindings."
+    dataProviders(filter: [Filter!], paginate: PaginateInput = {}): DataProviderBindings!
+
+    "Look up Data Rules that map identifiers to data providers."
+    dataRules(filter: [Filter!], paginate: PaginateInput = {}): DataRules!
+
+    "Look up FinancialAssets aggregated by ISIN from data adapter data. Filter by isin to get a specific asset."
+    financialAssets(filter: [Filter!], paginate: PaginateInput = {}): FinancialAssets!
 }
 
 type PageInfo {
@@ -1459,6 +1618,7 @@ type Subscription {
     plansChangedBy(fieldNames: [PlanField!]!): ExecutionPlan!
     userHoldingAdded: User!
     userHoldingChanged(fieldNames: [HoldingFields!]!): User!
+    assetDataChanged(identifierType: AssetDataIdentifierType, identifierValue: String, dataTypes: [DataType!]): AssetDataItem!
 }
 
 "Fields to subscribe on"

--- a/finp2p-client/package.json
+++ b/finp2p-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "description": "FinP2P API Client",
   "homepage": "https://ownera.io/",
   "main": "./dist/index.js",

--- a/finp2p-client/src/oss/graphql.d.ts
+++ b/finp2p-client/src/oss/graphql.d.ts
@@ -143,6 +143,43 @@ export type AssetIssuedTokensArgs = {
   filter?: InputMaybe<Array<Filter>>;
 };
 
+/** Identifier type for asset data */
+export enum AssetDataIdentifierType {
+  Caip19 = 'CAIP19',
+  Isin = 'ISIN',
+}
+
+/** Represents financial data for an asset from a data provider */
+export type AssetDataItem = {
+  __typename?: 'AssetDataItem';
+  /** When the record was created */
+  createdAt: Scalars['Int']['output'];
+  /** The actual data as JSON string */
+  data: Scalars['String']['output'];
+  /** Type of financial data */
+  dataType: DataType;
+  id: Scalars['String']['output'];
+  /** Type of identifier used (ISIN or CAIP19) */
+  identifierType: AssetDataIdentifierType;
+  /** The identifier value (e.g., US0378331005 for ISIN) */
+  identifierValue: Scalars['String']['output'];
+  /** Provider timestamp (epoch ms) */
+  providerTimestamp?: Maybe<Scalars['Int']['output']>;
+  /** Data provider source identifier */
+  source?: Maybe<Scalars['String']['output']>;
+  /** When the record was last updated */
+  updatedAt: Scalars['Int']['output'];
+};
+
+/** Results for asset data query. */
+export type AssetDatas = {
+  __typename?: 'AssetDatas';
+  /** Collection of AssetDataItem Objects, conforms to the Filter input if provided. */
+  nodes?: Maybe<Array<AssetDataItem>>;
+  /** Keeps pagination info in-case limit input was provided */
+  pageInfo?: Maybe<PageInfo>;
+};
+
 /** Asset details - now always FinP2P */
 export type AssetDetails = FinP2PAsset;
 
@@ -184,6 +221,23 @@ export type AssetOrderTerm = {
 export type AssetPolicies = {
   __typename?: 'AssetPolicies';
   proof: ProofPolicy;
+};
+
+/** Refresh configuration for an asset's data from a provider */
+export type AssetRefreshConfigItem = {
+  __typename?: 'AssetRefreshConfigItem';
+  createdAt: Scalars['Int']['output'];
+  dataType: Scalars['String']['output'];
+  enabled: Scalars['Boolean']['output'];
+  id: Scalars['String']['output'];
+  identifierType: AssetDataIdentifierType;
+  identifierValue: Scalars['String']['output'];
+  lastRefreshAt?: Maybe<Scalars['Int']['output']>;
+  nextRefreshAt?: Maybe<Scalars['Int']['output']>;
+  /** UUID of the data provider */
+  providerId?: Maybe<Scalars['String']['output']>;
+  refreshInterval: Scalars['String']['output'];
+  updatedAt: Scalars['Int']['output'];
 };
 
 export type AssetTerm = {
@@ -368,6 +422,77 @@ export type DataAccess = {
 export enum DataAccessType {
   Balance = 'Balance',
   Unknown = 'Unknown',
+}
+
+/** Represents a data provider binding configuration */
+export type DataProviderBinding = {
+  __typename?: 'DataProviderBinding';
+  backoff: Scalars['String']['output'];
+  createdAt: Scalars['Int']['output'];
+  /** JSON string of per-data-type fetch configuration */
+  dataTypeConfig?: Maybe<Scalars['String']['output']>;
+  /** JSON array of data type strings this provider serves */
+  dataTypes?: Maybe<Array<Scalars['String']['output']>>;
+  displayName?: Maybe<Scalars['String']['output']>;
+  endpoint: Scalars['String']['output'];
+  /** Unique identifier (UUID) for the data provider */
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+  /** Type of data provider: adapter (external HTTP) or finp2p (internal P2P) */
+  providerType: Scalars['String']['output'];
+  requestTimeout: Scalars['String']['output'];
+  updatedAt: Scalars['Int']['output'];
+};
+
+/** Results for data provider query. */
+export type DataProviderBindings = {
+  __typename?: 'DataProviderBindings';
+  /** Collection of DataProviderBinding Objects, conforms to the Filter input if provided. */
+  nodes?: Maybe<Array<DataProviderBinding>>;
+  /** Keeps pagination info in-case limit input was provided */
+  pageInfo?: Maybe<PageInfo>;
+};
+
+/** Represents a data rule mapping an asset identifier to a data provider */
+export type DataRuleItem = {
+  __typename?: 'DataRuleItem';
+  /** When the rule was created (epoch seconds) */
+  createdAt: Scalars['Int']['output'];
+  /** The data type this rule covers */
+  dataType: Scalars['String']['output'];
+  /** Whether this rule is active */
+  enabled: Scalars['Boolean']['output'];
+  id: Scalars['String']['output'];
+  /** Type of identifier (e.g., ISIN) */
+  identifierType: Scalars['String']['output'];
+  /** The identifier value (e.g., US0378331005) */
+  identifierValue: Scalars['String']['output'];
+  /** UUID of the data provider */
+  providerId: Scalars['String']['output'];
+  /** Refresh interval for this rule (e.g., 1h, 24h, RT) */
+  refreshInterval?: Maybe<Scalars['String']['output']>;
+  /** When the rule was last updated (epoch seconds) */
+  updatedAt: Scalars['Int']['output'];
+};
+
+/** Results for data rules query. */
+export type DataRules = {
+  __typename?: 'DataRules';
+  /** Collection of DataRuleItem Objects, conforms to the Filter input if provided. */
+  nodes?: Maybe<Array<DataRuleItem>>;
+  /** Keeps pagination info in-case limit input was provided */
+  pageInfo?: Maybe<PageInfo>;
+};
+
+/** Financial data types provided by data providers */
+export enum DataType {
+  AssetHeader = 'assetHeader',
+  CorporateActions = 'corporateActions',
+  Fundamentals = 'fundamentals',
+  MarketData = 'marketData',
+  Pricing = 'pricing',
+  Ratings = 'ratings',
+  ReferenceData = 'referenceData',
 }
 
 export type Delivered = {
@@ -581,6 +706,34 @@ export type FinP2PevmOperatorDetails = {
   __typename?: 'FinP2PEVMOperatorDetails';
   allowanceRequired: Scalars['Boolean']['output'];
   finP2POperatorContractAddress: Scalars['String']['output'];
+};
+
+/** Aggregated view of a financial asset identified by ISIN */
+export type FinancialAsset = {
+  __typename?: 'FinancialAsset';
+  /** CAIP19 identifiers — asset instances on different networks/blockchains (from assetHeader data) */
+  caip19Identifiers: Array<Scalars['String']['output']>;
+  /** Financial data items from data adapters for this ISIN */
+  dataItems: Array<AssetDataItem>;
+  /** ISIN identifier value (e.g., US0378331005) */
+  isin: Scalars['String']['output'];
+  /** FinP2P assets linked by matching ISIN identifier (may be empty) */
+  linkedAssets: Array<Asset>;
+  /** Refresh configurations for this ISIN */
+  refreshConfigs: Array<AssetRefreshConfigItem>;
+};
+
+
+/** Aggregated view of a financial asset identified by ISIN */
+export type FinancialAssetDataItemsArgs = {
+  dataTypes?: InputMaybe<Array<DataType>>;
+};
+
+/** Results for financial asset query. */
+export type FinancialAssets = {
+  __typename?: 'FinancialAssets';
+  nodes?: Maybe<Array<FinancialAsset>>;
+  pageInfo?: Maybe<PageInfo>;
 };
 
 export type FinancialIdentifier = {
@@ -1324,11 +1477,19 @@ export type ProofPolicy = NoProofPolicy | SignatureProofPolicy;
 export type Query = {
   __typename?: 'Query';
   approvalConfigs: ApprovalConfigs;
+  /** Look up Asset Data, Optional provide Filter. */
+  assetDatas: AssetDatas;
   /** Look up Assets, Optional provide Filters or Aggregates. */
   assets: Assets;
   /** Look up Certificates, Optional provide Filter or Aggregate. */
   certificates: Certificates;
   custodyProviders: CustodyProviders;
+  /** Look up Data Provider bindings. */
+  dataProviders: DataProviderBindings;
+  /** Look up Data Rules that map identifiers to data providers. */
+  dataRules: DataRules;
+  /** Look up FinancialAssets aggregated by ISIN from data adapter data. Filter by isin to get a specific asset. */
+  financialAssets: FinancialAssets;
   /** Look up Issuers, Optional provide Filter. */
   issuers: Issuers;
   ledgers: LedgerBindings;
@@ -1353,6 +1514,13 @@ export type QueryApprovalConfigsArgs = {
 
 
 /** The query root of Ownera's GraphQL interface. */
+export type QueryAssetDatasArgs = {
+  filter?: InputMaybe<Array<Filter>>;
+  paginate?: InputMaybe<PaginateInput>;
+};
+
+
+/** The query root of Ownera's GraphQL interface. */
 export type QueryAssetsArgs = {
   aggregate?: InputMaybe<Array<Aggregate>>;
   filter?: InputMaybe<Array<Filter>>;
@@ -1371,6 +1539,27 @@ export type QueryCertificatesArgs = {
 
 /** The query root of Ownera's GraphQL interface. */
 export type QueryCustodyProvidersArgs = {
+  filter?: InputMaybe<Array<Filter>>;
+  paginate?: InputMaybe<PaginateInput>;
+};
+
+
+/** The query root of Ownera's GraphQL interface. */
+export type QueryDataProvidersArgs = {
+  filter?: InputMaybe<Array<Filter>>;
+  paginate?: InputMaybe<PaginateInput>;
+};
+
+
+/** The query root of Ownera's GraphQL interface. */
+export type QueryDataRulesArgs = {
+  filter?: InputMaybe<Array<Filter>>;
+  paginate?: InputMaybe<PaginateInput>;
+};
+
+
+/** The query root of Ownera's GraphQL interface. */
+export type QueryFinancialAssetsArgs = {
   filter?: InputMaybe<Array<Filter>>;
   paginate?: InputMaybe<PaginateInput>;
 };
@@ -1558,6 +1747,8 @@ export type RepaymentTerm = {
   repaymentVolume: Scalars['String']['output'];
 };
 
+export type RequestForTransferAssetInstruction = RequestForTransferRequestInstruction | RequestForTransferSendInstruction;
+
 export type RequestForTransferContractDetails = {
   __typename?: 'RequestForTransferContractDetails';
   asset: AssetOrder;
@@ -1565,21 +1756,33 @@ export type RequestForTransferContractDetails = {
 
 export type RequestForTransferIntent = {
   __typename?: 'RequestForTransferIntent';
-  /** Action type of the intent */
-  actionType: ActionType;
-  /** Asset term specifies the asset information and amount of the intent */
-  assetTerm: AssetTerm;
-  /** resource id of the creditor */
-  creditor?: Maybe<Scalars['String']['output']>;
-  /** resource id of the debitor */
-  debitor?: Maybe<Scalars['String']['output']>;
-  /** Destination account - used when actionType is REQUEST */
-  destination?: Maybe<FinP2PAssetAccount>;
+  asset: RequestForTransferIntentAsset;
+  /** resource id of the receiver */
+  receiver?: Maybe<Scalars['String']['output']>;
+  /** resource id of the sender */
+  sender?: Maybe<Scalars['String']['output']>;
   signaturePolicy: RequestForTransferSignaturePolicy;
-  /** Signature policy type */
   signaturePolicyType: SignaturePolicyType;
-  /** Source account - used when actionType is SEND */
-  source?: Maybe<FinP2PAssetAccount>;
+};
+
+export type RequestForTransferIntentAsset = {
+  __typename?: 'RequestForTransferIntentAsset';
+  assetInstruction: RequestForTransferAssetInstruction;
+  assetTerm: AssetTerm;
+};
+
+export type RequestForTransferRequestInstruction = {
+  __typename?: 'RequestForTransferRequestInstruction';
+  /** Action type - always 'request' */
+  action: Scalars['String']['output'];
+  receiverAccount?: Maybe<FinP2PAssetAccount>;
+};
+
+export type RequestForTransferSendInstruction = {
+  __typename?: 'RequestForTransferSendInstruction';
+  /** Action type - always 'send' */
+  action: Scalars['String']['output'];
+  senderAccount?: Maybe<FinP2PAssetAccount>;
 };
 
 export type RequestForTransferSignaturePolicy = ManualIntentSignaturePolicy | PresignedRequestForTransferIntentSignaturePolicy;
@@ -1683,11 +1886,19 @@ export type StatusTransition = {
 
 export type Subscription = {
   __typename?: 'Subscription';
+  assetDataChanged: AssetDataItem;
   planAdded: ExecutionPlan;
   plansChangedBy: ExecutionPlan;
   receiptAdded: Receipt;
   userHoldingAdded: User;
   userHoldingChanged: User;
+};
+
+
+export type SubscriptionAssetDataChangedArgs = {
+  dataTypes?: InputMaybe<Array<DataType>>;
+  identifierType?: InputMaybe<AssetDataIdentifierType>;
+  identifierValue?: InputMaybe<Scalars['String']['input']>;
 };
 
 


### PR DESCRIPTION
## Summary

- Copy latest `ownership.graphql` from `owneraio/oss/graphql/ownership.graphql`
- Regenerate typed GraphQL definitions
- Bump finp2p-client to 0.28.2

The schema already uses `financialIdentifier` (matching the field rename in 0.28.1). This PR brings in any other schema changes that have landed upstream.

## Test plan

- [x] `npm run build` passes
- [ ] CI green, then tag `finp2p-client-v0.28.2` to publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)