### PR TITLE
adapter-tests: sync package-lock.json for 0.28.1 release

### DIFF
--- a/adapter-tests/package-lock.json
+++ b/adapter-tests/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@owneraio/adapter-tests",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/adapter-tests",
-      "version": "0.28.0",
+      "version": "0.28.1",
       "license": "ISC",
       "dependencies": {
-        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.0",
+        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.6",
         "axios": "^1.12.2",
         "secp256k1": "^3.7.1",
         "yaml": "^2.8.1",
@@ -1760,9 +1760,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-client": {
-      "version": "0.28.0",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-client/0.28.0/46c459b00027a7500e8ac2f572880c69f4208490",
-      "integrity": "sha512-EWKjfNwhCGoLy6ehLGXNX+XzqBCikZMOxY7F28q48b4tClCAv7Vx2MhuHSsFa6lLC46NirwGgCPG3N0VJQ/nHg==",
+      "version": "0.28.6",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-client/0.28.6/0b66643c9727a464e52dbb6bde237f09168cc60d",
+      "integrity": "sha512-4CsT8BHRx7XOuuLbS+yDmqnufCaRNP58K/UXllpQCbJrBmFjsxPPJTMr9DCeqI0W3ZA1H2xtNJ890I+rJdeLbQ==",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -1773,9 +1773,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-nodejs-skeleton-adapter": {
-      "version": "0.28.0",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.0/54f339504e134c810d57924ded569ffbc0f818e5",
-      "integrity": "sha512-dUQjKDCSOFUph5s4nDyKj22EQi46dBcIWLo50/VvYv697A1Uk+GxYdiTDLpauXCiC2nsI87HewBmA49hCPyI/A==",
+      "version": "0.28.6",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.6/4939b821be296ade442cc755423fd0f7e82ba0ed",
+      "integrity": "sha512-ukQdnKfbOdbUoWa++AO6W1hc4gb8uUgHtHZ1O3fUwC8k+Izt+gBs+nma5+JDWyZeEqsEOWh+N09vrnWB+EHIWQ==",
       "license": "TBD",
       "dependencies": {
         "axios": "1.11.0",
@@ -1789,7 +1789,7 @@
         "winston": "^3.18.3"
       },
       "peerDependencies": {
-        "@owneraio/finp2p-client": "^0.28.0-custody-native.7",
+        "@owneraio/finp2p-client": "^0.28.6",
         "pg": "^8.15.6"
       }
     },


### PR DESCRIPTION
## Summary

PR #182 bumped [adapter-tests/package.json](adapter-tests/package.json) to `0.28.1` with skeleton dep `^0.28.6` but left [adapter-tests/package-lock.json](adapter-tests/package-lock.json) pointing at the pre-bump versions (skeleton `0.28.0`, finp2p-client `0.28.0-custody-native.7`). `npm ci` in the adapter-tests publish workflow rejects this mismatch with EUSAGE, so the `adapter-tests-v0.28.1` tag never reached the registry.

Regenerate the lock file so it matches the declared ranges (skeleton `0.28.6`, finp2p-client `0.28.6`).

## Follow-up

After merge, re-tag `adapter-tests-v0.28.1` on the new master HEAD (the old tag never published anything, so deleting & re-pushing is safe).

## Test plan

- [x] `npm run build` in adapter-tests clean against published skeleton 0.28.6
- [ ] CI green on this PR
- [ ] Re-tagged `adapter-tests-v0.28.1` publish workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)