### PR TITLE
receiptToAPI: surface counterpartyAssetId on wire destination.asset

### DIFF
--- a/skeleton/package-lock.json
+++ b/skeleton/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-  "version": "0.28.14",
+  "version": "0.28.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-      "version": "0.28.14",
+      "version": "0.28.15",
       "license": "TBD",
       "dependencies": {
         "axios": "1.11.0",

--- a/skeleton/package.json
+++ b/skeleton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-  "version": "0.28.14",
+  "version": "0.28.15",
   "description": "",
   "homepage": "https://ownera.io/",
   "main": "dist/index.js",

--- a/skeleton/src/routes/mapping.ts
+++ b/skeleton/src/routes/mapping.ts
@@ -458,13 +458,23 @@ export const receiptToAPI = (receipt: Receipt): components['schemas']['receipt']
     proof,
     timestamp,
   } = receipt;
-  const apiAsset = assetToAPI(asset);
+  const sourceAsset = assetToAPI(asset);
+  // Cross-org DvP: each side binds the same on-chain token as its own FinP2P
+  // resource. The service receives the destination's binding via
+  // `exCtx.counterpartyAssetId` and lets it ride through on the in-memory
+  // receipt's tradeDetails.executionContext. Here we use it to populate the
+  // destination side of the wire account schema; the wire executionContext
+  // gets stripped to {planId, sequence} by `executionContextOptToAPI`.
+  const counterpartyAssetId = tradeDetails.executionContext?.counterpartyAssetId;
+  const destinationAsset = counterpartyAssetId
+    ? { ...sourceAsset, resourceId: counterpartyAssetId }
+    : sourceAsset;
   return {
     id,
     quantity,
     timestamp,
-    source: source ? { finId: source.finId, asset: apiAsset, ledgerAccount: ledgerAccountToAPI(source.account) } : undefined,
-    destination: destination ? { finId: destination.finId, asset: apiAsset, ledgerAccount: ledgerAccountToAPI(destination.account) } : undefined,
+    source: source ? { finId: source.finId, asset: sourceAsset, ledgerAccount: ledgerAccountToAPI(source.account) } : undefined,
+    destination: destination ? { finId: destination.finId, asset: destinationAsset, ledgerAccount: ledgerAccountToAPI(destination.account) } : undefined,
     operationType: operationType as components['schemas']['operationType'],
     tradeDetails: tradeDetailsToAPI(tradeDetails),
     transactionDetails: transactionDetailsToAPI(transactionDetails),


### PR DESCRIPTION
## Why

The DLT-adapter API receipt schema ([skeleton/apis/dlt-adapter-api.yaml#L1247](skeleton/apis/dlt-adapter-api.yaml#L1247)) has \`source: account\` and \`destination: account\`, where each \`account = { asset, finId, ledgerAccount }\` — so the wire **natively** supports a per-side asset. Until 0.28.14, [\`receiptToAPI\`](skeleton/src/routes/mapping.ts) populated both sides with the same \`receipt.asset\`, which is wrong for cross-org DvP where each org binds the same on-chain token as its own FinP2P resource.

PR #201 (0.28.14) added \`ExecutionContext.counterpartyAssetId\` as a pass-through input on the service contract. This PR closes the loop on the wire side.

## What

Five lines in [\`receiptToAPI\`](skeleton/src/routes/mapping.ts). Read \`tradeDetails.executionContext.counterpartyAssetId\` from the in-memory receipt and use it as the wire \`destination.asset\`'s \`resourceId\` (carrying \`ledgerIdentifier\` over from the source side since both bind the same on-chain token):

\`\`\`ts
const sourceAsset = assetToAPI(asset);
const counterpartyAssetId = tradeDetails.executionContext?.counterpartyAssetId;
const destinationAsset = counterpartyAssetId
  ? { ...sourceAsset, resourceId: counterpartyAssetId }
  : sourceAsset;
\`\`\`

\`executionContextOptToAPI\` already strips \`counterpartyAssetId\` from the wire \`executionContext\` (it destructures only \`{planId, sequence}\`). Net wire output:

| field | value |
|---|---|
| \`source.asset\` | adapter's local binding |
| \`destination.asset\` | counterparty's binding (when \`exCtx.counterpartyAssetId\` is set) |
| \`tradeDetails.executionContext\` | \`{executionPlanId, instructionSequenceNumber}\` only |

## What did NOT change

- \`Receipt\` domain type — unchanged.
- \`Destination\` domain type — unchanged.
- Service-method signatures — unchanged.
- \`exCtx.counterpartyAssetId\` is service-input plumbing only; it doesn't surface on the wire \`executionContext\` and doesn't require a new field on any domain type. The single in-memory \`receipt.asset\` continues to represent the source side; the per-side split happens at the wire boundary.

## Bumps

- skeleton **0.28.14 → 0.28.15**
- Lockfile regenerated

## Test plan

- [x] 30/30 skeleton tests green
- [ ] CI green on this PR

## vanilla-service

No code change required. Its existing \`buildReceipt\` already passes the whole \`exCtx\` into \`tradeDetails.executionContext\`, so the wire mapper picks up \`counterpartyAssetId\` from there. Just bump the skeleton dep on the next vanilla-service patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)