### PR TITLE
AccountMappingServiceImpl: configurable case sensitivity

### DIFF
--- a/skeleton/package-lock.json
+++ b/skeleton/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-  "version": "0.28.10",
+  "version": "0.28.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-      "version": "0.28.10",
+      "version": "0.28.11",
       "license": "TBD",
       "dependencies": {
         "axios": "1.11.0",

--- a/skeleton/package.json
+++ b/skeleton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-  "version": "0.28.10",
+  "version": "0.28.11",
   "description": "",
   "homepage": "https://ownera.io/",
   "main": "dist/index.js",

--- a/skeleton/src/services/mapping.ts
+++ b/skeleton/src/services/mapping.ts
@@ -1,14 +1,31 @@
 import { AccountMappingService, AccountMapping } from '../models';
 import { AccountStore } from '../storage';
 
+export interface AccountMappingOptions {
+  /**
+   * Match account-mapping field values case-sensitively. Default: true.
+   *
+   * When false, the service lowercases values on both save and lookup so a
+   * caller looking up `0xABC...` finds an account saved as `0xabc...` and
+   * vice versa. Useful for ledger account fields that consumers may submit
+   * mixed-case (e.g. EIP-55 checksummed Ethereum addresses) when the
+   * underlying address space is logically case-insensitive.
+   *
+   * Trade-off: case-insensitive mode discards the original casing at write
+   * time. If the adapter cares about preserving display casing, leave this
+   * at the default and rely on callers to canonicalize before submitting.
+   */
+  caseSensitive?: boolean;
+}
+
 /**
  * AccountMappingService backed by a shared AccountStore.
  */
 export class AccountMappingServiceImpl implements AccountMappingService {
-  private store: AccountStore;
+  private readonly caseSensitive: boolean;
 
-  constructor(store: AccountStore) {
-    this.store = store;
+  constructor(private store: AccountStore, options?: AccountMappingOptions) {
+    this.caseSensitive = options?.caseSensitive ?? true;
   }
 
   async getAccounts(finIds?: string[]): Promise<AccountMapping[]> {
@@ -16,14 +33,25 @@ export class AccountMappingServiceImpl implements AccountMappingService {
   }
 
   async getByFieldValue(fieldName: string, value: string): Promise<AccountMapping[]> {
-    return this.store.getByFieldValue(fieldName, value);
+    return this.store.getByFieldValue(fieldName, this.normalize(value));
   }
 
   async saveAccount(finId: string, fields: Record<string, string>): Promise<AccountMapping> {
-    return this.store.saveAccount(finId, fields);
+    return this.store.saveAccount(finId, this.normalizeFields(fields));
   }
 
   async deleteAccount(finId: string, fieldName?: string): Promise<void> {
     await this.store.deleteAccount(finId, fieldName);
+  }
+
+  private normalize(value: string): string {
+    return this.caseSensitive ? value : value.toLowerCase();
+  }
+
+  private normalizeFields(fields: Record<string, string>): Record<string, string> {
+    if (this.caseSensitive) return fields;
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(fields)) out[k] = v.toLowerCase();
+    return out;
   }
 }

--- a/skeleton/tests/workflows/account-mappings.test.ts
+++ b/skeleton/tests/workflows/account-mappings.test.ts
@@ -1,5 +1,6 @@
 import { migrateIfNeeded } from '../../src/workflows'
 import { PgAccountStore } from '../../src/storage'
+import { AccountMappingServiceImpl } from '../../src/services/mapping'
 import { Pool } from 'pg'
 
 describe("account mappings", () => {
@@ -114,6 +115,43 @@ describe("account mappings", () => {
   test("empty result for nonexistent finId", async () => {
     const mappings = await store.getAccounts(["does-not-exist"]);
     expect(mappings).toHaveLength(0);
+  });
+
+  describe("AccountMappingServiceImpl case sensitivity", () => {
+    test("default service is case-sensitive (matches store behavior)", async () => {
+      const service = new AccountMappingServiceImpl(store);
+      await service.saveAccount("fin-1", { ledgerAccountId: "0xABCDEF" });
+      await service.saveAccount("fin-2", { ledgerAccountId: "0xabcdef" });
+
+      const upper = await service.getByFieldValue("ledgerAccountId", "0xABCDEF");
+      expect(upper.map(m => m.finId)).toEqual(["fin-1"]);
+
+      const lower = await service.getByFieldValue("ledgerAccountId", "0xabcdef");
+      expect(lower.map(m => m.finId)).toEqual(["fin-2"]);
+    });
+
+    test("caseSensitive: false normalizes on save and lookup", async () => {
+      const service = new AccountMappingServiceImpl(store, { caseSensitive: false });
+
+      // Saved with mixed case — should be lowercased before reaching the store.
+      const saved = await service.saveAccount("fin-1", { ledgerAccountId: "0xAbCdEf" });
+      expect(saved.fields.ledgerAccountId).toBe("0xabcdef");
+
+      // Lookup with any casing finds the same record.
+      for (const probe of ["0xAbCdEf", "0xabcdef", "0xABCDEF"]) {
+        const matches = await service.getByFieldValue("ledgerAccountId", probe);
+        expect(matches.map(m => m.finId)).toEqual(["fin-1"]);
+      }
+    });
+
+    test("caseSensitive: false also applies on update — last write wins, lowercased", async () => {
+      const service = new AccountMappingServiceImpl(store, { caseSensitive: false });
+      await service.saveAccount("fin-1", { ledgerAccountId: "0xOLDADDR" });
+      await service.saveAccount("fin-1", { ledgerAccountId: "0xNewAddr" });
+
+      const all = await store.getAccounts(["fin-1"]);
+      expect(all[0].fields.ledgerAccountId).toBe("0xnewaddr");
+    });
   });
 
   test("getByFieldValue returns all fields for matched finIds", async () => {


### PR DESCRIPTION
## Why

The default account-mapping behavior since #185 is case-sensitive — needed because EIP-55 checksummed Ethereum addresses carry meaningful casing. But callers that submit \`0xABC…\` and later look up \`0xabc…\` expect a hit when the underlying address space is logically case-insensitive (e.g. lowercase canonical form). Adapter authors should be able to opt into that mode without rewriting the service.

## What

- New \`AccountMappingOptions\` with a single \`caseSensitive?: boolean\` flag (default \`true\`).
- When \`caseSensitive: false\`, the service lowercases values on both save and lookup. The store stays case-sensitive (Postgres \`=\`); normalization is done above it.
- Default behavior unchanged → no regression for existing wirings.

[skeleton/src/services/mapping.ts](skeleton/src/services/mapping.ts):

\`\`\`ts
new AccountMappingServiceImpl(store);                              // case-sensitive (default)
new AccountMappingServiceImpl(store, { caseSensitive: false });    // case-insensitive
\`\`\`

## Trade-off

Case-insensitive mode discards the original casing at write time (because we lowercase before persisting). Adapters that need to preserve display casing (or where checksummed casing is load-bearing) should leave the flag at the default and rely on the caller to canonicalize.

We keep the toggle at the service layer rather than per-field. If an adapter later needs mixed sensitivity (say, case-sensitive IBANs alongside case-insensitive Ethereum addresses), the simple path is to wire two service instances, each over the same store.

## Test plan

- [x] 13/13 in [account-mappings.test.ts](skeleton/tests/workflows/account-mappings.test.ts) — 10 existing + 3 new (default sensitivity, save/lookup normalization, update last-write-wins-lowercased)
- [x] Full skeleton suite: 30/30 green
- [ ] CI green on this PR

## Bumps

- skeleton **0.28.10 → 0.28.11**
- Lockfile regenerated to keep \`npm ci\` aligned (preempts the EUSAGE race fixed in #193)

🤖 Generated with [Claude Code](https://claude.com/claude-code)