### PR TITLE
vanilla-service: bump skeleton dep to ^0.28.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 cache
 /adapter-tests/.npmrc
 .codex
+.claude

--- a/vanilla-service/package-lock.json
+++ b/vanilla-service/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@owneraio/finp2p-vanilla-service",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-vanilla-service",
-      "version": "0.28.3",
+      "version": "0.28.4",
       "license": "TBD",
       "dependencies": {
-        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.13",
+        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.15",
         "bs58": "^6.0.0",
         "pg": "^8.15.6",
         "winston": "^3.18.3"
@@ -1420,9 +1420,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-nodejs-skeleton-adapter": {
-      "version": "0.28.13",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.13/042ebf90cfc7ea5550649ead0f550822ba435953",
-      "integrity": "sha512-fe8gu7yED7pHx2JwC91JNErJJ72KYKKkSpk6B+CHYvmsPoHp45qgvCUU1/4ItsU83nkkCiDFoIxKafBqYH5MDA==",
+      "version": "0.28.15",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.15/990156ffae13b881f4066186b117d73927c5edd9",
+      "integrity": "sha512-YpIzwIHIqfgbgnpcyNN5YMGUZy5TotpndCsoTxNXx0+3/JNRbKBg2uCwzWWuu2DOQymMn8A4zMgbjwaVhJX0Dg==",
       "license": "TBD",
       "dependencies": {
         "axios": "1.11.0",

--- a/vanilla-service/package.json
+++ b/vanilla-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-vanilla-service",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "description": "Vanilla DB ledger service for FinP2P adapters — per-investor balance segregation in PostgreSQL",
   "main": "./dist/index.js",
   "types": "dist/index.d.ts",
@@ -20,7 +20,7 @@
   "author": "",
   "license": "TBD",
   "dependencies": {
-    "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.13",
+    "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.15",
     "bs58": "^6.0.0",
     "pg": "^8.15.6",
     "winston": "^3.18.3"


### PR DESCRIPTION
## Why

Skeleton 0.28.15 (PR #202) wires \`exCtx.counterpartyAssetId\` through to the wire receipt's \`destination.asset.resourceId\` — purely in skeleton's \`receiptToAPI\`. vanilla-service's \`buildReceipt\` already passes the whole \`exCtx\` into \`receipt.tradeDetails.executionContext\`, which is exactly where the skeleton mapper now reads it from. So no vanilla-service code change is needed; just floor the skeleton dep range so consumers using vanilla-service 0.28.4+ pick up the new wire behavior.

## Changes

- \`@owneraio/finp2p-nodejs-skeleton-adapter\`: \`^0.28.13\` → \`^0.28.15\`
- vanilla-service: **0.28.3 → 0.28.4**
- Lockfile regenerated; resolves skeleton to 0.28.15
- \`.gitignore\`: add \`.claude\` (untrack a session lock file accidentally captured)

## Test plan

- [x] 59/59 vanilla-service tests green against skeleton 0.28.15
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)