### PR TITLE
finp2p-client 0.28.5: align flows with v0.28 OpenAPI + custody bind + loan/transfer helpers

### DIFF
--- a/finp2p-client/apis/application-api.base.yaml
+++ b/finp2p-client/apis/application-api.base.yaml
@@ -2725,14 +2725,14 @@ components:
 
     symbol:
       type: string
-      pattern: '^[A-Z0-9]+$'
+      pattern: '^[A-Z0-9][A-Z0-9.\-]{0,49}$'
       minLength: 1
       maxLength: 50
       description: The symbol of the asset
 
     symbolOpt:
       type: string
-      pattern: '^[A-Z0-9]+$'
+      pattern: '^[A-Z0-9][A-Z0-9.\-]{0,49}$'
       minLength: 1
       maxLength: 50
       description: The symbol of the asset

--- a/finp2p-client/apis/common-external-components.yaml
+++ b/finp2p-client/apis/common-external-components.yaml
@@ -751,7 +751,7 @@ components:
         code:
           type: string
           description: Unique code identifying the denomination asset type
-          pattern: '^[a-zA-Z0-9]*$'
+          pattern: '^[a-zA-Z0-9][a-zA-Z0-9.\-]*$'
           maxLength: 150
           minLength: 1
     assetType:

--- a/finp2p-client/package.json
+++ b/finp2p-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.28.4",
+  "version": "0.28.5",
   "description": "FinP2P API Client",
   "homepage": "https://ownera.io/",
   "main": "./dist/index.js",

--- a/finp2p-client/src/client.ts
+++ b/finp2p-client/src/client.ts
@@ -107,6 +107,16 @@ export class FinP2PClient {
     return this.finAPIClient.updateLedger(...args);
   }
 
+  // ── Custody provider management ──
+
+  async bindCustodyProvider(...args: Parameters<FinAPIClient['bindCustodyProvider']>) {
+    return this.finAPIClient.bindCustodyProvider(...args);
+  }
+
+  async updateCustodyProvider(...args: Parameters<FinAPIClient['updateCustodyProvider']>) {
+    return this.finAPIClient.updateCustodyProvider(...args);
+  }
+
   // ── Approval routing ──
 
   async setApprovalRouting(...args: Parameters<FinAPIClient['setApprovalRouting']>) {

--- a/finp2p-client/src/finapi/finapi.client.ts
+++ b/finp2p-client/src/finapi/finapi.client.ts
@@ -175,6 +175,19 @@ export class FinAPIClient {
     });
   }
 
