### PR TITLE
finp2p-client: default to http:// when URL has no scheme

### DIFF
--- a/finp2p-client/package.json
+++ b/finp2p-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.28.5",
+  "version": "0.28.6",
   "description": "FinP2P API Client",
   "homepage": "https://ownera.io/",
   "main": "./dist/index.js",

--- a/finp2p-client/src/finapi/finapi.client.ts
+++ b/finp2p-client/src/finapi/finapi.client.ts
@@ -1,7 +1,7 @@
 import createClient, { Client, Middleware } from 'openapi-fetch';
 import { components as FinAPIComponents, paths as FinAPIPaths } from './model-gen';
 import { components as OpComponents, paths as OpPaths } from './op-model-gen';
-import { sleep } from './utils';
+import { normalizeBaseUrl, sleep } from './utils';
 
 // Helper: extract the request body type for a given path + method from openapi-fetch paths
 type RequestBody<P extends keyof FinAPIPaths, M extends keyof FinAPIPaths[P]> =
@@ -21,10 +21,11 @@ export class FinAPIClient {
   opClient: Client<OpPaths>;
 
   constructor(finP2PUrl: string, authTokenResolver: (() => string) | undefined = undefined) {
-    this.finP2PUrl = finP2PUrl;
+    const baseUrl = normalizeBaseUrl(finP2PUrl);
+    this.finP2PUrl = baseUrl;
     this.authTokenResolver = authTokenResolver;
-    this.apiClient = createClient<FinAPIPaths>({ baseUrl: finP2PUrl });
-    this.opClient = createClient<OpPaths>({ baseUrl: finP2PUrl });
+    this.apiClient = createClient<FinAPIPaths>({ baseUrl });
+    this.opClient = createClient<OpPaths>({ baseUrl });
 
     if (authTokenResolver) {
       const authMiddleware: Middleware = {

--- a/finp2p-client/src/finapi/utils.ts
+++ b/finp2p-client/src/finapi/utils.ts
@@ -12,6 +12,19 @@ export function extractOrgId(resourceId: string): string {
   return parts[0];
 }
 
+/**
+ * Normalize a base URL: prepend `http://` if no scheme is present.
+ * Operators frequently set FINP2P_ADDRESS to `host:port` or a bare hostname —
+ * without a scheme, `fetch` rejects with "unknown scheme". Default to plain
+ * http so those configurations keep working.
+ */
+export function normalizeBaseUrl(url: string): string {
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(url)) {
+    return url;
+  }
+  return `http://${url}`;
+}
+
 export function hexNonce(size = 16): string {
   return crypto.randomBytes(size).toString('hex');
 }

--- a/finp2p-client/src/oss/oss.client.ts
+++ b/finp2p-client/src/oss/oss.client.ts
@@ -10,6 +10,7 @@ import PLANS from './graphql/plans.graphql';
 import RECEIPTS from './graphql/receipts.graphql';
 import { OssApprovalConfigNodes, OssAssetNodes, OssCertificate, OssExecutionPlan, OssExecutionPlanNodes, OssLedgerBindingNodes, OssOrganizationNodes, OssOwnerNodes, OssReceipt, OssReceiptNodes } from './model';
 import { ItemNotFoundError } from './errors';
+import { normalizeBaseUrl } from '../finapi/utils';
 
 export class OssClient {
 
@@ -18,7 +19,7 @@ export class OssClient {
   authTokenResolver: (() => string) | undefined;
 
   constructor(ossUrl: string, authTokenResolver: (() => string) | undefined = undefined) {
-    this.ossUrl = ossUrl;
+    this.ossUrl = normalizeBaseUrl(ossUrl);
     this.authTokenResolver = authTokenResolver;
   }
 


### PR DESCRIPTION
## Summary

The error `"unknown scheme"` (from undici `fetch`) was coming from passing `FINP2P_ADDRESS` like `host:port` or a bare hostname without `http://`. The callback silently failed.

- Add `normalizeBaseUrl()` in `finapi/utils` (leaves `http://`/`https://`/etc. alone, prepends `http://` otherwise)
- Apply in both `FinAPIClient` and `OssClient` constructors

**Re: "are we parsing this env?"** — no. `sample-adapter/src/index.ts` just passes `process.env.FINP2P_ADDRESS` straight through to `new FinP2PClient(finAPIUrl, ossUrl)`. Normalizing inside the client fixes every consumer at once.

Bumps finp2p-client to 0.28.6.

## Test plan

- [x] `npm run build` passes
- [ ] CI green, then tag `finp2p-client-v0.28.6` to publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)