### PR TITLE
finp2p-client: remove payment-asset stubs, simplify getAssetProofPolicy

### DIFF
--- a/finp2p-client/package.json
+++ b/finp2p-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.28.5",
+  "version": "0.28.4",
   "description": "FinP2P API Client",
   "homepage": "https://ownera.io/",
   "main": "./dist/index.js",

--- a/finp2p-client/package.json
+++ b/finp2p-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.28.4",
+  "version": "0.28.5",
   "description": "FinP2P API Client",
   "homepage": "https://ownera.io/",
   "main": "./dist/index.js",

--- a/finp2p-client/package.json
+++ b/finp2p-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "description": "FinP2P API Client",
   "homepage": "https://ownera.io/",
   "main": "./dist/index.js",

--- a/finp2p-client/src/client.ts
+++ b/finp2p-client/src/client.ts
@@ -1,8 +1,7 @@
-import { OssClient, OssExecutionPlan, parseProofDomain, Proof, ProofDomain, ProofPolicy } from './oss';
+import { OssClient, OssExecutionPlan, parseProofDomain, ProofPolicy } from './oss';
 import { FinAPIClient } from './finapi';
 import { components as FinAPIComponents } from './finapi/model-gen';
 import { components as OpComponents } from './finapi/op-model-gen';
-import { ItemNotFoundError } from './oss/errors';
 import { sleep } from './finapi/utils';
 
 
@@ -154,32 +153,14 @@ export class FinP2PClient {
     return this.ossClient.getAsset(assetId);
   }
 
