### PR TITLE
adapter-tests: sync package-lock.json for 0.28.2 release

### DIFF
--- a/adapter-tests/package-lock.json
+++ b/adapter-tests/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@owneraio/adapter-tests",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/adapter-tests",
-      "version": "0.28.1",
+      "version": "0.28.2",
       "license": "ISC",
       "dependencies": {
-        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.6",
+        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.10",
         "axios": "^1.12.2",
         "secp256k1": "^3.7.1",
         "yaml": "^2.8.1",
@@ -1773,9 +1773,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-nodejs-skeleton-adapter": {
-      "version": "0.28.6",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.6/4939b821be296ade442cc755423fd0f7e82ba0ed",
-      "integrity": "sha512-ukQdnKfbOdbUoWa++AO6W1hc4gb8uUgHtHZ1O3fUwC8k+Izt+gBs+nma5+JDWyZeEqsEOWh+N09vrnWB+EHIWQ==",
+      "version": "0.28.10",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.10/6b3aef3c1708423a7741787762363935f4b569e2",
+      "integrity": "sha512-5XjeH/fNjs05eVgGAaLVKQkXlaohTLc0wHPS1fMvuSiDNxKaGvEqyZEWu0vyZZiGhNWLN+hP505p9D+ak4hLxg==",
       "license": "TBD",
       "dependencies": {
         "axios": "1.11.0",


### PR DESCRIPTION
## Summary

PR #191 bumped adapter-tests to \`0.28.2\` with skeleton dep \`^0.28.10\` but left the lockfile pinned at skeleton \`0.28.6\`. \`npm ci\` in the publish workflow rejects this with EUSAGE so \`adapter-tests-v0.28.2\` never reached the registry. Regenerate the lock file.

Same fix pattern as #183 (adapter-tests 0.28.1) and #189 (vanilla-service 0.28.2).

After merge: re-tag \`adapter-tests-v0.28.2\` on the new master HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)