### PR TITLE
finp2p-client: align OSS receipt query/model to v0.28 schema

### DIFF
--- a/finp2p-client/apis/ownership.graphql
+++ b/finp2p-client/apis/ownership.graphql
@@ -1111,10 +1111,20 @@ type ReceiptState{
 }
 
 
+"Role of an organization participating in an Execution Plan"
+enum ExecutionOrganizationRole {
+    "Participates in plan approval and instruction execution"
+    contributor
+    "Read-only participant; receives state updates but does not approve or execute"
+    observer
+}
+
 "Information about organization in an Execution Plan context"
 type ExecutionOrganization {
     organizationId: String!
-    #    Role:
+
+    "Roles this organization holds in the execution plan. An organization with only the observer role is a passive recipient of state updates."
+    roles: [ExecutionOrganizationRole!]
 }
 
 type ExecutionsPlans {

--- a/finp2p-client/package.json
+++ b/finp2p-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.28.6",
+  "version": "0.28.7",
   "description": "FinP2P API Client",
   "homepage": "https://ownera.io/",
   "main": "./dist/index.js",

--- a/finp2p-client/src/oss/graphql.d.ts
+++ b/finp2p-client/src/oss/graphql.d.ts
@@ -542,7 +542,17 @@ export type ExecutionContext = {
 export type ExecutionOrganization = {
   __typename?: 'ExecutionOrganization';
   organizationId: Scalars['String']['output'];
+  /** Roles this organization holds in the execution plan. An organization with only the observer role is a passive recipient of state updates. */
+  roles?: Maybe<Array<ExecutionOrganizationRole>>;
 };
+
+/** Role of an organization participating in an Execution Plan */
+export enum ExecutionOrganizationRole {
+  /** Participates in plan approval and instruction execution */
+  Contributor = 'contributor',
+  /** Read-only participant; receives state updates but does not approve or execute */
+  Observer = 'observer',
+}
 
 export type ExecutionPlan = {
   __typename?: 'ExecutionPlan';

--- a/finp2p-client/src/oss/graphql/receipts.graphql
+++ b/finp2p-client/src/oss/graphql/receipts.graphql
@@ -16,6 +16,16 @@ query GetReceipts($filter: [Filter!]) {
             destinationAccount {
                 ... ledgerAccountAsset
             }
+            proof {
+                __typename
+                ... on SignatureProof {
+                    signature {
+                        signature
+                        hashFunction
+                        templateType
+                    }
+                }
+            }
         }
     }
 }
@@ -24,10 +34,21 @@ fragment ledgerAccountAsset on LedgerAccountAsset {
     finp2pAccount {
         asset {
             resourceId
+            ledgerIdentifier {
+                __typename
+                ... on Caip19Identifier {
+                    network
+                    standard
+                    tokenId
+                }
+            }
         }
         account {
             finId
             orgId
+            custodian {
+                orgId
+            }
         }
     }
     networkAccount {

--- a/finp2p-client/src/oss/model.ts
+++ b/finp2p-client/src/oss/model.ts
@@ -206,12 +206,23 @@ export type OssAccountIdentifier =
 
 /**
  * Modelled on the `LedgerAccountAsset` schema type — instruction source/destination
- * fields on execution-plan instructions all return this composite now.
+ * and receipt source/destination fields all return this composite now.
+ *
+ * `asset.ledgerIdentifier` is the CAIP-19 union (currently single member
+ * `Caip19Identifier`); `account.custodian` carries the holding org id when the
+ * finId sits behind a custodian.
  */
 export type OssLedgerAccountAsset = {
   finp2pAccount: {
-    asset?: { resourceId: string } | null;
-    account?: { finId: string; orgId: string } | null;
+    asset?: {
+      resourceId: string;
+      ledgerIdentifier?: ({ __typename: 'Caip19Identifier' } & Caip19Identifier) | null;
+    } | null;
+    account?: {
+      finId: string;
+      orgId: string;
+      custodian?: { orgId: string } | null;
+    } | null;
   };
   networkAccount?: { wallet?: { type: string; address: string } | null } | null;
 };
@@ -255,6 +266,13 @@ export type OssInstructionApproval = {
   reason: string | null;
 };
 
+export type OssReceiptProof =
+  | { __typename: 'NoProof' }
+  | {
+    __typename: 'SignatureProof';
+    signature: { signature: string; hashFunction: string; templateType: string };
+  };
+
 export type OssReceipt = {
   __typename: 'Receipt';
   id: string;
@@ -270,6 +288,7 @@ export type OssReceipt = {
   quantity: string;
   timestamp: string;
   status: string;
+  proof?: OssReceiptProof | null;
 };
 
 export type OssInstructionState =


### PR DESCRIPTION
## Summary

The v0.28 OSS schema removed the top-level `asset` field on `Receipt` and pushed it inside `sourceAccount` / `destinationAccount` — each side carries its own `LedgerAccountAsset` referencing the asset held there (so an in-flight transaction can have two distinct asset ids on each leg, both pointing at the same physical instrument). `source` / `destination` remain as legacy flat scalar owner ids.

Example v0.28 receipt:
```json
{
  "source": null,
  "destination": "org-c:101:f160949f-...",
  "destinationAccount": {
    "finp2pAccount": {
      "asset": {
        "resourceId": "org-a:102:99f7fa2c-...",
        "ledgerIdentifier": null
      },
      "account": {
        "finId": "024fe86e9f5d762b...",
        "orgId": "024fe86e9f5d762b...",
        "custodian": null
      }
    }
  },
  "proof": { "__typename": "NoProof" }
}
```

The current `receipts.graphql` already pulls `sourceAccount`/`destinationAccount` but skips three fields the platform now populates:

- `asset.ledgerIdentifier` — CAIP-19 union (currently single member `Caip19Identifier`); requires an inline fragment to render at all.
- `account.custodian` — orgId of the holding custodian when the finId isn't self-custodied.
- `proof` — `NoProof | SignatureProof` union; surface `__typename` so callers can branch and inline-fragment to read the signature.

## Changes

- [finp2p-client/apis/ownership.graphql](finp2p-client/apis/ownership.graphql) — sync to upstream `oss/master` HEAD. Only unrelated drift was the `ExecutionOrganizationRole` enum + `roles` field on PlanOrganization (picked up as a side effect).
- [finp2p-client/src/oss/graphql.d.ts](finp2p-client/src/oss/graphql.d.ts) — regenerate from the synced schema.
- [finp2p-client/src/oss/graphql/receipts.graphql](finp2p-client/src/oss/graphql/receipts.graphql) — extend the `ledgerAccountAsset` fragment with `ledgerIdentifier` (Caip19Identifier inline fragment) and `custodian.orgId`; add a `proof` selection on the receipt with the union inline fragment.
- [finp2p-client/src/oss/model.ts](finp2p-client/src/oss/model.ts) — extend `OssLedgerAccountAsset` with the new asset/account fields; add `OssReceiptProof` union; add `proof?` on `OssReceipt`. Reuses the existing `Caip19Identifier` shape.
- Bump finp2p-client to **0.28.7** — additive only, existing callers keep reading `source` / `destination` / `quantity` / `status` etc. as before.

## Aside

The example payload has `account.finId === account.orgId === "024fe86e9f5d762b..."` — that's identical, suspicious data. Looks like the seed env populated `orgId` with the finId as a placeholder. This PR doesn't try to fix that; flagging only.

## Test plan

- [x] `npm run graphql-gen` clean
- [x] `npm run build` in finp2p-client clean
- [x] Skeleton builds against the updated client (`npm install ../finp2p-client && npm run build`)
- [ ] CI green on this PR (skeleton + adapter-tests + sample-adapter + vanilla-service)
- [ ] Tag `finp2p-client-v0.28.7` and confirm publish workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)