-  async getAssetProofPolicy(assetCode: string, assetType: string, paymentOrgId: string): Promise<ProofPolicy> {
-    let proof: Proof;
-    let domain: ProofDomain | null = null;
-    let configRaw: string;
-    switch (assetType) {
-      case 'finp2p': {
-        ({ policies: { proof }, config: configRaw } = await this.getAsset(assetCode));
-        domain = parseProofDomain(configRaw);
-        break;
-      }
-      case 'cryptocurrency':
-      case 'fiat': {
-        try {
-          ({ policies: { proof } } = await this.getPaymentAsset(paymentOrgId, assetCode));
-        } catch (e) {
-          if (e instanceof ItemNotFoundError) {
-            return { type: 'NoProofPolicy' };
-          }
-          throw e;
-        }
-        break;
-      }
-      default:
-        throw new Error(`Unknown asset type: ${assetType}`);
+  async getAssetProofPolicy(assetCode: string, assetType: string): Promise<ProofPolicy> {
+    // v0.28 OSS schema only exposes proof policies for finp2p assets.
+    // Fiat / cryptocurrency payment assets no longer have a proof policy endpoint.
+    if (assetType !== 'finp2p') {
+      return { type: 'NoProofPolicy' };
     }
-
+    const { policies: { proof }, config: configRaw } = await this.getAsset(assetCode);
+    const domain = parseProofDomain(configRaw);
     switch (proof.type) {
       case 'NoProofPolicy':
         return { type: 'NoProofPolicy' };
@@ -187,14 +168,6 @@ export class FinP2PClient {
         return { ...proof, domain };
       }
     }
-  }
-
-  async getPaymentAssets() {
-    return this.ossClient.getPaymentAssets();
-  }
-
-  async getPaymentAsset(orgId: string, assetCode: string) {
-    return this.ossClient.getPaymentAsset(orgId, assetCode);
   }
 
   async getOwnerByFinId(finId: string) {

--- a/finp2p-client/src/flows.ts
+++ b/finp2p-client/src/flows.ts
@@ -33,6 +33,63 @@ async function unwrap(client: FinP2PClient, result: any, label: string): Promise
   return data;
 }
 
+// ── Asset creation ──
+
+export interface CreateAssetParams {
+  name: string;
+  type: 'finp2p' | 'fiat' | 'cryptocurrency';
+  issuerId: string;
+  symbol?: string;
+  denominationCode: string;
+  denominationType?: 'finp2p' | 'fiat' | 'cryptocurrency';
+  intentTypes: Array<'primarySale' | 'buyingIntent' | 'sellingIntent' | 'loanIntent' | 'redemptionIntent' | 'privateOfferIntent' | 'requestForTransferIntent'>;
+  /** Logical ledger name, must match the ledgerName registered via /ledger/bind */
+  ledger: string;
+  /** CAIP-2 chain id, e.g. 'eip155:11155111' (Sepolia) */
+  network: string;
+  /** Token identifier on the ledger (e.g. ERC-20 contract address) */
+  tokenId: string;
+  /** Token standard, e.g. 'erc20' */
+  standard: string;
+  assetPolicies?: any;
+  config?: string;
+  metadata?: any;
+  /** Optional financial asset identifier (ISIN/ISO4217/etc.) */
+  financialIdentifier?: {
+    assetIdentifierType: 'ISIN' | 'ISO4217' | 'NONE';
+    assetIdentifierValue?: string;
+  };
+}
+
+export async function createAsset(client: FinP2PClient, params: CreateAssetParams): Promise<string> {
+  const result = await (client.createAsset as any)(
+    params.name,
+    params.type,
+    params.issuerId,
+    params.symbol,
+    { type: params.denominationType ?? params.type, code: params.denominationCode },
+    params.intentTypes,
+    {
+      ledger: params.ledger,
+      bind: {
+        assetIdentifierType: 'CAIP-19' as const,
+        network: params.network,
+        tokenId: params.tokenId,
+        standard: params.standard,
+      },
+    },
+    params.assetPolicies,
+    params.config,
+    params.metadata,
+    params.financialIdentifier,
+  );
+
+  const res = await unwrap(client, result, 'createAsset');
+  const assetId = res?.id;
+  if (!assetId) throw new Error('Failed to create asset');
+  return assetId;
+}
+
 // ── Intent creation ──
 
 export interface PrimarySaleParams {

--- a/finp2p-client/src/flows.ts
+++ b/finp2p-client/src/flows.ts
@@ -249,6 +249,66 @@ export async function createRedemptionIntent(client: FinP2PClient, params: Redem
   return intentId;
 }
 
+export interface RequestForTransferIntentParams {
+  assetId: string;
+  amount: number;
+  senderId: string;
+  senderFinId: string;
+  receiverId: string;
+  receiverFinId: string;
+  action: 'send' | 'request';
+  custodianOrgId: string;
+}
+
+export async function createRequestForTransferIntent(
+  client: FinP2PClient,
+  params: RequestForTransferIntentParams,
+): Promise<string> {
+  const assetOrgId = extractOrgId(params.assetId);
+  const { start, end } = intentWindow();
+
+  // The side that *initiates* the intent provides its own account.
+  // `send`: sender initiates, provides senderAccount.
+  // `request`: receiver initiates, provides receiverAccount.
+  const assetInstruction = params.action === 'send'
+    ? {
+      action: 'send',
+      senderAccount: {
+        asset: { type: 'finp2p', resourceId: params.assetId },
+        account: finIdAccount(params.senderFinId, assetOrgId, params.custodianOrgId),
+      },
+    }
+    : {
+      action: 'request',
+      receiverAccount: {
+        asset: { type: 'finp2p', resourceId: params.assetId },
+        account: finIdAccount(params.receiverFinId, assetOrgId, params.custodianOrgId),
+      },
+    };
+
+  const result = await (client.createIntent as any)(params.assetId, {
+    start, end,
+    intent: {
+      type: 'requestForTransferIntent',
+      sender: params.senderId,
+      receiver: params.receiverId,
+      asset: {
+        assetTerm: {
+          asset: { type: 'finp2p', resourceId: params.assetId },
+          amount: String(params.amount),
+        },
+        assetInstruction,
+      },
+      signaturePolicy: { type: 'manualPolicy' },
+    },
+  });
+
+  const res = await unwrap(client, result, 'createRequestForTransferIntent');
+  const intentId = res?.id;
+  if (!intentId) throw new Error('Failed to create request-for-transfer intent');
+  return intentId;
+}
+
 // ── Intent execution ──
 
 export interface ExecutePrimarySaleParams {
@@ -449,5 +509,61 @@ export async function executeRedemptionIntent(client: FinP2PClient, params: Exec
   const res = await unwrap(client, result, 'executeRedemptionIntent');
   const planId = res?.executionPlanId ?? res?.response?.executionPlanId;
   if (!planId) throw new Error('Failed to execute redemption intent');
+  return planId;
+}
+
+export interface ExecuteRequestForTransferIntentParams {
+  intentId: string;
+  executionId: string;
+  assetId: string;
+  amount: number;
+  sender: { id: string; finId: string; custodianOrgId: string };
+  receiver: { id: string; finId: string; custodianOrgId: string };
+  action: 'send' | 'request';
+}
+
+export async function executeRequestForTransferIntent(
+  client: FinP2PClient,
+  params: ExecuteRequestForTransferIntentParams,
+): Promise<string> {
+  const assetOrgId = extractOrgId(params.assetId);
+
+  // Counterparty to the action initiates execution:
+  // `send`: sender initiated → receiver executes
+  // `request`: receiver initiated → sender executes
+  const user = params.action === 'send' ? params.receiver.id : params.sender.id;
+
+  const result = await (client.executeIntent as any)({
+    user,
+    intentId: params.intentId,
+    executionId: params.executionId,
+    intent: {
+      type: 'requestForTransferIntentExecution',
+      nonce: hexNonce(),
+      action: params.action,
+      sender: params.sender.id,
+      receiver: params.receiver.id,
+      asset: {
+        term: {
+          asset: { type: 'finp2p', resourceId: params.assetId },
+          amount: String(params.amount),
+        },
+        instruction: {
+          sourceAccount: {
+            asset: { type: 'finp2p', resourceId: params.assetId },
+            account: finIdAccount(params.sender.finId, assetOrgId, params.sender.custodianOrgId),
+          },
+          destinationAccount: {
+            asset: { type: 'finp2p', resourceId: params.assetId },
+            account: finIdAccount(params.receiver.finId, assetOrgId, params.receiver.custodianOrgId),
+          },
+        },
+      },
+    },
+  });
+
+  const res = await unwrap(client, result, 'executeRequestForTransferIntent');
+  const planId = res?.executionPlanId ?? res?.response?.executionPlanId;
+  if (!planId) throw new Error('Failed to execute request-for-transfer intent');
   return planId;
 }

--- a/finp2p-client/src/oss/graphql.d.ts
+++ b/finp2p-client/src/oss/graphql.d.ts
@@ -20,7 +20,7 @@ export type AccountIdentifier = CryptoWalletAccount | FinP2PAccount | Iban;
 export enum ActionType {
   Request = 'request',
   Send = 'send',
-  Unknown = 'unknown'
+  Unknown = 'unknown',
 }
 
 export type AdditionalContractDetails = {
@@ -42,7 +42,7 @@ export enum AggregateFunc {
   Count = 'COUNT',
   Max = 'MAX',
   Min = 'MIN',
-  Sum = 'SUM'
+  Sum = 'SUM',
 }
 
 /** Result of Aggregation function applied on an Object numeric field. */
@@ -73,7 +73,7 @@ export type ApprovalConfigs = {
 export enum ApprovalStatus {
   Approved = 'Approved',
   Rejected = 'Rejected',
-  Unknown = 'Unknown'
+  Unknown = 'Unknown',
 }
 
 /** Represents an Asset in the network. */
@@ -146,7 +146,7 @@ export type AssetIssuedTokensArgs = {
 /** Identifier type for asset data */
 export enum AssetDataIdentifierType {
   Caip19 = 'CAIP19',
-  Isin = 'ISIN'
+  Isin = 'ISIN',
 }
 
 /** Represents financial data for an asset from a data provider */
@@ -199,7 +199,7 @@ export enum AssetOrderField {
   /** Assets order by determined by Name field */
   Name = 'NAME',
   /** Assets order by determined by OrganizationId field */
-  Organization = 'ORGANIZATION'
+  Organization = 'ORGANIZATION',
 }
 
 export type AssetOrderInput = {
@@ -249,7 +249,7 @@ export type AssetTerm = {
 export enum AssetType {
   Cryptocurrency = 'cryptocurrency',
   Fiat = 'fiat',
-  Finp2p = 'finp2p'
+  Finp2p = 'finp2p',
 }
 
 /** Results for asset query. */
@@ -349,7 +349,7 @@ export type CertificateOrder = {
 
 export enum CertificateOrderField {
   /** certificates order by determined by Id field */
-  Id = 'ID'
+  Id = 'ID',
 }
 
 /** Results for certificates query. */
@@ -421,7 +421,7 @@ export type DataAccess = {
 
 export enum DataAccessType {
   Balance = 'Balance',
-  Unknown = 'Unknown'
+  Unknown = 'Unknown',
 }
 
 /** Represents a data provider binding configuration */
@@ -492,7 +492,7 @@ export enum DataType {
   MarketData = 'marketData',
   Pricing = 'pricing',
   Ratings = 'ratings',
-  ReferenceData = 'referenceData'
+  ReferenceData = 'referenceData',
 }
 
 export type Delivered = {
@@ -601,7 +601,7 @@ export enum ExecutionPlanInstructionStatus {
   Failed = 'Failed',
   Pending = 'Pending',
   Rejected = 'Rejected',
-  Unknown = 'Unknown'
+  Unknown = 'Unknown',
 }
 
 export type ExecutionPlanInstructions = {
@@ -623,7 +623,7 @@ export type ExecutionPlanOrder = {
 export enum ExecutionPlanOrderField {
   CreationTimestamp = 'CREATION_TIMESTAMP',
   /** plan order by PlanId field */
-  PlanId = 'PLAN_ID'
+  PlanId = 'PLAN_ID',
 }
 
 export enum ExecutionPlanStatus {
@@ -635,7 +635,7 @@ export enum ExecutionPlanStatus {
   InProgress = 'InProgress',
   Pending = 'Pending',
   Rejected = 'Rejected',
-  Unknown = 'Unknown'
+  Unknown = 'Unknown',
 }
 
 export type ExecutionsPlans = {
@@ -746,7 +746,7 @@ export enum FinancialIdentifierType {
   Custom = 'CUSTOM',
   Isin = 'ISIN',
   Iso4217 = 'ISO4217',
-  Unspecified = 'UNSPECIFIED'
+  Unspecified = 'UNSPECIFIED',
 }
 
 export type FullSettlement = {
@@ -797,7 +797,7 @@ export enum HoldingFields {
   SyncedAvailableBalance = 'SyncedAvailableBalance',
   SyncedBalance = 'SyncedBalance',
   SyncedHeldBalance = 'SyncedHeldBalance',
-  WithheldBalance = 'WithheldBalance'
+  WithheldBalance = 'WithheldBalance',
 }
 
 export type Holdings = {
@@ -810,7 +810,7 @@ export type Holdings = {
 
 export enum HttpSchemas {
   Http1_1 = 'HTTP1_1',
-  Http2 = 'HTTP2'
+  Http2 = 'HTTP2',
 }
 
 /** IBAN bank account */
@@ -884,7 +884,7 @@ export enum IntentStatus {
   Completed = 'COMPLETED',
   Expired = 'EXPIRED',
   NonActive = 'NON_ACTIVE',
-  Rejected = 'REJECTED'
+  Rejected = 'REJECTED',
 }
 
 export enum IntentTypes {
@@ -893,7 +893,7 @@ export enum IntentTypes {
   PrimarySale = 'PRIMARY_SALE',
   PrivateOffer = 'PRIVATE_OFFER',
   RequestForTransfer = 'REQUEST_FOR_TRANSFER',
-  Selling = 'SELLING'
+  Selling = 'SELLING',
 }
 
 /** Results for itents query. */
@@ -920,7 +920,7 @@ export enum InvestorRole {
   Buyer = 'BUYER',
   Issuer = 'ISSUER',
   Lender = 'LENDER',
-  Seller = 'SELLER'
+  Seller = 'SELLER',
 }
 
 export type IssuanceContractDetails = {
@@ -969,7 +969,7 @@ export type IssuerOrder = {
 
 export enum IssuerOrderField {
   /** issuers order by determined by Id field */
-  Id = 'ID'
+  Id = 'ID',
 }
 
 /** Results for issuers query. */
@@ -1007,7 +1007,7 @@ export type LedgerAuthOptions = LedgerApiKeyOptions | LedgerMtlsOptions | Ledger
 export enum LedgerAuthType {
   ApiKey = 'API_KEY',
   Mtls = 'MTLS',
-  Oauth = 'OAUTH'
+  Oauth = 'OAUTH',
 }
 
 export type LedgerBinding = {
@@ -1191,7 +1191,7 @@ export enum OperationType {
   Redeem = 'Redeem',
   Release = 'Release',
   Transfer = 'Transfer',
-  Unknown = 'Unknown'
+  Unknown = 'Unknown',
 }
 
 /** Operators available to be used  */
@@ -1213,7 +1213,7 @@ export enum Operator {
   /** Not Equals */
   Neq = 'NEQ',
   /** Not In */
-  Nin = 'NIN'
+  Nin = 'NIN',
 }
 
 /** Organization's information. */
@@ -1263,7 +1263,7 @@ export type OrganizationOrder = {
 
 export enum OrganizationOrderField {
   /** organizations order by determined by Id field */
-  Id = 'ID'
+  Id = 'ID',
 }
 
 /** Results for Organization query. */
@@ -1371,7 +1371,7 @@ export type PlanApprovals = {
 
 /** Fields to subscribe on */
 export enum PlanField {
-  Status = 'Status'
+  Status = 'Status',
 }
 
 export type PresignedBuyingIntentSignaturePolicy = {
@@ -1653,7 +1653,7 @@ export type ReceiptOrder = {
 
 export enum ReceiptOrderField {
   /** receipt order by determined by Id field */
-  Id = 'ID'
+  Id = 'ID',
 }
 
 export type ReceiptState = {
@@ -1664,7 +1664,7 @@ export type ReceiptState = {
 export enum ReceiptStatus {
   Invalid = 'Invalid',
   Unknown = 'Unknown',
-  Valid = 'Valid'
+  Valid = 'Valid',
 }
 
 /** Results for receipts query. */
@@ -1854,7 +1854,7 @@ export type Signature = {
 
 export enum SignaturePolicyType {
   ManualPolicy = 'ManualPolicy',
-  PresignedPolicy = 'PresignedPolicy'
+  PresignedPolicy = 'PresignedPolicy',
 }
 
 export type SignatureProof = {
@@ -1871,12 +1871,12 @@ export type SignatureProofPolicy = {
 export enum SignatureTemplate {
   Eip712 = 'EIP712',
   HashList = 'HashList',
-  Unknown = 'Unknown'
+  Unknown = 'Unknown',
 }
 
 export enum SortOrder {
   Asc = 'ASC',
-  Desc = 'DESC'
+  Desc = 'DESC',
 }
 
 export type StatusTransition = {
@@ -2031,7 +2031,7 @@ export type UserOrder = {
 
 export enum UserOrderField {
   /** users order by determined by Id field */
-  Id = 'ID'
+  Id = 'ID',
 }
 
 /** Results for asset query. */
@@ -2097,7 +2097,7 @@ export enum WorkflowAdminAction {
   Cancel = 'CANCEL',
   Reset = 'RESET',
   Resume = 'RESUME',
-  Retry = 'RETRY'
+  Retry = 'RETRY',
 }
 
 /** Admin operations metadata and history */
@@ -2144,7 +2144,7 @@ export enum WorkflowHealthStatus {
   Healthy = 'HEALTHY',
   Stale = 'STALE',
   Stuck = 'STUCK',
-  Unhealthy = 'UNHEALTHY'
+  Unhealthy = 'UNHEALTHY',
 }
 
 export type WorkflowMetadata = {
@@ -2168,7 +2168,7 @@ export enum WorkflowOrderField {
   /** workflow order */
   Name = 'NAME',
   ReferenceId = 'REFERENCE_ID',
-  Status = 'STATUS'
+  Status = 'STATUS',
 }
 
 export type Workflows = {
@@ -2180,5 +2180,5 @@ export type Workflows = {
 
 export enum TemplateType {
   Eip712Template = 'EIP712Template',
-  HashListTemplate = 'HashListTemplate'
+  HashListTemplate = 'HashListTemplate',
 }

--- a/finp2p-client/src/oss/model.ts
+++ b/finp2p-client/src/oss/model.ts
@@ -115,21 +115,6 @@ export type OssAssetNodes = {
   assets: { nodes: OssAsset[] }
 };
 
-/**
- * Legacy payment-asset / escrow types.
- *
- * The `escrows` root query (and the `PaymentAsset` schema graph that hung off it)
- * was removed from the OSS schema in router v0.28. The surviving
- * `OssClient.getPaymentAsset` / `getPaymentAssets` methods are kept for
- * API compatibility but now return empty / throw `ItemNotFoundError`.
- * This type is retained only so callers that still reference it continue to compile.
- */
-export type OssPaymentAsset = {
-  code: string
-  type: string
-  policies: AssetPolicies
-};
-
 export type OssOwner = {
   id: string,
   name: string,

--- a/finp2p-client/src/oss/oss.client.ts
+++ b/finp2p-client/src/oss/oss.client.ts
@@ -8,7 +8,7 @@ import LEDGERS from './graphql/ledgers.graphql';
 import APPROVAL_CONFIGS from './graphql/approval-configs.graphql';
 import PLANS from './graphql/plans.graphql';
 import RECEIPTS from './graphql/receipts.graphql';
-import { OssApprovalConfigNodes, OssAssetNodes, OssCertificate, OssExecutionPlan, OssExecutionPlanNodes, OssLedgerBindingNodes, OssOrganizationNodes, OssOwnerNodes, OssPaymentAsset, OssReceipt, OssReceiptNodes } from './model';
+import { OssApprovalConfigNodes, OssAssetNodes, OssCertificate, OssExecutionPlan, OssExecutionPlanNodes, OssLedgerBindingNodes, OssOrganizationNodes, OssOwnerNodes, OssReceipt, OssReceiptNodes } from './model';
 import { ItemNotFoundError } from './errors';
 
 export class OssClient {
@@ -94,16 +94,6 @@ export class OssClient {
       throw new ItemNotFoundError(assetId, 'Asset');
     }
     return resp.assets.nodes[0];
-  }
-
-  async getPaymentAssets(): Promise<OssPaymentAsset[]> {
-    // `escrows` / payment assets query was removed in OSS schema v0.28.
-    return [];
-  }
-
-  async getPaymentAsset(orgId: string, assetCode: string): Promise<OssPaymentAsset> {
-    // `escrows` / payment assets query was removed in OSS schema v0.28.
-    throw new ItemNotFoundError(`${orgId}:${assetCode}`, 'Payment asset');
   }
 
   async getOrganization(orgId: string) {


### PR DESCRIPTION
## Summary

- Remove `OssClient.getPaymentAssets` / `getPaymentAsset` (escrows root query was removed in v0.28)
- Remove `FinP2PClient.getPaymentAssets` / `getPaymentAsset` wrappers
- Remove `OssPaymentAsset` type
- Simplify `getAssetProofPolicy`: drop `paymentOrgId` param, return `NoProofPolicy` directly for non-finp2p asset types (fiat, crypto)

**Breaking change** on the client signature: `getAssetProofPolicy(assetCode, assetType, paymentOrgId)` → `getAssetProofPolicy(assetCode, assetType)`. No callers in this monorepo.

Bumps finp2p-client to 0.28.4.

## Status of the 4 audit items

1. **`ledgerAssetBinding` structure change** — Types are correctly regenerated. `ledgerAssetBinding.bind` is typed as `ledgerAssetIdentifier` which requires `{ assetIdentifierType: 'CAIP-19', network, tokenId, standard }`. TypeScript will catch the old shape at compile time. The 503 is a caller-side issue — the caller is constructing the old `{ type: 'tokenId', tokenId }` shape (matches the unused `ledgerTokenId` type from legacy spec). No client fix needed.
2. **`payment-assets.graphql` removed** — addressed by this PR (stubs removed).
3. **API surface audit** — `LedgerAccountAsset`, `FinP2PAssetAccount`, `AssetDetails`, instruction `source`/`destination`, `AccountInstruction` removal: all updated in 0.28.3 (#176).
4. **`createTransferRequest` / `executeTransferIntent` absence** — These endpoints don't exist in v0.28. Callers should use `createIntent` with `requestForTransferIntent` type + `executeIntent`. No client change.

## Test plan

- [x] `npm run build` passes
- [ ] CI green, then tag `finp2p-client-v0.28.4` to publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)