### PR TITLE
Fix final idempotency assertion (flaky on slow CI)

### DIFF
--- a/skeleton/tests/workflows/service.test.ts
+++ b/skeleton/tests/workflows/service.test.ts
@@ -226,13 +226,13 @@ describe("Service operation tests", () => {
       service.callCount.get(JSON.stringify([otherIdempotencyKey, planId])),
     ).toBeGreaterThanOrEqual(1);
 
-    // Duplicating the earlier request
+    // Duplicating the earlier request — count must not increase
     await expect(
       proxied.approvePlan(idempotencyKey, planId),
     ).resolves.toBeDefined();
     expect(
       service.callCount.get(JSON.stringify([idempotencyKey, planId])),
-    ).toBe(1);
+    ).toBe(countBefore);
 
     expect(service.callCount.size).toBe(2);
   });


### PR DESCRIPTION
## Summary

The final `toBe(1)` assertion in the 'calling the same inputs will result cached response' test is inconsistent with the earlier `toBeGreaterThanOrEqual(1)` assertions that tolerate crash-recovery double-execution. On slow CI, the initial count can be `2` — then the duplicate-request assertion fails because count stayed at `2`, not `1`.

Use `toBe(countBefore)` (already captured earlier) so the final assertion tracks whatever the non-duplicated count ended up being.

## Test plan

- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)