### PR TITLE
[Feature] Allow FinP2P client to query `orgSettlementAccount`

### DIFF
--- a/finp2p-client/package-lock.json
+++ b/finp2p-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.28.9",
+  "version": "0.28.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-client",
-      "version": "0.28.9",
+      "version": "0.28.10",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.12.2",

--- a/finp2p-client/package.json
+++ b/finp2p-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.28.9",
+  "version": "0.28.10",
   "description": "FinP2P API Client",
   "homepage": "https://ownera.io/",
   "main": "./dist/index.js",

--- a/finp2p-client/src/oss/graphql/assets.graphql
+++ b/finp2p-client/src/oss/graphql/assets.graphql
@@ -37,6 +37,12 @@ query GetAssets($filter: [Filter!]) {
             ledgerAssetInfo {
                 ...assetInfo
             }
+            orgSettlementAccount {
+                wallet {
+                    type
+                    address
+                }
+            }
             intents {
                 nodes {
                     id

--- a/finp2p-client/src/oss/model.ts
+++ b/finp2p-client/src/oss/model.ts
@@ -109,6 +109,11 @@ export type OssAsset = {
     nodes: OssIntent[]
   }
   ledgerAssetInfo: LedgerAssetInfo
+  orgSettlementAccount?: OssNetworkAccount | null
+};
+
+export type OssNetworkAccount = {
+  wallet?: { type: string; address: string } | null
 };
 
 export type OssAssetNodes = {


### PR DESCRIPTION
## Why

Read-side counterpart to PR #197 (which exposed \`orgSettlementAccount\` on the *create*/*update* paths). With #197 we can now write the field; this PR lets consumers fetch it back via the OSS \`GetAssets\` query.

## What

- [\`finp2p-client/src/oss/graphql/assets.graphql\`](finp2p-client/src/oss/graphql/assets.graphql) — extend the \`GetAssets\` selection to pull \`orgSettlementAccount.wallet { type, address }\` alongside \`ledgerAssetInfo\`.
- [\`finp2p-client/src/oss/model.ts\`](finp2p-client/src/oss/model.ts) — add \`orgSettlementAccount?: OssNetworkAccount | null\` to \`OssAsset\` and define \`OssNetworkAccount = { wallet?: { type; address } | null }\`.

Pure additive read-side. No method/facade changes.

## Provenance

Original work by Shakhzod Ikromov (@GRiMe2D) on branch \`feature/query-org-settlement-acc\` (PR #187), which had been opened against earlier master and prereleased as \`finp2p-client-v0.28.9-omnibus.0\`. Since the create/update half (#197) just landed and bumped finp2p-client to \`0.28.9\`, this PR cherry-picks Shakhzod's commit onto current master, drops the now-obsolete prerelease version bump, and bumps to \`0.28.10\` instead. Authorship preserved on the cherry-picked commit. PR #187 will be closed in favor of this one.

## Bumps

- finp2p-client **0.28.9 → 0.28.10**
- Lockfile regenerated

## Test plan

- [x] \`npm run build\` clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)