### PR TITLE
Plan introspection: fire InboundTransferHook for `release` too + extractOrgId gating

### DIFF
--- a/skeleton/package-lock.json
+++ b/skeleton/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-  "version": "0.28.12",
+  "version": "0.28.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-      "version": "0.28.12",
+      "version": "0.28.13",
       "license": "TBD",
       "dependencies": {
         "axios": "1.11.0",

--- a/skeleton/package.json
+++ b/skeleton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-  "version": "0.28.12",
+  "version": "0.28.13",
   "description": "",
   "homepage": "https://ownera.io/",
   "main": "dist/index.js",

--- a/skeleton/src/services/plan/service.ts
+++ b/skeleton/src/services/plan/service.ts
@@ -3,9 +3,19 @@ import {
   ExecutionPlan,
   InstructionResult, PlanFailureReason,
   PlanApprovalService, PlanProposal, InboundTransferHook,
-  PlanApprovalStatus, rejectedPlan, TransferInstruction,
+  PlanApprovalStatus, rejectedPlan, ReleaseInstruction, TransferInstruction,
 } from '../../models';
 import { FinP2PClient, OpComponents } from '@owneraio/finp2p-client';
+
+/**
+ * Extract the org prefix from a FinP2P resource id of the form
+ * `<orgId>:<type>:<uuid>`. Inlined here (rather than imported from
+ * finp2p-client) so the skeleton runtime doesn't pull in finp2p-client
+ * for a one-line operation — keeps the peer-dep purely typeful.
+ */
+function orgIdFromResource(resourceId: string): string {
+  return resourceId.split(':', 1)[0];
+}
 
 import { executionFromAPI } from './mapper';
 import { PluginManager } from '../../plugins';
@@ -97,9 +107,16 @@ export class PlanApprovalServiceImpl implements PlanApprovalService {
       }
 
       const { operation } = instruction;
-      if (operation.type === 'transfer') {
-        const transfer = instruction.operation as TransferInstruction;
-        if (transfer.destination.orgId === this.orgId) {
+      // Inbound hook fires for both `transfer` and `release` — both move value
+      // from a source account to a destination account on a single asset, and
+      // the adapter on the receiving side needs to observe either flavor.
+      // Gate by the destination *asset*'s org (extracted from its resourceId)
+      // rather than the destination account's orgId — the asset binding always
+      // belongs to the destination side's org by construction in v0.28
+      // cross-org DvP, and resourceId carries the prefix unconditionally.
+      if (operation.type === 'transfer' || operation.type === 'release') {
+        const op = operation as TransferInstruction | ReleaseInstruction;
+        if (orgIdFromResource(op.destinationAsset.assetId) === this.orgId) {
           const event = execution.instructionsCompletionEvents
             ?.find(e => e.instructionSequenceNumber === instructionSequence);
           const result = mapInstructionResult(event);
@@ -107,13 +124,13 @@ export class PlanApprovalServiceImpl implements PlanApprovalService {
             await this.inboundTransferHook.onInboundTransfer(idempotencyKey, {
               planId,
               instructionSequence,
-              sourceFinId: operation.source.finId,
+              sourceFinId: op.source.finId,
               // Use the destination-side asset binding: this hook fires only
               // when the adapter is on the receiving side, so the local
               // resource lives on `destination.finp2pAccount.asset`.
-              asset: operation.destinationAsset,
-              destinationFinId: operation.destination.finId,
-              amount: operation.amount,
+              asset: op.destinationAsset,
+              destinationFinId: op.destination.finId,
+              amount: op.amount,
               result,
             });
           } else {
@@ -189,7 +206,8 @@ export class PlanApprovalServiceImpl implements PlanApprovalService {
             const { asset, destinationAsset, source, destination, amount } = operation;
             // Hook fires only for the inbound side (we are the destination):
             // the adapter's local resource is on the destination's binding.
-            if (this.inboundTransferHook && destination.orgId === this.orgId) {
+            // Gate via the destination asset's org prefix.
+            if (this.inboundTransferHook && orgIdFromResource(destinationAsset.assetId) === this.orgId) {
               await this.inboundTransferHook.onPlannedInboundTransfer(idempotencyKey, {
                 planId, sourceFinId: source.finId, asset: destinationAsset,
                 destinationFinId: destination.finId, amount,
@@ -198,6 +216,21 @@ export class PlanApprovalServiceImpl implements PlanApprovalService {
             if (plugin) {
               return await plugin.validateTransfer(source.finId, destination.finId, asset, amount);
             }
+            break;
+          }
+
+          case 'release': {
+            const { destinationAsset, source, destination, amount } = operation;
+            // Same inbound-hook semantics as `transfer`: a release moves value
+            // from a held position on the source side to the destination
+            // account, so the destination's adapter needs to credit locally.
+            if (this.inboundTransferHook && orgIdFromResource(destinationAsset.assetId) === this.orgId) {
+              await this.inboundTransferHook.onPlannedInboundTransfer(idempotencyKey, {
+                planId, sourceFinId: source.finId, asset: destinationAsset,
+                destinationFinId: destination.finId, amount,
+              });
+            }
+            // No plugin call — release isn't a separately validated op.
             break;
           }
 


### PR DESCRIPTION
## Why

A cross-org DvP \`release\` instruction moves value from a held position on the source-side adapter to the destination's account — same "destination side credits locally" shape as a \`transfer\`. The receiving adapter needs to observe both. Today the inbound hook only fires for \`transfer\`, so a destination-side adapter learns nothing when a \`release\` lands in its account.

## What

- **\`proposeInstructionApproval\`** (post-execution callback path) — widen the type check to \`transfer | release\`, narrow the operation to \`TransferInstruction | ReleaseInstruction\`. Both already carry \`destinationAsset\` (PR #196), so the hook payload is identical.
- **\`validatePlan\`** — add a \`case 'release'\` mirroring \`transfer\`'s hook-fire branch. No plugin call (release isn't separately validated by \`PlanApprovalPlugin\`; it's the settle leg of an earlier hold).
- **Receiver-side gate switched from \`op.destination.orgId\` to \`extractOrgId(op.destinationAsset.assetId)\`.** The destination's asset binding always belongs to the destination's org by construction in v0.28 cross-org DvP, and the FinP2P resourceId always carries the \`<orgId>:<type>:<uuid>\` prefix — extracting from there is a more robust signal than relying on \`account.orgId\` being populated on every plan-side shape we read. Same change applied to both callsites.

## Bumps

- skeleton **0.28.12 → 0.28.13**
- Lockfile regenerated

## Test plan

- [x] 30/30 skeleton tests green
- [ ] CI green on this PR

## Side note for the operator

Field reports a \`release\` HTTP body that doesn't carry \`orgId\` on the source/destination accounts (only \`finId\`, \`asset\`, \`ledgerAccount\`). That's the regular \`POST /api/assets/release\` body shape and is unrelated to the inbound hook (which fires from plan-introspection where the plan instruction has full context). Adapters on the source side that need to identify a side from the regular API body can use the same \`extractOrgId(asset.resourceId)\` trick — the resourceId prefix carries the org reliably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)