### PR TITLE
vanilla-service: thread EscrowDelegate.transactionId into receipts

### DIFF
--- a/vanilla-service/package-lock.json
+++ b/vanilla-service/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@owneraio/finp2p-vanilla-service",
-  "version": "0.28.2",
+  "version": "0.28.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-vanilla-service",
-      "version": "0.28.2",
+      "version": "0.28.3",
       "license": "TBD",
       "dependencies": {
-        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.9",
+        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.13",
         "bs58": "^6.0.0",
         "pg": "^8.15.6",
         "winston": "^3.18.3"
@@ -1420,9 +1420,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-nodejs-skeleton-adapter": {
-      "version": "0.28.9",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.9/a71ce7777fe5194dde5a1ab21654800d1173a060",
-      "integrity": "sha512-DRG7VZ3gqDYCE0Ib6IgLQkP98ioLneOha3aKo4ykTkqiphYs7S6o2YTlASOMv7MF1rmFpHWP2IUalG3+w2GddQ==",
+      "version": "0.28.13",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.13/042ebf90cfc7ea5550649ead0f550822ba435953",
+      "integrity": "sha512-fe8gu7yED7pHx2JwC91JNErJJ72KYKKkSpk6B+CHYvmsPoHp45qgvCUU1/4ItsU83nkkCiDFoIxKafBqYH5MDA==",
       "license": "TBD",
       "dependencies": {
         "axios": "1.11.0",

--- a/vanilla-service/package.json
+++ b/vanilla-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-vanilla-service",
-  "version": "0.28.2",
+  "version": "0.28.3",
   "description": "Vanilla DB ledger service for FinP2P adapters — per-investor balance segregation in PostgreSQL",
   "main": "./dist/index.js",
   "types": "dist/index.d.ts",
@@ -20,7 +20,7 @@
   "author": "",
   "license": "TBD",
   "dependencies": {
-    "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.9",
+    "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.13",
     "bs58": "^6.0.0",
     "pg": "^8.15.6",
     "winston": "^3.18.3"

--- a/vanilla-service/src/service.ts
+++ b/vanilla-service/src/service.ts
@@ -175,6 +175,7 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
 
     const tx = await this.storage.lock(source.finId, quantity, asset.assetId, details, asset.assetType);
 
+    let extTransactionId: string | undefined;
     if (this.escrowDelegate) {
       const result = await this.escrowDelegate.hold(
         idempotencyKey, source, destination, asset, quantity, operationId, exCtx,
@@ -185,10 +186,11 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
         }, asset.assetType);
         return failedReceiptOperation(1, result.error);
       }
+      extTransactionId = result.transactionId;
     }
 
     const receipt = buildReceipt(
-      tx, asset, source, destination, quantity, 'hold', exCtx, operationId,
+      tx, asset, source, destination, quantity, 'hold', exCtx, operationId, extTransactionId,
     );
     return successfulReceiptOperation(receipt);
   }
@@ -200,6 +202,7 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
   ): Promise<ReceiptOperation> {
     getLogger().info('Release operation', { source: source.finId, destination: destination.finId, quantity, operationId });
 
+    let extTransactionId: string | undefined;
     if (this.escrowDelegate) {
       const result = await this.escrowDelegate.release(
         idempotencyKey, source, destination, asset, quantity, operationId, exCtx,
@@ -207,6 +210,7 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
       if (!result.success) {
         return failedReceiptOperation(1, result.error);
       }
+      extTransactionId = result.transactionId;
     }
 
     await this.storage.ensureAccount(destination.finId, asset.assetId, asset.assetType);
@@ -219,7 +223,7 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
       }, asset.assetType,
     );
     const receipt = buildReceipt(
-      tx, asset, source, destination, quantity, 'release', exCtx, operationId,
+      tx, asset, source, destination, quantity, 'release', exCtx, operationId, extTransactionId,
     );
     return successfulReceiptOperation(receipt);
   }
@@ -231,6 +235,7 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
   ): Promise<ReceiptOperation> {
     getLogger().info('Rollback operation', { source: source.finId, quantity, operationId });
 
+    let extTransactionId: string | undefined;
     if (this.escrowDelegate) {
       const result = await this.escrowDelegate.rollback(
         idempotencyKey, source, asset, quantity, operationId, exCtx,
@@ -238,6 +243,7 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
       if (!result.success) {
         return failedReceiptOperation(1, result.error);
       }
+      extTransactionId = result.transactionId;
     }
 
     const tx = await this.storage.unlock(source.finId, quantity, asset.assetId, {
@@ -248,7 +254,7 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
     }, asset.assetType);
 
     const receipt = buildReceipt(
-      tx, asset, source, undefined, quantity, 'release', exCtx, operationId,
+      tx, asset, source, undefined, quantity, 'release', exCtx, operationId, extTransactionId,
     );
     return successfulReceiptOperation(receipt);
   }


### PR DESCRIPTION
## Why

The transfer flow already captures \`extResult.transactionId\` from the \`TransferDelegate\` and stamps it onto the receipt via \`buildReceipt\`'s \`externalTransactionId\` arg ([service.ts:115-117](vanilla-service/src/service.ts#L115-L117)). The three escrow flows (\`hold\` / \`release\` / \`rollback\`) ran the \`EscrowDelegate\` but discarded its returned \`transactionId\`, leaving the receipt's \`transactionDetails.transactionId\` defaulted to the local DB tx id — losing the on-chain link the delegate just established.

## What

Three callsites updated, same pattern in each:

\`\`\`ts
let extTransactionId: string | undefined;
if (this.escrowDelegate) {
  const result = await this.escrowDelegate.<op>(...);
  if (!result.success) { /* unlock + fail */ }
  extTransactionId = result.transactionId;
}
// ... storage step ...
const receipt = buildReceipt(tx, asset, source, destination, quantity, '<op>', exCtx, operationId, extTransactionId);
\`\`\`

\`buildReceipt\`'s 9th arg already supports \`externalTransactionId\` — it overrides \`tx.id\` for \`transactionDetails.transactionId\` when set ([utils.ts:28](vanilla-service/src/utils.ts#L28)). No interface or type changes; just plumbing through what the delegate already returns.

Symmetric with the transfer path now: in either flow, when an external delegate is wired, its \`transactionId\` is what surfaces on the receipt — operators get a single id that ties the local row, the receipt, and the chain transaction together.

## Bumps

- vanilla-service **0.28.2 → 0.28.3**
- Lockfile regenerated

## Test plan

- [x] 59/59 vanilla-service tests green
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)