### PR TITLE
ExecutionContext: thread counterpartyAssetId from destination.asset

### DIFF
--- a/skeleton/package-lock.json
+++ b/skeleton/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-  "version": "0.28.13",
+  "version": "0.28.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-      "version": "0.28.13",
+      "version": "0.28.14",
       "license": "TBD",
       "dependencies": {
         "axios": "1.11.0",

--- a/skeleton/package.json
+++ b/skeleton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-  "version": "0.28.13",
+  "version": "0.28.14",
   "description": "",
   "homepage": "https://ownera.io/",
   "main": "dist/index.js",

--- a/skeleton/src/models/model.ts
+++ b/skeleton/src/models/model.ts
@@ -51,6 +51,7 @@ export type LedgerAccount = {
 export type ExecutionContext = {
   planId: string
   sequence: number
+  counterpartyAssetId?: string
 };
 
 export type ErrorDetails = {

--- a/skeleton/src/routes/mapping.ts
+++ b/skeleton/src/routes/mapping.ts
@@ -91,16 +91,26 @@ export const depositPayoutAccountToAPI = (dest: Destination): components['schema
   return { finId, account: { type: 'finId', finId } };
 };
 
-export const executionContextFromAPI = (ep: components['schemas']['executionContext']): ExecutionContext => {
+export const executionContextFromAPI = (
+  ep: components['schemas']['executionContext'],
+  counterpartyAssetId?: string,
+): ExecutionContext => {
   const { executionPlanId, instructionSequenceNumber } = ep;
-  return { planId: executionPlanId, sequence: instructionSequenceNumber };
+  return {
+    planId: executionPlanId,
+    sequence: instructionSequenceNumber,
+    counterpartyAssetId,
+  };
 };
 
-export const executionContextOptFromAPI = (ep: components['schemas']['executionContext'] | undefined): ExecutionContext | undefined => {
+export const executionContextOptFromAPI = (
+  ep: components['schemas']['executionContext'] | undefined,
+  counterpartyAssetId?: string,
+): ExecutionContext | undefined => {
   if (!ep) {
     return undefined;
   }
-  return executionContextFromAPI(ep);
+  return executionContextFromAPI(ep, counterpartyAssetId);
 };
 
 export const assetBindingFromAPI = (assetBind: components['schemas']['ledgerAssetBinding']): AssetBind => {

--- a/skeleton/src/routes/routes.ts
+++ b/skeleton/src/routes/routes.ts
@@ -179,7 +179,7 @@ export const register = (app: Application,
       const dst = destinationFromAPI(destination);
       const ast = assetFromAPI(source.asset);
       const sgn = signatureFromAPI(signature);
-      const exCtx = executionContextOptFromAPI(executionContext);
+      const exCtx = executionContextOptFromAPI(executionContext, destination.asset?.resourceId);
 
       const rsp = await tokenService.transfer(ik, nonce, src, dst, ast, quantity, sgn, exCtx);
 
@@ -222,7 +222,7 @@ export const register = (app: Application,
       const dst = destinationOptFromAPI(destination);
       const ast = assetFromAPI(source.asset);
       const sgn = signatureFromAPI(signature);
-      const exCtx = executionContextOptFromAPI(executionContext);
+      const exCtx = executionContextOptFromAPI(executionContext, destination?.asset?.resourceId);
 
       const rsp = await escrowService.hold(ik, nonce, src, dst, ast, quantity, sgn, operationId, exCtx);
       res.json(receiptOperationToAPI(rsp));
@@ -238,7 +238,7 @@ export const register = (app: Application,
       const src = sourceFromAPI(source);
       const dst = destinationFromAPI(destination);
       const ast = assetFromAPI(source.asset);
-      const exCtx = executionContextOptFromAPI(executionContext);
+      const exCtx = executionContextOptFromAPI(executionContext, destination.asset?.resourceId);
 
       const rsp = await escrowService.release(ik, src, dst, ast, quantity, operationId, exCtx);
 


### PR DESCRIPTION
## Why

In v0.28 cross-org DvP, each side binds the same on-chain token as its own FinP2P resource. The source-side adapter handling a transfer / release / hold sees \`source.asset\` (its own binding) on the request, while \`destination.asset.resourceId\` carries the counterparty's binding for the same token. The skeleton's mapping layer was dropping that destination-asset on the floor — adapters that wanted to construct a bilateral receipt (showing both legs of the move) had no way to learn the other side.

You said: "we only need it for receipt building... let's extend the execution context type to include optional counterpartyAssetId which will take the destination asset value." — that's what this is.

## What

Two-part change, both inside skeleton.

**1. Domain model — \`ExecutionContext\`** ([skeleton/src/models/model.ts](skeleton/src/models/model.ts)):

\`\`\`ts
export type ExecutionContext = {
  planId: string;
  sequence: number;
  /** Resource id of the counterparty's asset binding (set on transfer/release/hold). */
  counterpartyAssetId?: string;
};
\`\`\`

This is the **internal** domain type, not the wire OpenAPI schema. The wire \`executionContext\` schema (planId/sequence) is unchanged — no router-side update needed.

**2. Route handlers — populate from \`destination.asset.resourceId\`**

\`executionContextOptFromAPI\` ([skeleton/src/routes/mapping.ts](skeleton/src/routes/mapping.ts)) gains an optional second arg \`counterpartyAssetId\` that gets stamped onto the resulting context. Three route handlers wire it through:

- \`POST /api/assets/transfer\` → \`destination.asset.resourceId\`
- \`POST /api/assets/release\` → \`destination.asset.resourceId\`
- \`POST /api/assets/hold\` → \`destination?.asset?.resourceId\` (destination is optional on hold)

\`issue\` and \`redeem\` are deliberately not threaded — they're single-sided (issue has no source asset, redeem has no destination asset).

## Why not change the service signatures

Adding a parameter to \`TokenService.transfer\` / \`EscrowService.release\` etc. would ripple through every adapter implementation in the wild. Threading via \`ExecutionContext\` keeps the service contract stable: implementations that don't care continue to ignore exCtx, ones that build bilateral receipts read \`exCtx.counterpartyAssetId\` during receipt construction.

## Bumps

- skeleton **0.28.13 → 0.28.14**
- Lockfile regenerated

## Test plan

- [x] 30/30 skeleton tests green
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)