### PR TITLE
vanilla-service: sync package-lock.json for 0.28.2 release

### DIFF
--- a/vanilla-service/package-lock.json
+++ b/vanilla-service/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@owneraio/finp2p-vanilla-service",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-vanilla-service",
-      "version": "0.28.1",
+      "version": "0.28.2",
       "license": "TBD",
       "dependencies": {
-        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.4",
+        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.9",
         "bs58": "^6.0.0",
         "pg": "^8.15.6",
         "winston": "^3.18.3"
@@ -1407,9 +1407,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-client": {
-      "version": "0.28.0",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-client/0.28.0/46c459b00027a7500e8ac2f572880c69f4208490",
-      "integrity": "sha512-EWKjfNwhCGoLy6ehLGXNX+XzqBCikZMOxY7F28q48b4tClCAv7Vx2MhuHSsFa6lLC46NirwGgCPG3N0VJQ/nHg==",
+      "version": "0.28.7",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-client/0.28.7/55adcf40750476d6542eba321e1ffdde355c1411",
+      "integrity": "sha512-VeuXp5A0VLx+UHQCrrzszdnUU9yytkm7Oym1zViaLRIumlPSBEpZ9V6vJD5CO2PScwrDHgisANGPZGJfsuMlRg==",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -1420,9 +1420,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-nodejs-skeleton-adapter": {
-      "version": "0.28.4",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.4/7d02e779c0e5bd788b6e98cd8d7dff40f6a1400c",
-      "integrity": "sha512-f7KTkKaZNtZwk//TjIfK+xjopo+NVBdcep3J1Vp/+xyFeizrjul5lJQef8flJARhSux8U7bt+/4JBiWw1fWPPg==",
+      "version": "0.28.9",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.9/a71ce7777fe5194dde5a1ab21654800d1173a060",
+      "integrity": "sha512-DRG7VZ3gqDYCE0Ib6IgLQkP98ioLneOha3aKo4ykTkqiphYs7S6o2YTlASOMv7MF1rmFpHWP2IUalG3+w2GddQ==",
       "license": "TBD",
       "dependencies": {
         "axios": "1.11.0",
@@ -1436,7 +1436,7 @@
         "winston": "^3.18.3"
       },
       "peerDependencies": {
-        "@owneraio/finp2p-client": "^0.28.0",
+        "@owneraio/finp2p-client": "^0.28.6",
         "pg": "^8.15.6"
       }
     },
@@ -2751,9 +2751,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {


### PR DESCRIPTION
## Summary

PR #188 bumped vanilla-service to `0.28.2` with skeleton dep `^0.28.9` but left [vanilla-service/package-lock.json](vanilla-service/package-lock.json) pinned at skeleton `0.28.4`. `npm ci` in the publish workflow rejects this with EUSAGE so `vanilla-service-v0.28.2` never reached the registry. Regenerate the lock file. Same fix pattern as PR #183 for adapter-tests.

## Follow-up

After merge, re-tag `vanilla-service-v0.28.2` on the new master HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)