### PR TITLE
Plan introspection: pass destination-side asset to InboundTransferHook

### DIFF
--- a/skeleton/package-lock.json
+++ b/skeleton/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-  "version": "0.28.11",
+  "version": "0.28.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-      "version": "0.28.11",
+      "version": "0.28.12",
       "license": "TBD",
       "dependencies": {
         "axios": "1.11.0",

--- a/skeleton/package.json
+++ b/skeleton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-  "version": "0.28.11",
+  "version": "0.28.12",
   "description": "",
   "homepage": "https://ownera.io/",
   "main": "dist/index.js",

--- a/skeleton/src/models/model.ts
+++ b/skeleton/src/models/model.ts
@@ -139,7 +139,15 @@ export type HoldInstruction = {
 
 export type ReleaseInstruction = {
   type: 'release';
+  /** Source-side binding of the asset (the adapter's local resource when outbound). */
   asset: Asset;
+  /**
+   * Destination-side binding of the asset (the adapter's local resource when
+   * inbound). In cross-org DvP each side binds the same on-chain token as its
+   * own FinP2P resource, so this can differ from `asset`. Consumers that act
+   * on the destination side (e.g. InboundTransferHook) must read this field.
+   */
+  destinationAsset: Asset;
   source: FinIdAccount;
   destination: FinIdAccount;
   amount: string;
@@ -154,7 +162,15 @@ export type IssueInstruction = {
 
 export type TransferInstruction = {
   type: 'transfer';
+  /** Source-side binding of the asset (the adapter's local resource when outbound). */
   asset: Asset;
+  /**
+   * Destination-side binding of the asset (the adapter's local resource when
+   * inbound). In cross-org DvP each side binds the same on-chain token as its
+   * own FinP2P resource, so this can differ from `asset`. Consumers that act
+   * on the destination side (e.g. InboundTransferHook) must read this field.
+   */
+  destinationAsset: Asset;
   source: FinIdAccount;
   destination: FinIdAccount;
   amount: string;

--- a/skeleton/src/services/plan/mapper.ts
+++ b/skeleton/src/services/plan/mapper.ts
@@ -172,6 +172,7 @@ const epOperationFromAPI = (instruction: OpComponents['schemas']['executionPlanO
       return {
         type: 'transfer',
         asset: assetFromFinp2pAsset(source.finp2pAccount.asset),
+        destinationAsset: assetFromFinp2pAsset(destination.finp2pAccount.asset),
         source: finIdAccountFromAPI(source),
         destination: finIdAccountFromAPI(destination),
         amount,
@@ -202,6 +203,7 @@ const epOperationFromAPI = (instruction: OpComponents['schemas']['executionPlanO
       return {
         type: 'release',
         asset: assetFromFinp2pAsset(source.finp2pAccount.asset),
+        destinationAsset: assetFromFinp2pAsset(destination.finp2pAccount.asset),
         source: finIdAccountFromAPI(source),
         destination: finIdAccountFromAPI(destination),
         amount,

--- a/skeleton/src/services/plan/service.ts
+++ b/skeleton/src/services/plan/service.ts
@@ -108,7 +108,10 @@ export class PlanApprovalServiceImpl implements PlanApprovalService {
               planId,
               instructionSequence,
               sourceFinId: operation.source.finId,
-              asset: operation.asset,
+              // Use the destination-side asset binding: this hook fires only
+              // when the adapter is on the receiving side, so the local
+              // resource lives on `destination.finp2pAccount.asset`.
+              asset: operation.destinationAsset,
               destinationFinId: operation.destination.finId,
               amount: operation.amount,
               result,
@@ -183,10 +186,13 @@ export class PlanApprovalServiceImpl implements PlanApprovalService {
           }
 
           case 'transfer': {
-            const { asset, source, destination, amount } = operation;
-            if (this.inboundTransferHook) {
+            const { asset, destinationAsset, source, destination, amount } = operation;
+            // Hook fires only for the inbound side (we are the destination):
+            // the adapter's local resource is on the destination's binding.
+            if (this.inboundTransferHook && destination.orgId === this.orgId) {
               await this.inboundTransferHook.onPlannedInboundTransfer(idempotencyKey, {
-                planId, sourceFinId: source.finId, asset, destinationFinId: destination.finId, amount,
+                planId, sourceFinId: source.finId, asset: destinationAsset,
+                destinationFinId: destination.finId, amount,
               });
             }
             if (plugin) {


### PR DESCRIPTION
## Why

In a cross-org DvP transfer / release each side binds the same on-chain token as its own FinP2P resource, so \`source.finp2pAccount.asset\` is the *other* org's binding when the adapter is on the receiving side. The plan-introspection mapper was always pulling \`asset\` from the source, then forwarding it to \`InboundTransferHook\` — leaving the hook with an asset id it couldn't look up locally.

## Scope

**Plan introspection only.** Regular ledger operations (\`POST /api/assets/transfer\`, \`/release\`, etc.) take a single \`asset: Asset\` from the request body via [routes/mapping.ts](skeleton/src/routes/mapping.ts) and feed it into \`TokenService\`/\`EscrowService\` directly — they don't touch \`TransferInstruction\`/\`ReleaseInstruction\`, so they keep their existing \"source.asset = adapter's local resource\" assumption unchanged.

## What

- [\`TransferInstruction\`](skeleton/src/models/model.ts) and [\`ReleaseInstruction\`](skeleton/src/models/model.ts) gain a required \`destinationAsset: Asset\` field. \`asset\` keeps its existing source-side meaning (preserved for outbound consumers like \`validateTransfer\`).
- [Plan-introspection mapper](skeleton/src/services/plan/mapper.ts) populates both fields by reading \`source.finp2pAccount.asset\` and \`destination.finp2pAccount.asset\`.
- [Plan service](skeleton/src/services/plan/service.ts) invokes the inbound hook with \`operation.destinationAsset\`:
  - \`onInboundTransfer\` (post-execution callback path) — already gated by \`destination.orgId === this.orgId\`.
  - \`onPlannedInboundTransfer\` (plan validation path) — added the same \`destination.orgId\` gate; the planned hook was previously firing for any transfer instruction we participated in, including outbound, which never made sense semantically.

## Bumps

- skeleton **0.28.11 → 0.28.12**
- Lockfile regenerated

## Test plan

- [x] 30/30 skeleton tests green
- [ ] CI green on this PR

## Note for downstream adapters

Any code that reads \`operation.destinationAsset\` from a freshly-mapped \`ExecutionPlan\` will get the destination-side resource. Code that wasn't reading the field (the existing pattern is to look at \`operation.asset\`) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)