+  // ── Custody provider management (operational API) ──
+
+  async bindCustodyProvider(body: OpRequestBody<'/custody/bind', 'post'>) {
+    return this.opClient.POST('/custody/bind', { body });
+  }
+
+  async updateCustodyProvider(name: string, body: OpRequestBody<'/custody/{name}/update', 'patch'>) {
+    return this.opClient.PATCH('/custody/{name}/update', {
+      params: { path: { name } },
+      body,
+    });
+  }
+
   // ── Approval routing (operational API) ──
 
   async setApprovalRouting(body: OpRequestBody<'/execution/proposals', 'put'>) {

--- a/finp2p-client/src/finapi/utils.ts
+++ b/finp2p-client/src/finapi/utils.ts
@@ -24,9 +24,21 @@ export function generateNonce(): Buffer {
   return buffer;
 }
 
-export type AccountRef = { type: string; [key: string]: unknown };
+export type FinIdAccountRef = {
+  type: 'finId';
+  finId: string;
+  orgId: string;
+  custodian: { orgId: string };
+};
 
-export function finIdAccount(finId: string, orgId: string, custodianOrgId: string): AccountRef {
+export type CryptoWalletAccountRef = {
+  type: 'cryptoWallet';
+  address: string;
+};
+
+export type AccountRef = FinIdAccountRef | CryptoWalletAccountRef;
+
+export function finIdAccount(finId: string, orgId: string, custodianOrgId: string): FinIdAccountRef {
   return { type: 'finId', finId, orgId, custodian: { orgId: custodianOrgId } };
 }
 

--- a/finp2p-client/src/flows.ts
+++ b/finp2p-client/src/flows.ts
@@ -5,16 +5,30 @@
  * with structured parameter objects and automatic async operation polling.
  */
 import type { FinP2PClient } from './client';
-import { extractOrgId, hexNonce, finIdAccount, settlementAccount } from './finapi/utils';
+import { extractOrgId, hexNonce, finIdAccount } from './finapi/utils';
 
 const OP_TIMEOUT = 100_000;
 
-type SettlementAsset = { type: 'fiat'; code: string } | { type: 'finp2p'; resourceId: string };
+/**
+ * Reference to a FinP2P asset as required by v0.28 intent payloads:
+ * { id, ledgerIdentifier } — no `resourceId`/`code`/`type` variants.
+ */
+export type Finp2pAsset = {
+  id: string;
+  ledgerIdentifier: {
+    assetIdentifierType: 'CAIP-19';
+    network: string;
+    tokenId: string;
+    standard: string;
+  };
+};
 
-function makeSettlementAsset(paymentAssetCode: string, paymentAssetId?: string): SettlementAsset {
-  return paymentAssetId
-    ? { type: 'finp2p', resourceId: paymentAssetId }
-    : { type: 'fiat', code: paymentAssetCode };
+/** Build the asset payload embedded in intent instructions (matches schema `finp2pAsset`). */
+function finp2pAsset(ref: Finp2pAsset) {
+  return {
+    id: ref.id,
+    ledgerIdentifier: ref.ledgerIdentifier,
+  };
 }
 
 function intentWindow(): { start: number; end: number } {
@@ -37,10 +51,12 @@ async function unwrap(client: FinP2PClient, result: any, label: string): Promise
 
 export interface CreateAssetParams {
   name: string;
-  type: 'finp2p' | 'fiat' | 'cryptocurrency';
+  /** Asset classification (Equity, Debt, Cryptocurrency, Fiat, etc.) */
+  type: 'Equity' | 'Debt' | 'Loans' | 'Fund' | 'RealEstate' | 'Commodity' | 'Fiat' | 'Cryptocurrency' | 'TokenizedCash' | 'DigitalNatives' | 'Basket' | 'Other';
   issuerId: string;
   symbol?: string;
   denominationCode: string;
+  /** How the asset is denominated for settlement purposes. Defaults to 'finp2p'. */
   denominationType?: 'finp2p' | 'fiat' | 'cryptocurrency';
   intentTypes: Array<'primarySale' | 'buyingIntent' | 'sellingIntent' | 'loanIntent' | 'redemptionIntent' | 'privateOfferIntent' | 'requestForTransferIntent'>;
   /** Logical ledger name, must match the ledgerName registered via /ledger/bind */
@@ -54,20 +70,20 @@ export interface CreateAssetParams {
   assetPolicies?: any;
   config?: string;
   metadata?: any;
-  /** Optional financial asset identifier (ISIN/ISO4217/etc.) */
-  financialIdentifier?: {
-    assetIdentifierType: 'ISIN' | 'ISO4217' | 'NONE';
-    assetIdentifierValue?: string;
-  };
+  /** Optional financial asset identifier (ISIN/ISO4217/NONE) */
+  financialIdentifier?:
+  | { assetIdentifierType: 'ISIN'; assetIdentifierValue: string }
+  | { assetIdentifierType: 'ISO4217'; assetIdentifierValue: string }
+  | { assetIdentifierType: 'NONE' };
 }
 
 export async function createAsset(client: FinP2PClient, params: CreateAssetParams): Promise<string> {
-  const result = await (client.createAsset as any)(
+  const result = await client.createAsset(
     params.name,
     params.type,
     params.issuerId,
     params.symbol,
-    { type: params.denominationType ?? params.type, code: params.denominationCode },
+    { type: params.denominationType ?? 'finp2p', code: params.denominationCode },
     params.intentTypes,
     {
       ledger: params.ledger,
@@ -93,48 +109,43 @@ export async function createAsset(client: FinP2PClient, params: CreateAssetParam
 // ── Intent creation ──
 
 export interface PrimarySaleParams {
-  assetId: string;
+  asset: Finp2pAsset;
+  paymentAsset: Finp2pAsset;
   issuanceAmount: number;
   issuerId: string;
   issuerFinId: string;
-  paymentAssetCode: string;
-  paymentAssetId?: string;
   price: number;
   paymentOrgId: string;
   custodianOrgId: string;
 }
 
 export async function createPrimarySale(client: FinP2PClient, params: PrimarySaleParams): Promise<string> {
-  const assetOrgId = extractOrgId(params.assetId);
+  const assetOrgId = extractOrgId(params.asset.id);
   const { start, end } = intentWindow();
-  const settlement = makeSettlementAsset(params.paymentAssetCode, params.paymentAssetId);
 
-  const result = await (client.createIntent as any)(params.assetId, {
+  const result = await client.createIntent(params.asset.id, {
     start, end,
     intent: {
       type: 'primarySale',
       issuer: params.issuerId,
-      assetTerm: {
-        asset: { type: 'finp2p', resourceId: params.assetId },
-        amount: String(params.issuanceAmount),
-      },
-      assetInstruction: {
-        account: {
-          asset: { type: 'finp2p', resourceId: params.assetId },
-          account: finIdAccount(params.issuerFinId, assetOrgId, params.custodianOrgId),
+      asset: {
+        assetTerm: { amount: String(params.issuanceAmount) },
+        assetInstruction: {
+          sourceAccount: {
+            asset: finp2pAsset(params.asset),
+            account: finIdAccount(params.issuerFinId, assetOrgId, params.custodianOrgId),
+          },
         },
       },
-      settlementTerm: {
-        type: 'partialSettlement',
-        asset: settlement,
-        unitValue: params.price.toFixed(2),
-      },
-      settlementInstruction: {
-        destinationAccounts: [{
-          asset: settlement,
-          account: finIdAccount(params.issuerFinId, params.paymentOrgId, params.custodianOrgId),
-        }],
-      },
+      settlement: [{
+        settlementTerm: { type: 'partialSettlement', unitValue: params.price.toFixed(2) },
+        settlementInstruction: {
+          destinationAccount: {
+            asset: finp2pAsset(params.paymentAsset),
+            account: finIdAccount(params.issuerFinId, params.paymentOrgId, params.custodianOrgId),
+          },
+        },
+      }],
     },
   });
 
@@ -145,49 +156,43 @@ export async function createPrimarySale(client: FinP2PClient, params: PrimarySal
 }
 
 export interface SellingIntentParams {
-  assetId: string;
+  asset: Finp2pAsset;
+  paymentAsset: Finp2pAsset;
   sellingAmount: number;
   sellerId: string;
   sellerFinId: string;
-  paymentAssetCode: string;
-  paymentAssetId?: string;
   price: number;
   paymentOrgId: string;
   custodianOrgId: string;
-  sellerCryptoAddress?: string;
 }
 
 export async function createSellingIntent(client: FinP2PClient, params: SellingIntentParams): Promise<string> {
-  const assetOrgId = extractOrgId(params.assetId);
+  const assetOrgId = extractOrgId(params.asset.id);
   const { start, end } = intentWindow();
-  const settlement = makeSettlementAsset(params.paymentAssetCode, params.paymentAssetId);
 
-  const result = await (client.createIntent as any)(params.assetId, {
+  const result = await client.createIntent(params.asset.id, {
     start, end,
     intent: {
       type: 'sellingIntent',
       seller: params.sellerId,
-      assetTerm: {
-        asset: { type: 'finp2p', resourceId: params.assetId },
-        amount: String(params.sellingAmount),
-      },
-      assetInstruction: {
-        account: {
-          asset: { type: 'finp2p', resourceId: params.assetId },
-          account: finIdAccount(params.sellerFinId, assetOrgId, params.custodianOrgId),
+      asset: {
+        assetTerm: { amount: String(params.sellingAmount) },
+        assetInstruction: {
+          sourceAccount: {
+            asset: finp2pAsset(params.asset),
+            account: finIdAccount(params.sellerFinId, assetOrgId, params.custodianOrgId),
+          },
         },
       },
-      settlementTerm: {
-        type: 'partialSettlement',
-        asset: settlement,
-        unitValue: params.price.toFixed(2),
-      },
-      settlementInstruction: {
-        destinationAccounts: [{
-          asset: settlement,
-          account: settlementAccount(params.sellerFinId, params.paymentOrgId, params.custodianOrgId, params.sellerCryptoAddress),
-        }],
-      },
+      settlement: [{
+        settlementTerm: { type: 'partialSettlement', unitValue: params.price.toFixed(2) },
+        settlementInstruction: {
+          destinationAccount: {
+            asset: finp2pAsset(params.paymentAsset),
+            account: finIdAccount(params.sellerFinId, params.paymentOrgId, params.custodianOrgId),
+          },
+        },
+      }],
       signaturePolicy: { type: 'manualPolicy' },
     },
   });
@@ -199,47 +204,41 @@ export async function createSellingIntent(client: FinP2PClient, params: SellingI
 }
 
 export interface BuyingIntentParams {
-  assetId: string;
+  asset: Finp2pAsset;
+  paymentAsset: Finp2pAsset;
   buyingAmount: number;
   buyerId: string;
   buyerFinId: string;
-  paymentAssetCode: string;
-  paymentAssetId?: string;
   price: number;
   paymentOrgId: string;
   custodianOrgId: string;
-  buyerCryptoAddress?: string;
 }
 
 export async function createBuyingIntent(client: FinP2PClient, params: BuyingIntentParams): Promise<string> {
-  const assetOrgId = extractOrgId(params.assetId);
+  const assetOrgId = extractOrgId(params.asset.id);
   const { start, end } = intentWindow();
-  const settlement = makeSettlementAsset(params.paymentAssetCode, params.paymentAssetId);
 
-  const result = await (client.createIntent as any)(params.assetId, {
+  const result = await client.createIntent(params.asset.id, {
     start, end,
     intent: {
       type: 'buyingIntent',
       buyer: params.buyerId,
-      assetTerm: {
-        asset: { type: 'finp2p', resourceId: params.assetId },
-        amount: String(params.buyingAmount),
-      },
-      assetInstruction: {
-        account: {
-          asset: { type: 'finp2p', resourceId: params.assetId },
-          account: finIdAccount(params.buyerFinId, assetOrgId, params.custodianOrgId),
+      asset: {
+        assetTerm: { amount: String(params.buyingAmount) },
+        assetInstruction: {
+          destinationAccount: {
+            asset: finp2pAsset(params.asset),
+            account: finIdAccount(params.buyerFinId, assetOrgId, params.custodianOrgId),
+          },
         },
       },
-      settlementTerm: {
-        type: 'partialSettlement',
-        asset: settlement,
-        unitValue: params.price.toFixed(2),
-      },
-      settlementInstruction: {
-        sourceAccount: {
-          asset: settlement,
-          account: settlementAccount(params.buyerFinId, params.paymentOrgId, params.custodianOrgId, params.buyerCryptoAddress),
+      settlement: {
+        settlementTerm: { type: 'partialSettlement', unitValue: params.price.toFixed(2) },
+        settlementInstruction: {
+          sourceAccount: {
+            asset: finp2pAsset(params.paymentAsset),
+            account: finIdAccount(params.buyerFinId, params.paymentOrgId, params.custodianOrgId),
+          },
         },
       },
       signaturePolicy: { type: 'manualPolicy' },
@@ -253,50 +252,44 @@ export async function createBuyingIntent(client: FinP2PClient, params: BuyingInt
 }
 
 export interface RedemptionIntentParams {
-  assetId: string;
+  asset: Finp2pAsset;
+  paymentAsset: Finp2pAsset;
   redemptionAmount: number;
   issuerId: string;
   issuerFinId: string;
-  paymentAssetCode: string;
-  paymentAssetId?: string;
   price: number;
   paymentOrgId: string;
   custodianOrgId: string;
 }
 
 export async function createRedemptionIntent(client: FinP2PClient, params: RedemptionIntentParams): Promise<string> {
-  const assetOrgId = extractOrgId(params.assetId);
+  const assetOrgId = extractOrgId(params.asset.id);
   const { start, end } = intentWindow();
-  const settlement = makeSettlementAsset(params.paymentAssetCode, params.paymentAssetId);
 
-  const result = await (client.createIntent as any)(params.assetId, {
+  const result = await client.createIntent(params.asset.id, {
     start, end,
     intent: {
       type: 'redemptionIntent',
       issuer: params.issuerId,
-      assetTerm: {
-        asset: { type: 'finp2p', resourceId: params.assetId },
-        amount: String(params.redemptionAmount),
-      },
-      assetInstruction: {
-        account: {
-          asset: { type: 'finp2p', resourceId: params.assetId },
-          account: finIdAccount(params.issuerFinId, assetOrgId, params.custodianOrgId),
+      asset: {
+        assetTerm: { amount: String(params.redemptionAmount) },
+        assetInstruction: {
+          destinationAccount: {
+            asset: finp2pAsset(params.asset),
+            account: finIdAccount(params.issuerFinId, assetOrgId, params.custodianOrgId),
+          },
         },
       },
-      settlementTerm: {
-        type: 'partialSettlement',
-        asset: settlement,
-        unitValue: params.price.toFixed(2),
-      },
-      settlementInstruction: {
-        sourceAccounts: [{
-          asset: settlement,
-          account: finIdAccount(params.issuerFinId, params.paymentOrgId, params.custodianOrgId),
-        }],
-      },
+      settlement: [{
+        settlementTerm: { type: 'partialSettlement', unitValue: params.price.toFixed(2) },
+        settlementInstruction: {
+          sourceAccount: {
+            asset: finp2pAsset(params.paymentAsset),
+            account: finIdAccount(params.issuerFinId, params.paymentOrgId, params.custodianOrgId),
+          },
+        },
+      }],
       signaturePolicy: { type: 'manualPolicy' },
-      conditions: {},
     },
   });
 
@@ -306,8 +299,87 @@ export async function createRedemptionIntent(client: FinP2PClient, params: Redem
   return intentId;
 }
 
+/** Loan-specific conditions (required when `loanInstruction` is provided). */
+export type LoanConditions =
+  | { type: 'repaymentTerm'; closeAmount: string; interestRate?: string }
+  | { type: 'interestTerm'; interestRate: string }
+  | { type: 'closeAmountTerm'; closeAmount: string };
+
+export interface LoanIntentParams {
+  asset: Finp2pAsset;
+  paymentAsset: Finp2pAsset;
+  loanAmount: number;
+  creatorType: 'borrower' | 'lender';
+  borrowerId: string;
+  borrowerFinId: string;
+  lenderId: string;
+  lenderFinId: string;
+  price: number;
+  paymentOrgId: string;
+  custodianOrgId: string;
+  /** Epoch seconds */
+  openDate?: number;
+  /** Epoch seconds */
+  closeDate?: number;
+  conditions?: LoanConditions;
+}
+
+export async function createLoanIntent(client: FinP2PClient, params: LoanIntentParams): Promise<string> {
+  const assetOrgId = extractOrgId(params.asset.id);
+  const { start, end } = intentWindow();
+
+  const borrowerAccount = (assetRef: Finp2pAsset) => ({
+    asset: finp2pAsset(assetRef),
+    account: finIdAccount(params.borrowerFinId, assetOrgId, params.custodianOrgId),
+  });
+  const lenderAccount = (assetRef: Finp2pAsset) => ({
+    asset: finp2pAsset(assetRef),
+    account: finIdAccount(params.lenderFinId, assetOrgId, params.custodianOrgId),
+  });
+
+  // `loanInstruction.conditions` is required by the schema, so only include
+  // `loanInstruction` when the caller supplied `conditions`.
+  const loanInstruction = params.conditions
+    ? {
+      openDate: params.openDate ?? start,
+      closeDate: params.closeDate ?? end,
+      conditions: params.conditions,
+    }
+    : undefined;
+
+  const result = await client.createIntent(params.asset.id, {
+    start, end,
+    intent: {
+      type: 'loanIntent',
+      creatorType: params.creatorType,
+      borrower: params.borrowerId,
+      lender: params.lenderId,
+      asset: {
+        assetTerm: { amount: String(params.loanAmount) },
+        assetInstruction: {
+          borrowerAccount: borrowerAccount(params.asset),
+          lenderAccount: lenderAccount(params.asset),
+        },
+      },
+      settlement: [{
+        settlementTerm: { type: 'partialSettlement', unitValue: params.price.toFixed(2) },
+        settlementInstruction: {
+          borrowerAccount: borrowerAccount(params.paymentAsset),
+          lenderAccount: lenderAccount(params.paymentAsset),
+        },
+      }],
+      loanInstruction,
+    },
+  });
+
+  const res = await unwrap(client, result, 'createLoanIntent');
+  const intentId = res?.id;
+  if (!intentId) throw new Error('Failed to create loan intent');
+  return intentId;
+}
+
 export interface RequestForTransferIntentParams {
-  assetId: string;
+  asset: Finp2pAsset;
   amount: number;
   senderId: string;
   senderFinId: string;
@@ -321,39 +393,35 @@ export async function createRequestForTransferIntent(
   client: FinP2PClient,
   params: RequestForTransferIntentParams,
 ): Promise<string> {
-  const assetOrgId = extractOrgId(params.assetId);
+  const assetOrgId = extractOrgId(params.asset.id);
   const { start, end } = intentWindow();
 
-  // The side that *initiates* the intent provides its own account.
   // `send`: sender initiates, provides senderAccount.
   // `request`: receiver initiates, provides receiverAccount.
   const assetInstruction = params.action === 'send'
     ? {
-      action: 'send',
+      action: 'send' as const,
       senderAccount: {
-        asset: { type: 'finp2p', resourceId: params.assetId },
+        asset: finp2pAsset(params.asset),
         account: finIdAccount(params.senderFinId, assetOrgId, params.custodianOrgId),
       },
     }
     : {
-      action: 'request',
+      action: 'request' as const,
       receiverAccount: {
-        asset: { type: 'finp2p', resourceId: params.assetId },
+        asset: finp2pAsset(params.asset),
         account: finIdAccount(params.receiverFinId, assetOrgId, params.custodianOrgId),
       },
     };
 
-  const result = await (client.createIntent as any)(params.assetId, {
+  const result = await client.createIntent(params.asset.id, {
     start, end,
     intent: {
       type: 'requestForTransferIntent',
       sender: params.senderId,
       receiver: params.receiverId,
       asset: {
-        assetTerm: {
-          asset: { type: 'finp2p', resourceId: params.assetId },
-          amount: String(params.amount),
-        },
+        assetTerm: { amount: String(params.amount) },
         assetInstruction,
       },
       signaturePolicy: { type: 'manualPolicy' },
@@ -371,23 +439,19 @@ export async function createRequestForTransferIntent(
 export interface ExecutePrimarySaleParams {
   intentId: string;
   executionId: string;
-  assetId: string;
+  asset: Finp2pAsset;
+  paymentAsset: Finp2pAsset;
   assetAmount: number;
-  paymentAssetCode: string;
-  paymentAssetId?: string;
   paymentAmount: number;
   paymentOrgId: string;
   buyer: { id: string; finId: string; custodianOrgId: string };
   seller: { id: string; finId: string; custodianOrgId: string };
-  buyerCryptoAddress?: string;
-  sellerCryptoAddress?: string;
 }
 
 export async function executePrimarySale(client: FinP2PClient, params: ExecutePrimarySaleParams): Promise<string> {
-  const assetOrgId = extractOrgId(params.assetId);
-  const settlement = makeSettlementAsset(params.paymentAssetCode, params.paymentAssetId);
+  const assetOrgId = extractOrgId(params.asset.id);
 
-  const result = await (client.executeIntent as any)({
+  const result = await client.executeIntent({
     user: params.seller.id,
     intentId: params.intentId,
     executionId: params.executionId,
@@ -396,20 +460,31 @@ export async function executePrimarySale(client: FinP2PClient, params: ExecutePr
       nonce: hexNonce(),
       issuer: params.seller.id,
       buyer: params.buyer.id,
+      // `issuingAsset`: source only carries asset metadata (no account — the issuer
+      // mints), destination carries the buyer's finp2p account.
       asset: {
-        term: { asset: { type: 'finp2p', resourceId: params.assetId }, amount: String(params.assetAmount) },
-        instruction: {
+        assetTerm: { amount: String(params.assetAmount) },
+        assetInstruction: {
+          sourceAccount: {
+            asset: finp2pAsset(params.asset),
+          },
           destinationAccount: {
-            asset: { type: 'finp2p', resourceId: params.assetId },
+            asset: finp2pAsset(params.asset),
             account: finIdAccount(params.buyer.finId, assetOrgId, params.buyer.custodianOrgId),
           },
         },
       },
       settlement: {
-        term: { asset: settlement, amount: String(params.paymentAmount) },
+        term: { amount: String(params.paymentAmount) },
         instruction: {
-          sourceAccount: { asset: settlement, account: settlementAccount(params.buyer.finId, params.paymentOrgId, params.buyer.custodianOrgId, params.buyerCryptoAddress) },
-          destinationAccount: { asset: settlement, account: settlementAccount(params.seller.finId, params.paymentOrgId, params.seller.custodianOrgId, params.sellerCryptoAddress) },
+          sourceAccount: {
+            asset: finp2pAsset(params.paymentAsset),
+            account: finIdAccount(params.buyer.finId, params.paymentOrgId, params.buyer.custodianOrgId),
+          },
+          destinationAccount: {
+            asset: finp2pAsset(params.paymentAsset),
+            account: finIdAccount(params.seller.finId, params.paymentOrgId, params.seller.custodianOrgId),
+          },
         },
       },
     },
@@ -424,23 +499,19 @@ export async function executePrimarySale(client: FinP2PClient, params: ExecutePr
 export interface ExecuteSellingIntentParams {
   intentId: string;
   executionId: string;
-  assetId: string;
+  asset: Finp2pAsset;
+  paymentAsset: Finp2pAsset;
   assetAmount: number;
-  paymentAssetCode: string;
-  paymentAssetId?: string;
   paymentAmount: number;
   paymentOrgId: string;
   buyer: { id: string; finId: string; custodianOrgId: string };
   seller: { id: string; finId: string; custodianOrgId: string };
-  buyerCryptoAddress?: string;
-  sellerCryptoAddress?: string;
 }
 
 export async function executeSellingIntent(client: FinP2PClient, params: ExecuteSellingIntentParams): Promise<string> {
-  const assetOrgId = extractOrgId(params.assetId);
-  const settlement = makeSettlementAsset(params.paymentAssetCode, params.paymentAssetId);
+  const assetOrgId = extractOrgId(params.asset.id);
 
-  const result = await (client.executeIntent as any)({
+  const result = await client.executeIntent({
     user: params.seller.id,
     intentId: params.intentId,
     executionId: params.executionId,
@@ -449,17 +520,29 @@ export async function executeSellingIntent(client: FinP2PClient, params: Execute
       nonce: hexNonce(),
       buyer: params.buyer.id,
       asset: {
-        term: { asset: { type: 'finp2p', resourceId: params.assetId }, amount: String(params.assetAmount) },
+        term: { amount: String(params.assetAmount) },
         instruction: {
-          sourceAccount: { asset: { type: 'finp2p', resourceId: params.assetId }, account: finIdAccount(params.seller.finId, assetOrgId, params.seller.custodianOrgId) },
-          destinationAccount: { asset: { type: 'finp2p', resourceId: params.assetId }, account: finIdAccount(params.buyer.finId, assetOrgId, params.buyer.custodianOrgId) },
+          sourceAccount: {
+            asset: finp2pAsset(params.asset),
+            account: finIdAccount(params.seller.finId, assetOrgId, params.seller.custodianOrgId),
+          },
+          destinationAccount: {
+            asset: finp2pAsset(params.asset),
+            account: finIdAccount(params.buyer.finId, assetOrgId, params.buyer.custodianOrgId),
+          },
         },
       },
       settlement: {
-        term: { asset: settlement, amount: String(params.paymentAmount) },
+        term: { amount: String(params.paymentAmount) },
         instruction: {
-          sourceAccount: { asset: settlement, account: settlementAccount(params.buyer.finId, params.paymentOrgId, params.buyer.custodianOrgId, params.buyerCryptoAddress) },
-          destinationAccount: { asset: settlement, account: settlementAccount(params.seller.finId, params.paymentOrgId, params.seller.custodianOrgId, params.sellerCryptoAddress) },
+          sourceAccount: {
+            asset: finp2pAsset(params.paymentAsset),
+            account: finIdAccount(params.buyer.finId, params.paymentOrgId, params.buyer.custodianOrgId),
+          },
+          destinationAccount: {
+            asset: finp2pAsset(params.paymentAsset),
+            account: finIdAccount(params.seller.finId, params.paymentOrgId, params.seller.custodianOrgId),
+          },
         },
       },
     },
@@ -474,23 +557,19 @@ export async function executeSellingIntent(client: FinP2PClient, params: Execute
 export interface ExecuteBuyingIntentParams {
   intentId: string;
   executionId: string;
-  assetId: string;
+  asset: Finp2pAsset;
+  paymentAsset: Finp2pAsset;
   assetAmount: number;
-  paymentAssetCode: string;
-  paymentAssetId?: string;
   paymentAmount: number;
   paymentOrgId: string;
   buyer: { id: string; finId: string; custodianOrgId: string };
   seller: { id: string; finId: string; custodianOrgId: string };
-  buyerCryptoAddress?: string;
-  sellerCryptoAddress?: string;
 }
 
 export async function executeBuyingIntent(client: FinP2PClient, params: ExecuteBuyingIntentParams): Promise<string> {
-  const assetOrgId = extractOrgId(params.assetId);
-  const settlement = makeSettlementAsset(params.paymentAssetCode, params.paymentAssetId);
+  const assetOrgId = extractOrgId(params.asset.id);
 
-  const result = await (client.executeIntent as any)({
+  const result = await client.executeIntent({
     user: params.buyer.id,
     intentId: params.intentId,
     executionId: params.executionId,
@@ -499,17 +578,29 @@ export async function executeBuyingIntent(client: FinP2PClient, params: ExecuteB
       nonce: hexNonce(),
       seller: params.seller.id,
       asset: {
-        term: { asset: { type: 'finp2p', resourceId: params.assetId }, amount: String(params.assetAmount) },
+        term: { amount: String(params.assetAmount) },
         instruction: {
-          sourceAccount: { asset: { type: 'finp2p', resourceId: params.assetId }, account: finIdAccount(params.seller.finId, assetOrgId, params.seller.custodianOrgId) },
-          destinationAccount: { asset: { type: 'finp2p', resourceId: params.assetId }, account: finIdAccount(params.buyer.finId, assetOrgId, params.buyer.custodianOrgId) },
+          sourceAccount: {
+            asset: finp2pAsset(params.asset),
+            account: finIdAccount(params.seller.finId, assetOrgId, params.seller.custodianOrgId),
+          },
+          destinationAccount: {
+            asset: finp2pAsset(params.asset),
+            account: finIdAccount(params.buyer.finId, assetOrgId, params.buyer.custodianOrgId),
+          },
         },
       },
       settlement: {
-        term: { asset: settlement, amount: String(params.paymentAmount) },
+        term: { amount: String(params.paymentAmount) },
         instruction: {
-          sourceAccount: { asset: settlement, account: settlementAccount(params.buyer.finId, params.paymentOrgId, params.buyer.custodianOrgId, params.buyerCryptoAddress) },
-          destinationAccount: { asset: settlement, account: settlementAccount(params.seller.finId, params.paymentOrgId, params.seller.custodianOrgId, params.sellerCryptoAddress) },
+          sourceAccount: {
+            asset: finp2pAsset(params.paymentAsset),
+            account: finIdAccount(params.buyer.finId, params.paymentOrgId, params.buyer.custodianOrgId),
+          },
+          destinationAccount: {
+            asset: finp2pAsset(params.paymentAsset),
+            account: finIdAccount(params.seller.finId, params.paymentOrgId, params.seller.custodianOrgId),
+          },
         },
       },
     },
@@ -524,10 +615,9 @@ export async function executeBuyingIntent(client: FinP2PClient, params: ExecuteB
 export interface ExecuteRedemptionIntentParams {
   intentId: string;
   executionId: string;
-  assetId: string;
+  asset: Finp2pAsset;
+  paymentAsset: Finp2pAsset;
   assetAmount: number;
-  paymentAssetCode: string;
-  paymentAssetId?: string;
   paymentAmount: number;
   paymentOrgId: string;
   seller: { id: string; finId: string; custodianOrgId: string };
@@ -535,10 +625,9 @@ export interface ExecuteRedemptionIntentParams {
 }
 
 export async function executeRedemptionIntent(client: FinP2PClient, params: ExecuteRedemptionIntentParams): Promise<string> {
-  const assetOrgId = extractOrgId(params.assetId);
-  const settlement = makeSettlementAsset(params.paymentAssetCode, params.paymentAssetId);
+  const assetOrgId = extractOrgId(params.asset.id);
 
-  const result = await (client.executeIntent as any)({
+  const result = await client.executeIntent({
     user: params.issuer.id,
     intentId: params.intentId,
     executionId: params.executionId,
@@ -547,17 +636,31 @@ export async function executeRedemptionIntent(client: FinP2PClient, params: Exec
       nonce: hexNonce(),
       issuer: params.issuer.id,
       seller: params.seller.id,
+      // `redemptionIntentExecution.asset` requires both source (seller's holdings)
+      // and destination (optional account on issuer side, asset-only here).
       asset: {
-        term: { asset: { type: 'finp2p', resourceId: params.assetId }, amount: String(params.assetAmount) },
+        term: { amount: String(params.assetAmount) },
         instruction: {
-          sourceAccount: { asset: { type: 'finp2p', resourceId: params.assetId }, account: finIdAccount(params.seller.finId, assetOrgId, params.seller.custodianOrgId) },
+          sourceAccount: {
+            asset: finp2pAsset(params.asset),
+            account: finIdAccount(params.seller.finId, assetOrgId, params.seller.custodianOrgId),
+          },
+          destinationAccount: {
+            asset: finp2pAsset(params.asset),
+          },
         },
       },
       settlement: {
-        term: { asset: settlement, amount: String(params.paymentAmount) },
+        term: { amount: String(params.paymentAmount) },
         instruction: {
-          sourceAccount: { asset: settlement, account: finIdAccount(params.issuer.finId, params.paymentOrgId, params.issuer.custodianOrgId) },
-          destinationAccount: { asset: settlement, account: finIdAccount(params.seller.finId, params.paymentOrgId, params.seller.custodianOrgId) },
+          sourceAccount: {
+            asset: finp2pAsset(params.paymentAsset),
+            account: finIdAccount(params.issuer.finId, params.paymentOrgId, params.issuer.custodianOrgId),
+          },
+          destinationAccount: {
+            asset: finp2pAsset(params.paymentAsset),
+            account: finIdAccount(params.seller.finId, params.paymentOrgId, params.seller.custodianOrgId),
+          },
         },
       },
     },
@@ -569,10 +672,72 @@ export async function executeRedemptionIntent(client: FinP2PClient, params: Exec
   return planId;
 }
 
+export interface ExecuteLoanIntentParams {
+  intentId: string;
+  executionId: string;
+  asset: Finp2pAsset;
+  paymentAsset: Finp2pAsset;
+  assetAmount: number;
+  paymentAmount: number;
+  paymentOrgId: string;
+  executorType: 'borrower' | 'lender';
+  borrower: { id: string; finId: string; custodianOrgId: string };
+  lender: { id: string; finId: string; custodianOrgId: string };
+}
+
+export async function executeLoanIntent(client: FinP2PClient, params: ExecuteLoanIntentParams): Promise<string> {
+  const assetOrgId = extractOrgId(params.asset.id);
+  const user = params.executorType === 'borrower' ? params.borrower.id : params.lender.id;
+
+  const result = await client.executeIntent({
+    user,
+    intentId: params.intentId,
+    executionId: params.executionId,
+    intent: {
+      type: 'loanIntentExecution',
+      executorType: params.executorType,
+      nonce: hexNonce(),
+      borrower: params.borrower.id,
+      lender: params.lender.id,
+      asset: {
+        assetTerm: { amount: String(params.assetAmount) },
+        assetInstruction: {
+          borrowerAccount: {
+            asset: finp2pAsset(params.asset),
+            account: finIdAccount(params.borrower.finId, assetOrgId, params.borrower.custodianOrgId),
+          },
+          lenderAccount: {
+            asset: finp2pAsset(params.asset),
+            account: finIdAccount(params.lender.finId, assetOrgId, params.lender.custodianOrgId),
+          },
+        },
+      },
+      settlement: {
+        assetTerm: { amount: String(params.paymentAmount) },
+        assetInstruction: {
+          borrowerAccount: {
+            asset: finp2pAsset(params.paymentAsset),
+            account: finIdAccount(params.borrower.finId, params.paymentOrgId, params.borrower.custodianOrgId),
+          },
+          lenderAccount: {
+            asset: finp2pAsset(params.paymentAsset),
+            account: finIdAccount(params.lender.finId, params.paymentOrgId, params.lender.custodianOrgId),
+          },
+        },
+      },
+    },
+  });
+
+  const res = await unwrap(client, result, 'executeLoanIntent');
+  const planId = res?.executionPlanId ?? res?.response?.executionPlanId;
+  if (!planId) throw new Error('Failed to execute loan intent');
+  return planId;
+}
+
 export interface ExecuteRequestForTransferIntentParams {
   intentId: string;
   executionId: string;
-  assetId: string;
+  asset: Finp2pAsset;
   amount: number;
   sender: { id: string; finId: string; custodianOrgId: string };
   receiver: { id: string; finId: string; custodianOrgId: string };
@@ -583,14 +748,14 @@ export async function executeRequestForTransferIntent(
   client: FinP2PClient,
   params: ExecuteRequestForTransferIntentParams,
 ): Promise<string> {
-  const assetOrgId = extractOrgId(params.assetId);
+  const assetOrgId = extractOrgId(params.asset.id);
 
   // Counterparty to the action initiates execution:
   // `send`: sender initiated → receiver executes
   // `request`: receiver initiated → sender executes
   const user = params.action === 'send' ? params.receiver.id : params.sender.id;
 
-  const result = await (client.executeIntent as any)({
+  const result = await client.executeIntent({
     user,
     intentId: params.intentId,
     executionId: params.executionId,
@@ -601,17 +766,14 @@ export async function executeRequestForTransferIntent(
       sender: params.sender.id,
       receiver: params.receiver.id,
       asset: {
-        term: {
-          asset: { type: 'finp2p', resourceId: params.assetId },
-          amount: String(params.amount),
-        },
+        term: { amount: String(params.amount) },
         instruction: {
           sourceAccount: {
-            asset: { type: 'finp2p', resourceId: params.assetId },
+            asset: finp2pAsset(params.asset),
             account: finIdAccount(params.sender.finId, assetOrgId, params.sender.custodianOrgId),
           },
           destinationAccount: {
-            asset: { type: 'finp2p', resourceId: params.assetId },
+            asset: finp2pAsset(params.asset),
             account: finIdAccount(params.receiver.finId, assetOrgId, params.receiver.custodianOrgId),
           },
         },

--- a/skeleton/apis/common-external-components.yaml
+++ b/skeleton/apis/common-external-components.yaml
@@ -751,7 +751,7 @@ components:
         code:
           type: string
           description: Unique code identifying the denomination asset type
-          pattern: '^[a-zA-Z0-9]*$'
+          pattern: '^[a-zA-Z0-9][a-zA-Z0-9.\-]*$'
           maxLength: 150
           minLength: 1
     assetType:

--- a/skeleton/src/routes/model-gen.ts
+++ b/skeleton/src/routes/model-gen.ts
@@ -6,989 +6,987 @@
 /** Extracted recursive types to break circular references in generated schemas */
 export type RecursiveEIP712TypedValue = (string) | (number) | (boolean) | (string) | RecursiveEIP712TypeObject | RecursiveEIP712TypeArray;
 export type RecursiveEIP712TypeObject = {
-  [key: string]: RecursiveEIP712TypedValue;
-};
+            [key: string]: RecursiveEIP712TypedValue;
+        };
 export type RecursiveEIP712TypeArray = RecursiveEIP712TypedValue[];
 export interface paths {
-  '/plan/approve': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /**
+    "/plan/approve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
          * Approve execution plan
          * @description Expects a ledger to approve the upcoming execution plan
          */
-    post: operations['approveExecutionPlan'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/plan/proposal': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+        post: operations["approveExecutionPlan"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
+    "/plan/proposal": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
          * Approve a plan proposal plan
          * @description Request adapter approval or rejection to a proposal in an execution plan
          */
-    post: operations['executionPlanProposal'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/plan/proposal/status': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+        post: operations["executionPlanProposal"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
+    "/plan/proposal/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
          * Notify the adapter on the agreement status (Approve/Rejected) for a specific proposal
          * @description notify the adapter on proposal status
          */
-    post: operations['executionPlanProposalStatus'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/payments/depositInstruction': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+        post: operations["executionPlanProposalStatus"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
+    "/payments/depositInstruction": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
          * Deposit instruction
          * @description Create a deposit instruction for an owner
          */
-    post: operations['depositInstruction'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/payments/payout': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+        post: operations["depositInstruction"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
+    "/payments/payout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
          * Payout request
          * @description Payout owner assets to external destination
          */
-    post: operations['payout'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/assets/getBalance': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+        post: operations["payout"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
+    "/assets/getBalance": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
          * Get asset balance
          * @deprecated
          * @description Get asset balance for specified owner
          */
-    post: operations['getAssetBalance'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/assets/create': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+        post: operations["getAssetBalance"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
+    "/assets/create": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
          * Create asset
          * @description Create a new asset
          */
-    post: operations['createAsset'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/assets/issue': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+        post: operations["createAsset"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
+    "/assets/issue": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
          * Issue asset token
          * @description Issue specified amount of asset tokens for the owner
          */
-    post: operations['issueAssets'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/assets/redeem': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+        post: operations["issueAssets"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
+    "/assets/redeem": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
          * Asset Token Redeem
          * @description Redeem existing asset token for new owner. Redeem of ownership is done by eliminating existing tokens owned by the owner.
          */
-    post: operations['redeemAssets'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/assets/transfer': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+        post: operations["redeemAssets"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
+    "/assets/transfer": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
          * Asset Token Transfer
          * @description Transfer existing asset token to a new owner. Transfer of ownership is done by eliminating existing tokens owned by the sender and creating new tokens with the new owner.
          */
-    post: operations['transferAsset'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/assets/receipts/{transactionId}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+        post: operations["transferAsset"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
+    "/assets/receipts/{transactionId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
          * Get Receipt
          * @description Get asset transaction receipt
          */
-    get: operations['getReceipt'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/assets/hold': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+        get: operations["getReceipt"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
+    "/assets/hold": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
          * Hold Asset
          * @description Hold the owner asset
          */
-    post: operations['holdOperation'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/assets/release': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+        post: operations["holdOperation"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
+    "/assets/release": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
          * Release Asset
          * @description Release held assets
          */
-    post: operations['releaseOperation'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/assets/rollback': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+        post: operations["releaseOperation"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
+    "/assets/rollback": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
          * Rollback held asset
          * @description Release back held asset to the owner
          */
-    post: operations['rollbackOperation'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/operations/status/{cid}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+        post: operations["rollbackOperation"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
+    "/operations/status/{cid}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
          * Get Operation Status
          * @description Get the operation status by an operation correlation id
          */
-    get: operations['getOperation'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/asset/balance': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+        get: operations["getOperation"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
+    "/asset/balance": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
          * Get asset balance information
          * @description Get asset balance information for finId
          */
-    post: operations['GetAssetBalanceInfo'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/health': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+        post: operations["GetAssetBalanceInfo"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
+    "/health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
          * Health check
          * @description Returns the health status of the service.
          */
-    get: operations['getHealth'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
+        get: operations["getHealth"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-  schemas: {
-    DepositInstructionRequest: {
-      destination: components['schemas']['depositPayoutAccount'];
-      owner: components['schemas']['depositPayoutAccount'];
-      asset: components['schemas']['depositAsset'];
-      /** @description Amount to deposit */
-      amount?: string;
-      details?: Record<string, never>;
-      nonce?: components['schemas']['nonce'];
-      signature?: components['schemas']['signature'];
-    };
-    DepositInstructionResponse: components['schemas']['depositOperation'];
-    PayoutRequest: {
-      source: components['schemas']['depositPayoutAccount'];
-      destination?: components['schemas']['depositPayoutAccount'];
-      /** @description How many units of the asset */
-      quantity: string;
-      payoutInstruction?: components['schemas']['payoutInstruction'];
-      asset: components['schemas']['finp2pAsset'];
-      nonce?: components['schemas']['nonce'];
-      signature?: components['schemas']['signature'];
-    };
-    PayoutResponse: components['schemas']['receiptOperation'];
-    GetAssetBalanceRequest: {
-      owner: components['schemas']['account'];
-    };
-    GetAssetBalanceResponse: components['schemas']['balance'];
-    CreateAssetRequest: {
-      /** @description The asset metadata */
-      metadata?: {
-        [key: string]: unknown;
-      };
-      asset: components['schemas']['finp2pAssetBase'];
-      ledgerAssetBinding?: components['schemas']['ledgerAssetIdentifier'];
-      name?: components['schemas']['assetName'];
-      issuerId?: components['schemas']['ownerResourceId'];
-      denomination?: components['schemas']['assetDenomination'];
-    };
-    CreateAssetResponse: components['schemas']['OperationBase'] & {
-      error?: components['schemas']['createAssetOperationErrorInformation'];
-      response?: components['schemas']['assetCreateResponse'];
-    };
-    IssueAssetsRequest: {
-      nonce: components['schemas']['nonce'];
-      destination: components['schemas']['account'];
-      /** @description How many units of the asset tokens */
-      quantity: string;
-      /** @description Reference to the corresponding settlement operation */
-      settlementRef: string;
-      signature: components['schemas']['signature'];
-      executionContext?: components['schemas']['executionContext'];
-    };
-    IssueAssetsResponse: components['schemas']['receiptOperation'];
-    RedeemAssetsRequest: {
-      nonce: components['schemas']['nonce'];
-      operationId?: string;
-      source: components['schemas']['account'];
-      /** @description How many units of the asset tokens */
-      quantity: string;
-      /** @description Reference to the corresponding payment operation */
-      settlementRef: string;
-      signature: components['schemas']['signature'];
-      executionContext?: components['schemas']['executionContext'];
-    };
-    RedeemAssetsResponse: components['schemas']['receiptOperation'];
-    TransferAssetRequest: {
-      nonce: components['schemas']['nonce'];
-      source: components['schemas']['account'];
-      destination: components['schemas']['account'];
-      /** @description How many units of the asset tokens */
-      quantity: string;
-      /** @description Reference to the corresponding payment operation */
-      settlementRef: string;
-      signature: components['schemas']['signature'];
-      executionContext?: components['schemas']['executionContext'];
-    };
-    TransferAssetResponse: components['schemas']['receiptOperation'];
-    GetReceiptResponse: components['schemas']['receiptOperation'];
-    HoldOperationRequest: {
-      nonce: components['schemas']['nonce'];
-      /** @description A unique operation ID assigned to the hold request, used to track and reference the asset for future release or rollback actions */
-      operationId: string;
-      source: components['schemas']['account'];
-      destination?: components['schemas']['account'];
-      /** @description How many units of the asset tokens */
-      quantity: string;
-      /**
+    schemas: {
+        DepositInstructionRequest: {
+            destination: components["schemas"]["depositPayoutAccount"];
+            owner: components["schemas"]["depositPayoutAccount"];
+            asset: components["schemas"]["depositAsset"];
+            /** @description Amount to deposit */
+            amount?: string;
+            details?: Record<string, never>;
+            nonce?: components["schemas"]["nonce"];
+            signature?: components["schemas"]["signature"];
+        };
+        DepositInstructionResponse: components["schemas"]["depositOperation"];
+        PayoutRequest: {
+            source: components["schemas"]["depositPayoutAccount"];
+            destination?: components["schemas"]["depositPayoutAccount"];
+            /** @description How many units of the asset */
+            quantity: string;
+            payoutInstruction?: components["schemas"]["payoutInstruction"];
+            asset: components["schemas"]["finp2pAsset"];
+            nonce?: components["schemas"]["nonce"];
+            signature?: components["schemas"]["signature"];
+        };
+        PayoutResponse: components["schemas"]["receiptOperation"];
+        GetAssetBalanceRequest: {
+            owner: components["schemas"]["account"];
+        };
+        GetAssetBalanceResponse: components["schemas"]["balance"];
+        CreateAssetRequest: {
+            /** @description The asset metadata */
+            metadata?: {
+                [key: string]: unknown;
+            };
+            asset: components["schemas"]["finp2pAssetBase"];
+            ledgerAssetBinding?: components["schemas"]["ledgerAssetIdentifier"];
+            name?: components["schemas"]["assetName"];
+            issuerId?: components["schemas"]["ownerResourceId"];
+            denomination?: components["schemas"]["assetDenomination"];
+        };
+        CreateAssetResponse: components["schemas"]["OperationBase"] & {
+            error?: components["schemas"]["createAssetOperationErrorInformation"];
+            response?: components["schemas"]["assetCreateResponse"];
+        };
+        IssueAssetsRequest: {
+            nonce: components["schemas"]["nonce"];
+            destination: components["schemas"]["account"];
+            /** @description How many units of the asset tokens */
+            quantity: string;
+            /** @description Reference to the corresponding settlement operation */
+            settlementRef: string;
+            signature: components["schemas"]["signature"];
+            executionContext?: components["schemas"]["executionContext"];
+        };
+        IssueAssetsResponse: components["schemas"]["receiptOperation"];
+        RedeemAssetsRequest: {
+            nonce: components["schemas"]["nonce"];
+            operationId?: string;
+            source: components["schemas"]["account"];
+            /** @description How many units of the asset tokens */
+            quantity: string;
+            /** @description Reference to the corresponding payment operation */
+            settlementRef: string;
+            signature: components["schemas"]["signature"];
+            executionContext?: components["schemas"]["executionContext"];
+        };
+        RedeemAssetsResponse: components["schemas"]["receiptOperation"];
+        TransferAssetRequest: {
+            nonce: components["schemas"]["nonce"];
+            source: components["schemas"]["account"];
+            destination: components["schemas"]["account"];
+            /** @description How many units of the asset tokens */
+            quantity: string;
+            /** @description Reference to the corresponding payment operation */
+            settlementRef: string;
+            signature: components["schemas"]["signature"];
+            executionContext?: components["schemas"]["executionContext"];
+        };
+        TransferAssetResponse: components["schemas"]["receiptOperation"];
+        GetReceiptResponse: components["schemas"]["receiptOperation"];
+        HoldOperationRequest: {
+            nonce: components["schemas"]["nonce"];
+            /** @description A unique operation ID assigned to the hold request, used to track and reference the asset for future release or rollback actions */
+            operationId: string;
+            source: components["schemas"]["account"];
+            destination?: components["schemas"]["account"];
+            /** @description How many units of the asset tokens */
+            quantity: string;
+            /**
              * Format: uint64
              * @description ttl expiry value indicating the escrow hold time limitation
              */
-      expiry: number;
-      signature: components['schemas']['signature'];
-      executionContext?: components['schemas']['executionContext'];
-    };
-    HoldOperationResponse: components['schemas']['receiptOperation'];
-    ReleaseOperationRequest: {
-      /** @description The operation ID from the hold request, required to authorize the asset release */
-      operationId: string;
-      source: components['schemas']['account'];
-      destination: components['schemas']['account'];
-      /** @description How many units of the asset tokens */
-      quantity: string;
-      executionContext?: components['schemas']['executionContext'];
-    };
-    ReleaseOperationResponse: components['schemas']['receiptOperation'];
-    RollbackOperationRequest: {
-      /** @description The operation ID from the hold request, required to revert the asset hold */
-      operationId: string;
-      source: components['schemas']['account'];
-      /** @description How many units of the asset tokens */
-      quantity: string;
-      executionContext?: components['schemas']['executionContext'];
-    };
-    RollbackOperationResponse: components['schemas']['receiptOperation'];
-    GetOperationStatusRequest: {
-      /** @description correlation id of an operation */
-      cid?: string;
-    };
-    GetOperationStatusResponse: components['schemas']['operationStatus'];
-    depositInstruction: {
-      account: components['schemas']['depositPayoutAccount'];
-      asset?: components['schemas']['depositAsset'];
-      /** @description Instructions for the deposit operation */
-      description?: string;
-      paymentOptions?: components['schemas']['paymentMethods'];
-      /**
+            expiry: number;
+            signature: components["schemas"]["signature"];
+            executionContext?: components["schemas"]["executionContext"];
+        };
+        HoldOperationResponse: components["schemas"]["receiptOperation"];
+        ReleaseOperationRequest: {
+            /** @description The operation ID from the hold request, required to authorize the asset release */
+            operationId: string;
+            source: components["schemas"]["account"];
+            destination: components["schemas"]["account"];
+            /** @description How many units of the asset tokens */
+            quantity: string;
+            executionContext?: components["schemas"]["executionContext"];
+        };
+        ReleaseOperationResponse: components["schemas"]["receiptOperation"];
+        RollbackOperationRequest: {
+            /** @description The operation ID from the hold request, required to revert the asset hold */
+            operationId: string;
+            source: components["schemas"]["account"];
+            /** @description How many units of the asset tokens */
+            quantity: string;
+            executionContext?: components["schemas"]["executionContext"];
+        };
+        RollbackOperationResponse: components["schemas"]["receiptOperation"];
+        GetOperationStatusRequest: {
+            /** @description correlation id of an operation */
+            cid?: string;
+        };
+        GetOperationStatusResponse: components["schemas"]["operationStatus"];
+        depositInstruction: {
+            account: components["schemas"]["depositPayoutAccount"];
+            asset?: components["schemas"]["depositAsset"];
+            /** @description Instructions for the deposit operation */
+            description?: string;
+            paymentOptions?: components["schemas"]["paymentMethods"];
+            /**
              * @deprecated
              * @description Any addition deposit specific information, deprecated use "payment method options" instead fields
              */
-      details?: Record<string, never>;
-      /** @description operation id reference while will correlate with any receipt associated with the deposit operation */
-      operationId?: string;
-    };
-    asset: {
-      ledgerIdentifier: components['schemas']['ledgerAssetIdentifier'];
-    } & components['schemas']['finp2pAssetBase'];
-    payoutAsset: components['schemas']['finp2pAsset'];
-    payoutInstruction: {
-      /** @description withdrawal description */
-      description: string;
-    };
-    account: {
-      asset: components['schemas']['asset'];
-      finId: components['schemas']['finId'];
-      ledgerAccount?: components['schemas']['walletAccount'];
-    };
-    walletLedgerAccount: components['schemas']['walletAccount'];
-    depositPayoutAccount: {
-      finId: components['schemas']['finId'];
-      account: components['schemas']['finIdAccountBase'];
-    };
-    finIdAccountBase: {
-      /**
+            details?: Record<string, never>;
+            /** @description operation id reference while will correlate with any receipt associated with the deposit operation */
+            operationId?: string;
+        };
+        asset: {
+            ledgerIdentifier: components["schemas"]["ledgerAssetIdentifier"];
+        } & components["schemas"]["finp2pAssetBase"];
+        payoutAsset: components["schemas"]["finp2pAsset"];
+        payoutInstruction: {
+            /** @description withdrawal description */
+            description: string;
+        };
+        account: {
+            asset: components["schemas"]["asset"];
+            finId: components["schemas"]["finId"];
+            ledgerAccount?: components["schemas"]["walletAccount"];
+        };
+        walletLedgerAccount: components["schemas"]["walletAccount"];
+        depositPayoutAccount: {
+            finId: components["schemas"]["finId"];
+            account: components["schemas"]["finIdAccountBase"];
+        };
+        finIdAccountBase: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      type: 'finId';
-      finId: components['schemas']['finId'];
-    };
-    balance: {
-      asset: components['schemas']['asset'];
-      /** @description the number of asset tokens */
-      balance: string;
-    };
-    receiptOperation: components['schemas']['OperationBase'] & {
-      error?: components['schemas']['receiptOperationErrorInformation'];
-      response?: components['schemas']['receipt'];
-    };
-    createAssetOperation: components['schemas']['OperationBase'] & {
-      error?: components['schemas']['createAssetOperationErrorInformation'];
-      response?: components['schemas']['assetCreateResponse'];
-    };
-    assetCreateResponse: {
-      ledgerAssetInfo: components['schemas']['ledgerAssetInfo'];
-    };
-    depositOperation: components['schemas']['OperationBase'] & {
-      error?: components['schemas']['depositOperationErrorInformation'];
-      response?: components['schemas']['depositInstruction'];
-    };
-    depositOperationErrorInformation: Record<string, never>;
-    createAssetOperationErrorInformation: {
-      /** Format: uint32 */
-      code?: number;
-      message?: string;
-    };
-    receiptOperationErrorInformation: {
-      /**
+            type: "finId";
+            finId: components["schemas"]["finId"];
+        };
+        balance: {
+            asset: components["schemas"]["asset"];
+            /** @description the number of asset tokens */
+            balance: string;
+        };
+        receiptOperation: components["schemas"]["OperationBase"] & {
+            error?: components["schemas"]["receiptOperationErrorInformation"];
+            response?: components["schemas"]["receipt"];
+        };
+        createAssetOperation: components["schemas"]["OperationBase"] & {
+            error?: components["schemas"]["createAssetOperationErrorInformation"];
+            response?: components["schemas"]["assetCreateResponse"];
+        };
+        assetCreateResponse: {
+            ledgerAssetInfo: components["schemas"]["ledgerAssetInfo"];
+        };
+        depositOperation: components["schemas"]["OperationBase"] & {
+            error?: components["schemas"]["depositOperationErrorInformation"];
+            response?: components["schemas"]["depositInstruction"];
+        };
+        depositOperationErrorInformation: Record<string, never>;
+        createAssetOperationErrorInformation: {
+            /** Format: uint32 */
+            code?: number;
+            message?: string;
+        };
+        receiptOperationErrorInformation: {
+            /**
              * Format: uint32
              * @description 1 for failure in regApps validation, 4 failure in signature verification
              */
-      code: number;
-      message: string;
-      regulationErrorDetails?: components['schemas']['RegulationError'][];
-    };
-    executionOperationErrorInformation: Record<string, never>;
-    executionContext: {
-      /** @description execution plan id */
-      executionPlanId: string;
-      /**
+            code: number;
+            message: string;
+            regulationErrorDetails?: components["schemas"]["RegulationError"][];
+        };
+        executionOperationErrorInformation: Record<string, never>;
+        executionContext: {
+            /** @description execution plan id */
+            executionPlanId: string;
+            /**
              * Format: uint32
              * @description execution instruction sequence number
              */
-      instructionSequenceNumber: number;
-    };
-    operationStatus: components['schemas']['operationStatusCreateAsset'] | components['schemas']['operationStatusDeposit'] | components['schemas']['operationStatusReceipt'] | components['schemas']['operationStatusApproval'];
-    operationStatusCreateAsset: {
-      /**
+            instructionSequenceNumber: number;
+        };
+        operationStatus: components["schemas"]["operationStatusCreateAsset"] | components["schemas"]["operationStatusDeposit"] | components["schemas"]["operationStatusReceipt"] | components["schemas"]["operationStatusApproval"];
+        operationStatusCreateAsset: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      type: 'createAsset';
-      operation: components['schemas']['createAssetOperation'];
-    };
-    operationStatusDeposit: {
-      /**
+            type: "createAsset";
+            operation: components["schemas"]["createAssetOperation"];
+        };
+        operationStatusDeposit: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      type: 'deposit';
-      operation: components['schemas']['depositOperation'];
-    };
-    operationStatusReceipt: {
-      /**
+            type: "deposit";
+            operation: components["schemas"]["depositOperation"];
+        };
+        operationStatusReceipt: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      type: 'receipt';
-      operation: components['schemas']['receiptOperation'];
-    };
-    operationStatusApproval: {
-      /**
+            type: "receipt";
+            operation: components["schemas"]["receiptOperation"];
+        };
+        operationStatusApproval: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      type: 'approval';
-      operation: components['schemas']['ExecutionPlanApprovalOperation'];
-    };
-    /** @description represent a signature template information */
-    signature: {
-      /** @description hex representation of the signature */
-      signature: string;
-      template: components['schemas']['signatureTemplate'];
-      hashFunc: components['schemas']['hashFunction'];
-    };
-    signatureTemplate: components['schemas']['hashListTemplate'] | components['schemas']['EIP712Template'];
-    /** @description ordered list of hash groups */
-    hashListTemplate: {
-      /**
+            type: "approval";
+            operation: components["schemas"]["ExecutionPlanApprovalOperation"];
+        };
+        /** @description represent a signature template information */
+        signature: {
+            /** @description hex representation of the signature */
+            signature: string;
+            template: components["schemas"]["signatureTemplate"];
+            hashFunc: components["schemas"]["hashFunction"];
+        };
+        signatureTemplate: components["schemas"]["hashListTemplate"] | components["schemas"]["EIP712Template"];
+        /** @description ordered list of hash groups */
+        hashListTemplate: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      type: 'hashList';
-      hashGroups: components['schemas']['hashGroup'][];
-      /** @description hex representation of the combined hash groups hash value */
-      hash: string;
-    };
-    hashGroup: {
-      /** @description hex representation of the hash group hash value */
-      hash: string;
-      /** @description list of fields by order they appear in the hash group */
-      fields: components['schemas']['field'][];
-    };
-    /** @description describing a field in the hash group */
-    field: {
-      /** @description name of field */
-      name: string;
-      /**
+            type: "hashList";
+            hashGroups: components["schemas"]["hashGroup"][];
+            /** @description hex representation of the combined hash groups hash value */
+            hash: string;
+        };
+        hashGroup: {
+            /** @description hex representation of the hash group hash value */
+            hash: string;
+            /** @description list of fields by order they appear in the hash group */
+            fields: components["schemas"]["field"][];
+        };
+        /** @description describing a field in the hash group */
+        field: {
+            /** @description name of field */
+            name: string;
+            /**
              * @description type of field
              * @enum {string}
              */
-      type: 'string' | 'int' | 'bytes';
-      /** @description hex representation of the field value */
-      value: string;
-    };
-    EIP712Domain: {
-      name?: string;
-      version?: string;
-      /** Format: uint64 */
-      chainId?: number;
-      /** Format: address */
-      verifyingContract?: string;
-    };
-    EIP712TypedValue: RecursiveEIP712TypedValue;
-    EIP712Types: {
-      definitions?: components['schemas']['EIP712TypeDefinition'][];
-    };
-    EIP712TypeDefinition: {
-      name?: string;
-      fields?: components['schemas']['EIP712FieldDefinition'][];
-    };
-    EIP712FieldDefinition: {
-      name?: string;
-      type?: string;
-    };
-    EIP712Template: {
-      /**
+            type: "string" | "int" | "bytes";
+            /** @description hex representation of the field value */
+            value: string;
+        };
+        EIP712Domain: {
+            name?: string;
+            version?: string;
+            /** Format: uint64 */
+            chainId?: number;
+            /** Format: address */
+            verifyingContract?: string;
+        };
+        EIP712TypedValue: RecursiveEIP712TypedValue;
+        EIP712Types: {
+            definitions?: components["schemas"]["EIP712TypeDefinition"][];
+        };
+        EIP712TypeDefinition: {
+            name?: string;
+            fields?: components["schemas"]["EIP712FieldDefinition"][];
+        };
+        EIP712FieldDefinition: {
+            name?: string;
+            type?: string;
+        };
+        EIP712Template: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      type: 'EIP712';
-      domain: components['schemas']['EIP712Domain'];
-      message: {
-        [key: string]: components['schemas']['EIP712TypedValue'];
-      };
-      types: components['schemas']['EIP712Types'];
-      primaryType: string;
-      /** @description hex representation of template hash */
-      hash: string;
-    };
-    EIP712TypeString: string;
-    EIP712TypeByte: string;
-    EIP712TypeInteger: number;
-    EIP712TypeBool: boolean;
-    EIP712TypeObject: RecursiveEIP712TypeObject;
-    EIP712TypeArray: RecursiveEIP712TypeArray;
-    /**
+            type: "EIP712";
+            domain: components["schemas"]["EIP712Domain"];
+            message: {
+                [key: string]: components["schemas"]["EIP712TypedValue"];
+            };
+            types: components["schemas"]["EIP712Types"];
+            primaryType: string;
+            /** @description hex representation of template hash */
+            hash: string;
+        };
+        EIP712TypeString: string;
+        EIP712TypeByte: string;
+        EIP712TypeInteger: number;
+        EIP712TypeBool: boolean;
+        EIP712TypeObject: RecursiveEIP712TypeObject;
+        EIP712TypeArray: RecursiveEIP712TypeArray;
+        /**
          * @description hash function types
          * @enum {string}
          */
-    hashFunction: 'unspecified' | 'sha3_256' | 'sha3-256' | 'blake2b' | 'keccak_256' | 'keccak-256';
-    receipt: {
-      /** @description the receipt id */
-      id: string;
-      /** @description How many units of the asset tokens */
-      quantity: string;
-      /**
+        hashFunction: "unspecified" | "sha3_256" | "sha3-256" | "blake2b" | "keccak_256" | "keccak-256";
+        receipt: {
+            /** @description the receipt id */
+            id: string;
+            /** @description How many units of the asset tokens */
+            quantity: string;
+            /**
              * Format: int64
              * @description transaction timestamp
              */
-      timestamp: number;
-      source?: components['schemas']['account'];
-      destination?: components['schemas']['account'];
-      transactionDetails?: components['schemas']['transactionDetails'];
-      operationType?: components['schemas']['operationType'];
-      tradeDetails: components['schemas']['receiptTradeDetails'];
-      proof?: components['schemas']['proofPolicy'];
-    };
-    /** @description additional proof information attached to a receipt */
-    proofPolicy: components['schemas']['signatureProofPolicy'] | components['schemas']['noProofPolicy'];
-    /** @description no proof validation required for this policy */
-    noProofPolicy: {
-      /**
+            timestamp: number;
+            source?: components["schemas"]["account"];
+            destination?: components["schemas"]["account"];
+            transactionDetails?: components["schemas"]["transactionDetails"];
+            operationType?: components["schemas"]["operationType"];
+            tradeDetails: components["schemas"]["receiptTradeDetails"];
+            proof?: components["schemas"]["proofPolicy"];
+        };
+        /** @description additional proof information attached to a receipt */
+        proofPolicy: components["schemas"]["signatureProofPolicy"] | components["schemas"]["noProofPolicy"];
+        /** @description no proof validation required for this policy */
+        noProofPolicy: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      type: 'noProofPolicy';
-    };
-    signatureProofPolicy: {
-      /**
+            type: "noProofPolicy";
+        };
+        signatureProofPolicy: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      type: 'signatureProofPolicy';
-      signature?: components['schemas']['signature'];
-    };
-    /** @description additional ledger specific */
-    transactionDetails: {
-      /** @description The Transaction id on the underlying ledger */
-      transactionId: string;
-      /** @description The Operation id */
-      operationId?: string;
-    };
-    /** @enum {string} */
-    operationType: 'issue' | 'transfer' | 'hold' | 'release' | 'redeem';
-    ledgerAssetInfo: {
-      ledgerIdentifier: components['schemas']['ledgerAssetIdentifier'];
-      ledgerReference?: components['schemas']['contractDetails'];
-    };
-    contractDetails: {
-      /**
+            type: "signatureProofPolicy";
+            signature?: components["schemas"]["signature"];
+        };
+        /** @description additional ledger specific */
+        transactionDetails: {
+            /** @description The Transaction id on the underlying ledger */
+            transactionId: string;
+            /** @description The Operation id */
+            operationId?: string;
+        };
+        /** @enum {string} */
+        operationType: "issue" | "transfer" | "hold" | "release" | "redeem";
+        ledgerAssetInfo: {
+            ledgerIdentifier: components["schemas"]["ledgerAssetIdentifier"];
+            ledgerReference?: components["schemas"]["contractDetails"];
+        };
+        contractDetails: {
+            /**
              * @description the type of the identifier (enum property replaced by openapi-typescript)
              * @enum {string}
              */
-      type: 'contractDetails';
-      /** @description the address */
-      address: string;
-      /** @description The standard of the token (e.g., ERC20, ERC721) */
-      TokenStandard?: string;
-      additionalContractDetails?: components['schemas']['finP2PEVMOperatorDetails'];
-    };
-    finP2PEVMOperatorDetails: {
-      /** @description The FinP2P Operator Contract Address */
-      FinP2POperatorContractAddress?: string;
-      /** @description Indicates if allowance is required */
-      allowanceRequired?: boolean;
-    };
-    ledgerAssetBinding: components['schemas']['ledgerAssetIdentifier'];
-    AssetBalanceInfoRequest: {
-      account: components['schemas']['assetBalanceAccount'];
-      asset: components['schemas']['asset'];
-      marker?: components['schemas']['balanceMarker'];
-    };
-    assetBalanceAccount: components['schemas']['finIdAccountBase'];
-    /** @description marker of balance to denote the balance as of marker */
-    balanceMarker: components['schemas']['balanceMarkerTimestamp'] | components['schemas']['balanceMarkerTransactionBlock'];
-    balanceMarkerTimestamp: {
-      /**
+            type: "contractDetails";
+            /** @description the address */
+            address: string;
+            /** @description The standard of the token (e.g., ERC20, ERC721) */
+            TokenStandard?: string;
+            additionalContractDetails?: components["schemas"]["finP2PEVMOperatorDetails"];
+        };
+        finP2PEVMOperatorDetails: {
+            /** @description The FinP2P Operator Contract Address */
+            FinP2POperatorContractAddress?: string;
+            /** @description Indicates if allowance is required */
+            allowanceRequired?: boolean;
+        };
+        ledgerAssetBinding: components["schemas"]["ledgerAssetIdentifier"];
+        AssetBalanceInfoRequest: {
+            account: components["schemas"]["assetBalanceAccount"];
+            asset: components["schemas"]["asset"];
+            marker?: components["schemas"]["balanceMarker"];
+        };
+        assetBalanceAccount: components["schemas"]["finIdAccountBase"];
+        /** @description marker of balance to denote the balance as of marker */
+        balanceMarker: components["schemas"]["balanceMarkerTimestamp"] | components["schemas"]["balanceMarkerTransactionBlock"];
+        balanceMarkerTimestamp: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      type: 'timestamp';
-      /**
+            type: "timestamp";
+            /**
              * Format: int64
              * @description epoch timestamp in seconds
              */
-      timestamp: number;
-    };
-    balanceMarkerTransactionBlock: {
-      /**
+            timestamp: number;
+        };
+        balanceMarkerTransactionBlock: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      type: 'transactionBlock';
-      /** Format: int64 */
-      blockNumber: number;
-      transaction: string;
-    };
-    AssetBalanceInfoResponse: {
-      account: components['schemas']['assetBalanceAccount'];
-      asset: components['schemas']['asset'];
-      balanceInfo?: components['schemas']['assetBalance'];
-    };
-    assetBalance: {
-      asset: components['schemas']['asset'];
-      /**
+            type: "transactionBlock";
+            /** Format: int64 */
+            blockNumber: number;
+            transaction: string;
+        };
+        AssetBalanceInfoResponse: {
+            account: components["schemas"]["assetBalanceAccount"];
+            asset: components["schemas"]["asset"];
+            balanceInfo?: components["schemas"]["assetBalance"];
+        };
+        assetBalance: {
+            asset: components["schemas"]["asset"];
+            /**
              * Format: ^-?\d+(\.\d+)?$
              * @description The total amount currently in or owed by the account
              */
-      current: string;
-      /**
+            current: string;
+            /**
              * Format: ^-?\d+(\.\d+)?$
              * @description The amount immediately usable from the account
              */
-      available: string;
-      /**
+            available: string;
+            /**
              * Format: ^-?\d+(\.\d+)?$
              * @description The amount pending or on hold within the account
              */
-      held: string;
-      /** @description list of receipt associated with the balance info */
-      receipts?: components['schemas']['receipt'][];
-    };
-    ApproveExecutionPlanRequest: {
-      /** @description execution plan information */
-      executionPlan: {
-        /** @description execution plan id */
-        id: string;
-      };
-    };
-    pollingResultsStrategy: {
-      /**
+            held: string;
+            /** @description list of receipt associated with the balance info */
+            receipts?: components["schemas"]["receipt"][];
+        };
+        ApproveExecutionPlanRequest: {
+            /** @description execution plan information */
+            executionPlan: {
+                /** @description execution plan id */
+                id: string;
+            };
+        };
+        pollingResultsStrategy: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      type: 'random';
-      polling: components['schemas']['randomPollingInterval'] | components['schemas']['absolutePollingInterval'] | components['schemas']['relativePollingInterval'];
-    };
-    absolutePollingInterval: {
-      /**
+            type: "random";
+            polling: components["schemas"]["randomPollingInterval"] | components["schemas"]["absolutePollingInterval"] | components["schemas"]["relativePollingInterval"];
+        };
+        absolutePollingInterval: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      type: 'absolute';
-      /** @description absolute time as epoch time seconds */
-      time: number;
-    };
-    relativePollingInterval: {
-      /**
+            type: "absolute";
+            /** @description absolute time as epoch time seconds */
+            time: number;
+        };
+        relativePollingInterval: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      type: 'relative';
-      /**
+            type: "relative";
+            /**
              * @description ISO-8601 duration format
              * @example PT5M (5Min duration), P1DT30M (1 Day and 30 Minutes )
              */
-      duration: string;
-    };
-    randomPollingInterval: {
-      /**
+            duration: string;
+        };
+        randomPollingInterval: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      type: 'randomPollingInterval';
-    };
-    callbackEndpoint: {
-      /**
+            type: "randomPollingInterval";
+        };
+        callbackEndpoint: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      type: 'endpoint';
-    };
-    callbackResultsStrategy: {
-      /**
+            type: "endpoint";
+        };
+        callbackResultsStrategy: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      type: 'callback';
-      callback: components['schemas']['callbackEndpoint'];
-    };
-    /** @description additional metadata regarding the operation */
-    OperationMetadata: {
-      /**
-             * @description denote the expected response strategy of the operation, i.e. how would completion and results of the operation should be handled
+            type: "callback";
+            callback: components["schemas"]["callbackEndpoint"];
+        };
+        /** @description additional metadata regarding the operation */
+        OperationMetadata: {
+            /** @description denote the expected response strategy of the operation, i.e. how would completion and results of the operation should be handled
              *     optional, if not provided [polling strategy](#/components/schema/pollingResultsStrategy) will be use with [random interval](#/components/schema/randomPollingInterval)
-             */
-      operationResponseStrategy?: components['schemas']['pollingResultsStrategy'] | components['schemas']['callbackResultsStrategy'];
-    };
-    OperationBase: {
-      /** @description unique correlation id which identify the operation */
-      cid: string;
-      /**
+             *      */
+            operationResponseStrategy?: components["schemas"]["pollingResultsStrategy"] | components["schemas"]["callbackResultsStrategy"];
+        };
+        OperationBase: {
+            /** @description unique correlation id which identify the operation */
+            cid: string;
+            /**
              * @description flag indicating if the operation completed, if true then error or response must be present (but not both)
              * @default false
              */
-      isCompleted: boolean;
-      operationMetadata?: components['schemas']['OperationMetadata'];
-    };
-    PlanApproved: {
-      /**
+            isCompleted: boolean;
+            operationMetadata?: components["schemas"]["OperationMetadata"];
+        };
+        PlanApproved: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      status: 'approved';
-    };
-    ValidationFailure: {
-      /**
+            status: "approved";
+        };
+        ValidationFailure: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      failureType: 'validationFailure';
-      /**
+            failureType: "validationFailure";
+            /**
              * Format: uint32
              * @description ledger error code for validation
              */
-      code: number;
-      message: string;
-    };
-    RegulationError: {
-      /** @description the type of regulation */
-      regulationType: string;
-      /** @description actionable details of the error */
-      details: string;
-    };
-    RegulationFailure: {
-      /**
+            code: number;
+            message: string;
+        };
+        RegulationError: {
+            /** @description the type of regulation */
+            regulationType: string;
+            /** @description actionable details of the error */
+            details: string;
+        };
+        RegulationFailure: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      failureType: 'regulationFailure';
-      errors: components['schemas']['RegulationError'][];
-    };
-    PlanRejected: {
-      /**
+            failureType: "regulationFailure";
+            errors: components["schemas"]["RegulationError"][];
+        };
+        PlanRejected: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      status: 'rejected';
-      failure?: components['schemas']['ValidationFailure'] | components['schemas']['RegulationFailure'];
-    };
-    PlanApprovalResponse: {
-      approval?: components['schemas']['PlanApproved'] | components['schemas']['PlanRejected'];
-    };
-    ExecutionPlanApprovalOperation: components['schemas']['OperationBase'] & components['schemas']['PlanApprovalResponse'];
-    ApproveExecutionPlanResponse: components['schemas']['ExecutionPlanApprovalOperation'];
-    executionPlanCancellationProposal: {
-      /**
+            status: "rejected";
+            failure?: components["schemas"]["ValidationFailure"] | components["schemas"]["RegulationFailure"];
+        };
+        PlanApprovalResponse: {
+            approval?: components["schemas"]["PlanApproved"] | components["schemas"]["PlanRejected"];
+        };
+        ExecutionPlanApprovalOperation: components["schemas"]["OperationBase"] & components["schemas"]["PlanApprovalResponse"];
+        ApproveExecutionPlanResponse: components["schemas"]["ExecutionPlanApprovalOperation"];
+        executionPlanCancellationProposal: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      proposalType: 'cancel';
-    };
-    executionPlanResetProposal: {
-      /**
+            proposalType: "cancel";
+        };
+        executionPlanResetProposal: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      proposalType: 'reset';
-      /**
+            proposalType: "reset";
+            /**
              * Format: uint32
              * @description sequence number of the instruction to reset and retry in the execution plan
              */
-      proposedSequence: number;
-    };
-    executionPlanInstructionProposal: {
-      /**
+            proposedSequence: number;
+        };
+        executionPlanInstructionProposal: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      proposalType: 'instruction';
-      /**
+            proposalType: "instruction";
+            /**
              * Format: uint32
              * @description sequence number of the instruction completion event
              */
-      instructionSequence: number;
-    };
-    executionPlanProposalRequest: {
-      /** @description execution plan information */
-      executionPlan: {
-        /** @description execution plan id */
-        id: string;
-        /** @description type of proposal payload */
-        proposal: components['schemas']['executionPlanCancellationProposal'] | components['schemas']['executionPlanInstructionProposal'] | components['schemas']['executionPlanResetProposal'];
-      };
-    };
-    /** @description provides status update on the agreement reached for a specific proposal */
-    executionPlanProposalStatusRequest: {
-      /** @enum {string} */
-      status: 'approved' | 'rejected';
-      request: components['schemas']['executionPlanProposalRequest'];
-    };
-    /**
+            instructionSequence: number;
+        };
+        executionPlanProposalRequest: {
+            /** @description execution plan information */
+            executionPlan: {
+                /** @description execution plan id */
+                id: string;
+                /** @description type of proposal payload */
+                proposal: components["schemas"]["executionPlanCancellationProposal"] | components["schemas"]["executionPlanInstructionProposal"] | components["schemas"]["executionPlanResetProposal"];
+            };
+        };
+        /** @description provides status update on the agreement reached for a specific proposal */
+        executionPlanProposalStatusRequest: {
+            /** @enum {string} */
+            status: "approved" | "rejected";
+            request: components["schemas"]["executionPlanProposalRequest"];
+        };
+        /**
          * Format: finid
          * @description Existing owner hex representation of a secp256k1 public key 33 bytes compressed
          */
-    finId: string;
-    finp2pAssetWithType: {
-      /**
+        finId: string;
+        finp2pAssetWithType: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      type: 'finp2p';
-      /** @description unique resource ID of the FinP2P asset */
-      resourceId: string;
-    };
-    customAsset: {
-      /**
+            type: "finp2p";
+            /** @description unique resource ID of the FinP2P asset */
+            resourceId: string;
+        };
+        customAsset: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      type: 'custom';
-    };
-    depositAsset: components['schemas']['finp2pAssetWithType'] | components['schemas']['customAsset'];
-    /**
-         * @description 32 bytes buffer (24 randomly generated bytes by the client + 8 bytes epoch timestamp seconds) encoded to hex:
+            type: "custom";
+        };
+        depositAsset: components["schemas"]["finp2pAssetWithType"] | components["schemas"]["customAsset"];
+        /** @description 32 bytes buffer (24 randomly generated bytes by the client + 8 bytes epoch timestamp seconds) encoded to hex:
          *
          *       const nonce = Buffer.alloc(32);
          *       nonce.fill(crypto.randomBytes(24), 0, 24);
@@ -996,829 +994,829 @@ export interface components {
          *       const nowEpochSeconds = Math.floor(new Date().getTime() / 1000);
          *       const t = BigInt(nowEpochSeconds);
          *       nonce.writeBigInt64BE(t, 24);
-         */
-    nonce: string;
-    ibanAccountDetails: {
-      /**
+         *      */
+        nonce: string;
+        ibanAccountDetails: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      type: 'iban';
-      iban: string;
-    };
-    swiftAccountDetails: {
-      /**
+            type: "iban";
+            iban: string;
+        };
+        swiftAccountDetails: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      type: 'swift';
-      swiftCode: string;
-      accountNumber: string;
-    };
-    sortCodeDetails: {
-      /**
+            type: "swift";
+            swiftCode: string;
+            accountNumber: string;
+        };
+        sortCodeDetails: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      type: 'sortCode';
-      /** @description sort code has XX-XX-XX format */
-      code: string;
-      accountNumber: string;
-    };
-    wireDetails: components['schemas']['ibanAccountDetails'] | components['schemas']['swiftAccountDetails'] | components['schemas']['sortCodeDetails'];
-    wireTransfer: {
-      /**
+            type: "sortCode";
+            /** @description sort code has XX-XX-XX format */
+            code: string;
+            accountNumber: string;
+        };
+        wireDetails: components["schemas"]["ibanAccountDetails"] | components["schemas"]["swiftAccountDetails"] | components["schemas"]["sortCodeDetails"];
+        wireTransfer: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      type: 'wireTransfer';
-      accountHolderName: string;
-      bankName: string;
-      wireDetails: components['schemas']['wireDetails'];
-      line1?: string;
-      city?: string;
-      postalCode?: string;
-      country?: string;
-    };
-    wireTransferUSA: {
-      /**
+            type: "wireTransfer";
+            accountHolderName: string;
+            bankName: string;
+            wireDetails: components["schemas"]["wireDetails"];
+            line1?: string;
+            city?: string;
+            postalCode?: string;
+            country?: string;
+        };
+        wireTransferUSA: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      type: 'wireTransferUSA';
-      accountNumber: string;
-      routingNumber: string;
-      line1?: string;
-      city?: string;
-      postalCode?: string;
-      country?: string;
-      state?: string;
-    };
-    cryptoTransfer: {
-      /**
+            type: "wireTransferUSA";
+            accountNumber: string;
+            routingNumber: string;
+            line1?: string;
+            city?: string;
+            postalCode?: string;
+            country?: string;
+            state?: string;
+        };
+        cryptoTransfer: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      type: 'cryptoTransfer';
-      network: string;
-      contractAddress: string;
-      walletAddress: string;
-    };
-    paymentInstructions: {
-      /**
+            type: "cryptoTransfer";
+            network: string;
+            contractAddress: string;
+            walletAddress: string;
+        };
+        paymentInstructions: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      type: 'paymentInstructions';
-      instruction: string;
-    };
-    paymentMethod: {
-      description: string;
-      /** @description accepted currency for payment */
-      currency: string;
-      methodInstruction: components['schemas']['wireTransfer'] | components['schemas']['wireTransferUSA'] | components['schemas']['cryptoTransfer'] | components['schemas']['paymentInstructions'];
-    };
-    paymentMethods: components['schemas']['paymentMethod'][];
-    /**
+            type: "paymentInstructions";
+            instruction: string;
+        };
+        paymentMethod: {
+            description: string;
+            /** @description accepted currency for payment */
+            currency: string;
+            methodInstruction: components["schemas"]["wireTransfer"] | components["schemas"]["wireTransferUSA"] | components["schemas"]["cryptoTransfer"] | components["schemas"]["paymentInstructions"];
+        };
+        paymentMethods: components["schemas"]["paymentMethod"][];
+        /**
          * @description finp2p resource id format
          * @example bank-x:101:9929ccaf-8967-4ba3-9198-a4b8e3128388
          */
-    resourceId: string;
-    'ledgerAssetIdentifierTypeCAIP-19': {
-      /**
+        resourceId: string;
+        "ledgerAssetIdentifierTypeCAIP-19": {
+            /**
              * @description Classification type standards (enum property replaced by openapi-typescript)
              * @enum {string}
              */
-      assetIdentifierType: 'CAIP-19';
-      network: string;
-      tokenId: string;
-      standard: string;
-    };
-    ledgerAssetIdentifier: components['schemas']['ledgerAssetIdentifierTypeCAIP-19'];
-    /** @description describes asset information */
-    finp2pAsset: {
-      id: components['schemas']['resourceId'];
-      ledgerIdentifier: components['schemas']['ledgerAssetIdentifier'];
-    };
-    finp2pAssetBase: {
-      /** @description unique resource ID of the FinP2P asset */
-      resourceId: string;
-    };
-    walletAccount: {
-      /**
+            assetIdentifierType: "CAIP-19";
+            network: string;
+            tokenId: string;
+            standard: string;
+        };
+        ledgerAssetIdentifier: components["schemas"]["ledgerAssetIdentifierTypeCAIP-19"];
+        /** @description describes asset information */
+        finp2pAsset: {
+            id: components["schemas"]["resourceId"];
+            ledgerIdentifier: components["schemas"]["ledgerAssetIdentifier"];
+        };
+        finp2pAssetBase: {
+            /** @description unique resource ID of the FinP2P asset */
+            resourceId: string;
+        };
+        walletAccount: {
+            /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      type: 'walletAccount';
-      /** @description address of the wallet */
-      address: string;
-    };
-    receiptExecutionContext: {
-      executionPlanId: string;
-      instructionSequenceNumber: number;
-    };
-    receiptTradeDetails: {
-      intentId?: string;
-      intentVersion?: string;
-      executionContext?: components['schemas']['receiptExecutionContext'];
-    };
-    /** @description The name of the asset */
-    assetName: string;
-    /**
+            type: "walletAccount";
+            /** @description address of the wallet */
+            address: string;
+        };
+        receiptExecutionContext: {
+            executionPlanId: string;
+            instructionSequenceNumber: number;
+        };
+        receiptTradeDetails: {
+            intentId?: string;
+            intentVersion?: string;
+            executionContext?: components["schemas"]["receiptExecutionContext"];
+        };
+        /** @description The name of the asset */
+        assetName: string;
+        /**
          * @description Owner resource id
          * @example bank-x:101:511c1d7f-4ed8-410d-887c-a10e3e499a01
          */
-    ownerResourceId: string;
-    /**
+        ownerResourceId: string;
+        /**
          * @description Indicates how the asset is denominated
          * @enum {string}
          */
-    assetDenominationType: 'finp2p' | 'fiat' | 'cryptocurrency';
-    assetDenomination: {
-      type: components['schemas']['assetDenominationType'];
-      /** @description Unique code identifying the denomination asset type */
-      code: string;
+        assetDenominationType: "finp2p" | "fiat" | "cryptocurrency";
+        assetDenomination: {
+            type: components["schemas"]["assetDenominationType"];
+            /** @description Unique code identifying the denomination asset type */
+            code: string;
+        };
     };
-  };
-  responses: never;
-  parameters: never;
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-  approveExecutionPlan: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    approveExecutionPlan: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["ApproveExecutionPlanRequest"];
+            };
+        };
+        responses: {
+            /** @description successful operation */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApproveExecutionPlanResponse"];
+                };
+            };
+            /** @description Invalid Input */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description System error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
     };
-    requestBody?: {
-      content: {
-        'application/json': components['schemas']['ApproveExecutionPlanRequest'];
-      };
+    executionPlanProposal: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["executionPlanProposalRequest"];
+            };
+        };
+        responses: {
+            /** @description successful operation */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApproveExecutionPlanResponse"];
+                };
+            };
+            /** @description Invalid Input */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description System error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
     };
-    responses: {
-      /** @description successful operation */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    executionPlanProposalStatus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          'application/json': components['schemas']['ApproveExecutionPlanResponse'];
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["executionPlanProposalStatusRequest"];
+            };
         };
-      };
-      /** @description Invalid Input */
-      400: {
-        headers: {
-          [name: string]: unknown;
+        responses: {
+            /** @description successful operation */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description successful operation */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Invalid Input */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description System error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
-        content?: never;
-      };
-      /** @description System error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
     };
-  };
-  executionPlanProposal: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    depositInstruction: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
+                "Idempotency-Key": string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["DepositInstructionRequest"];
+            };
+        };
+        responses: {
+            /** @description successful operation */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DepositInstructionResponse"];
+                };
+            };
+            /** @description Invalid Input */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description System error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
     };
-    requestBody?: {
-      content: {
-        'application/json': components['schemas']['executionPlanProposalRequest'];
-      };
+    payout: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
+                "Idempotency-Key": string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["PayoutRequest"];
+            };
+        };
+        responses: {
+            /** @description successful operation */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PayoutResponse"];
+                };
+            };
+            /** @description Invalid Input */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description System error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
     };
-    responses: {
-      /** @description successful operation */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    getAssetBalance: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          'application/json': components['schemas']['ApproveExecutionPlanResponse'];
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["GetAssetBalanceRequest"];
+            };
         };
-      };
-      /** @description Invalid Input */
-      400: {
-        headers: {
-          [name: string]: unknown;
+        responses: {
+            /** @description successful operation */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GetAssetBalanceResponse"];
+                };
+            };
+            /** @description Owner not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description System error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
-        content?: never;
-      };
-      /** @description System error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
     };
-  };
-  executionPlanProposalStatus: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    createAsset: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
+                "Idempotency-Key": string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["CreateAssetRequest"];
+            };
+        };
+        responses: {
+            /** @description successful operation */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CreateAssetResponse"];
+                };
+            };
+            /** @description Invalid Input */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description System error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
     };
-    requestBody?: {
-      content: {
-        'application/json': components['schemas']['executionPlanProposalStatusRequest'];
-      };
+    issueAssets: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
+                "Idempotency-Key": string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["IssueAssetsRequest"];
+            };
+        };
+        responses: {
+            /** @description successful operation */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IssueAssetsResponse"];
+                };
+            };
+            /** @description Invalid Input */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description System error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
     };
-    responses: {
-      /** @description successful operation */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    redeemAssets: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
+                "Idempotency-Key": string;
+            };
+            path?: never;
+            cookie?: never;
         };
-        content?: never;
-      };
-      /** @description successful operation */
-      204: {
-        headers: {
-          [name: string]: unknown;
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["RedeemAssetsRequest"];
+            };
         };
-        content?: never;
-      };
-      /** @description Invalid Input */
-      400: {
-        headers: {
-          [name: string]: unknown;
+        responses: {
+            /** @description successful operation */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RedeemAssetsResponse"];
+                };
+            };
+            /** @description Invalid Input */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description System error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
-        content?: never;
-      };
-      /** @description System error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
     };
-  };
-  depositInstruction: {
-    parameters: {
-      query?: never;
-      header: {
-        /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
-        'Idempotency-Key': string;
-      };
-      path?: never;
-      cookie?: never;
+    transferAsset: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
+                "Idempotency-Key": string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["TransferAssetRequest"];
+            };
+        };
+        responses: {
+            /** @description successful operation */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TransferAssetResponse"];
+                };
+            };
+            /** @description Invalid Input */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description System error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
     };
-    requestBody?: {
-      content: {
-        'application/json': components['schemas']['DepositInstructionRequest'];
-      };
+    getReceipt: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description ID of the asset transaction */
+                transactionId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description successful operation */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GetReceiptResponse"];
+                };
+            };
+            /** @description Transaction not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description System error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
     };
-    responses: {
-      /** @description successful operation */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    holdOperation: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
+                "Idempotency-Key": string;
+            };
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          'application/json': components['schemas']['DepositInstructionResponse'];
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["HoldOperationRequest"];
+            };
         };
-      };
-      /** @description Invalid Input */
-      400: {
-        headers: {
-          [name: string]: unknown;
+        responses: {
+            /** @description successful operation */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HoldOperationResponse"];
+                };
+            };
+            /** @description Invalid Input */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description System error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
-        content?: never;
-      };
-      /** @description System error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
     };
-  };
-  payout: {
-    parameters: {
-      query?: never;
-      header: {
-        /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
-        'Idempotency-Key': string;
-      };
-      path?: never;
-      cookie?: never;
+    releaseOperation: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
+                "Idempotency-Key": string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["ReleaseOperationRequest"];
+            };
+        };
+        responses: {
+            /** @description successful operation */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReleaseOperationResponse"];
+                };
+            };
+            /** @description Invalid Input */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description System error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
     };
-    requestBody?: {
-      content: {
-        'application/json': components['schemas']['PayoutRequest'];
-      };
+    rollbackOperation: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
+                "Idempotency-Key": string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["RollbackOperationRequest"];
+            };
+        };
+        responses: {
+            /** @description successful operation */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RollbackOperationResponse"];
+                };
+            };
+            /** @description Invalid Input */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description System error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
     };
-    responses: {
-      /** @description successful operation */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    getOperation: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description correlation id of an operation */
+                cid: string;
+            };
+            cookie?: never;
         };
-        content: {
-          'application/json': components['schemas']['PayoutResponse'];
+        requestBody?: never;
+        responses: {
+            /** @description successful operation */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GetOperationStatusResponse"];
+                };
+            };
+            /** @description Transaction not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description System error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
-      };
-      /** @description Invalid Input */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description System error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
     };
-  };
-  getAssetBalance: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    GetAssetBalanceInfo: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AssetBalanceInfoRequest"];
+            };
+        };
+        responses: {
+            /** @description successful operation */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AssetBalanceInfoResponse"];
+                };
+            };
+            /** @description Owner not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description System error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
     };
-    requestBody?: {
-      content: {
-        'application/json': components['schemas']['GetAssetBalanceRequest'];
-      };
+    getHealth: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Service is healthy */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example ok */
+                        status?: string;
+                    };
+                };
+            };
+            /** @description Service is unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example unavailable */
+                        status?: string;
+                    };
+                };
+            };
+        };
     };
-    responses: {
-      /** @description successful operation */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['GetAssetBalanceResponse'];
-        };
-      };
-      /** @description Owner not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description System error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  createAsset: {
-    parameters: {
-      query?: never;
-      header: {
-        /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
-        'Idempotency-Key': string;
-      };
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: {
-      content: {
-        'application/json': components['schemas']['CreateAssetRequest'];
-      };
-    };
-    responses: {
-      /** @description successful operation */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['CreateAssetResponse'];
-        };
-      };
-      /** @description Invalid Input */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description System error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  issueAssets: {
-    parameters: {
-      query?: never;
-      header: {
-        /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
-        'Idempotency-Key': string;
-      };
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: {
-      content: {
-        'application/json': components['schemas']['IssueAssetsRequest'];
-      };
-    };
-    responses: {
-      /** @description successful operation */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['IssueAssetsResponse'];
-        };
-      };
-      /** @description Invalid Input */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description System error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  redeemAssets: {
-    parameters: {
-      query?: never;
-      header: {
-        /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
-        'Idempotency-Key': string;
-      };
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: {
-      content: {
-        'application/json': components['schemas']['RedeemAssetsRequest'];
-      };
-    };
-    responses: {
-      /** @description successful operation */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['RedeemAssetsResponse'];
-        };
-      };
-      /** @description Invalid Input */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description System error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  transferAsset: {
-    parameters: {
-      query?: never;
-      header: {
-        /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
-        'Idempotency-Key': string;
-      };
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: {
-      content: {
-        'application/json': components['schemas']['TransferAssetRequest'];
-      };
-    };
-    responses: {
-      /** @description successful operation */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['TransferAssetResponse'];
-        };
-      };
-      /** @description Invalid Input */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description System error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  getReceipt: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description ID of the asset transaction */
-        transactionId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description successful operation */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['GetReceiptResponse'];
-        };
-      };
-      /** @description Transaction not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description System error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  holdOperation: {
-    parameters: {
-      query?: never;
-      header: {
-        /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
-        'Idempotency-Key': string;
-      };
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: {
-      content: {
-        'application/json': components['schemas']['HoldOperationRequest'];
-      };
-    };
-    responses: {
-      /** @description successful operation */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HoldOperationResponse'];
-        };
-      };
-      /** @description Invalid Input */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description System error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  releaseOperation: {
-    parameters: {
-      query?: never;
-      header: {
-        /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
-        'Idempotency-Key': string;
-      };
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: {
-      content: {
-        'application/json': components['schemas']['ReleaseOperationRequest'];
-      };
-    };
-    responses: {
-      /** @description successful operation */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ReleaseOperationResponse'];
-        };
-      };
-      /** @description Invalid Input */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description System error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  rollbackOperation: {
-    parameters: {
-      query?: never;
-      header: {
-        /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
-        'Idempotency-Key': string;
-      };
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: {
-      content: {
-        'application/json': components['schemas']['RollbackOperationRequest'];
-      };
-    };
-    responses: {
-      /** @description successful operation */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['RollbackOperationResponse'];
-        };
-      };
-      /** @description Invalid Input */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description System error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  getOperation: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description correlation id of an operation */
-        cid: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description successful operation */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['GetOperationStatusResponse'];
-        };
-      };
-      /** @description Transaction not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description System error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  GetAssetBalanceInfo: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['AssetBalanceInfoRequest'];
-      };
-    };
-    responses: {
-      /** @description successful operation */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['AssetBalanceInfoResponse'];
-        };
-      };
-      /** @description Owner not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description System error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  getHealth: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Service is healthy */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @example ok */
-            status?: string;
-          };
-        };
-      };
-      /** @description Service is unavailable */
-      503: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @example unavailable */
-            status?: string;
-          };
-        };
-      };
-    };
-  };
 }


### PR DESCRIPTION
## Summary

- Sync `apis/*.yaml` from `finp2p-core` master, regenerate all generated types
- Restructure `src/flows.ts` to match v0.28 intent schema strictly (no `as any` casts on client calls)
- Add `FinAPIClient.bindCustodyProvider` / `updateCustodyProvider`
- Add `createLoanIntent` / `executeLoanIntent` flow helpers
- Add `createRequestForTransferIntent` / `executeRequestForTransferIntent`
- Add `createAsset` flow helper (constructs CAIP-19 `ledgerAssetBinding`)

## Schema alignment (flows.ts)

- `intent.asset = { assetTerm, assetInstruction }` (nested)
- `intent.settlement` is array for primarySale/selling/redemption/loan, single object for buyingIntent
- `assetTerm: { amount }` only (no asset field)
- `settlementTerm` discriminated: `{ type: 'partialSettlement', unitValue }`
- Asset in account: `{ id, ledgerIdentifier }` (no `type`/`resourceId`)
- Accounts: strict `{ type: 'finId', finId, orgId, custodian: { orgId } }`

## Breaking signature changes

- All intent params now take `asset: AssetRef` and `paymentAsset: AssetRef` objects (each `{ id, ledgerIdentifier: CAIP-19 }`)
- Dropped `*CryptoAddress` optional params — crypto-wallet settlement isn't reachable in v0.28 finp2p settlement paths
- `CreateAssetParams.type` is asset classification enum (`'Equity' | 'Debt' | ...`), not denomination type
- `ExecuteLoanIntentParams` gained required `executorType: 'borrower' | 'lender'`
- `financialIdentifier` is a strict discriminated union

Bumps finp2p-client to 0.28.5.

## Test plan

- [x] `npm run build` passes in finp2p-client (and skeleton, with regenerated `model-gen.ts`)
- [ ] CI green, then tag `finp2p-client-v0.28.5` from this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)