### PR TITLE
sample-adapter: bump skeleton ^0.28.15 + finp2p-client ^0.28.10

### DIFF
--- a/sample-adapter/package-lock.json
+++ b/sample-adapter/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@owneraio/sample-adapter",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/sample-adapter",
-      "version": "0.28.0",
+      "version": "0.28.1",
       "license": "ISC",
       "dependencies": {
-        "@owneraio/finp2p-client": "^0.28.0",
-        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.9",
+        "@owneraio/finp2p-client": "^0.28.10",
+        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.15",
         "axios": "1.11.0",
         "ethers": "^6.11.1",
         "express": "5.0.0",
@@ -2651,9 +2651,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-client": {
-      "version": "0.28.7",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-client/0.28.7/55adcf40750476d6542eba321e1ffdde355c1411",
-      "integrity": "sha512-VeuXp5A0VLx+UHQCrrzszdnUU9yytkm7Oym1zViaLRIumlPSBEpZ9V6vJD5CO2PScwrDHgisANGPZGJfsuMlRg==",
+      "version": "0.28.10",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-client/0.28.10/50248ec77a18ab0fe78bf5aea7f67b6b92777209",
+      "integrity": "sha512-yi1VWDfsA8DRlcV/MiOqdyrllZ9vsAp31H/ztd9xypyH7VGVNXb2qA8STsJnkANi/INSNJZGo2BiOEjUWBBAwg==",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.12.2",
@@ -2683,9 +2683,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-nodejs-skeleton-adapter": {
-      "version": "0.28.10",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.10/6b3aef3c1708423a7741787762363935f4b569e2",
-      "integrity": "sha512-5XjeH/fNjs05eVgGAaLVKQkXlaohTLc0wHPS1fMvuSiDNxKaGvEqyZEWu0vyZZiGhNWLN+hP505p9D+ak4hLxg==",
+      "version": "0.28.15",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.15/990156ffae13b881f4066186b117d73927c5edd9",
+      "integrity": "sha512-YpIzwIHIqfgbgnpcyNN5YMGUZy5TotpndCsoTxNXx0+3/JNRbKBg2uCwzWWuu2DOQymMn8A4zMgbjwaVhJX0Dg==",
       "license": "TBD",
       "dependencies": {
         "axios": "1.11.0",

--- a/sample-adapter/package.json
+++ b/sample-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/sample-adapter",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "description": "",
   "main": "./dist/index.js",
   "files": [
@@ -19,8 +19,8 @@
     "registry": "https://npm.pkg.github.com"
   },
   "dependencies": {
-    "@owneraio/finp2p-client": "^0.28.0",
-    "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.9",
+    "@owneraio/finp2p-client": "^0.28.10",
+    "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.15",
     "axios": "1.11.0",
     "ethers": "^6.11.1",
     "express": "5.0.0",


### PR DESCRIPTION
## Why

Floor the skeleton dep so the reference adapter exercises the wire \`counterpartyAssetId\` routing introduced in skeleton 0.28.15 (PR #202 — \`receiptToAPI\` surfaces \`destination.asset\` from \`exCtx.counterpartyAssetId\`). Also pull finp2p-client up to \`^0.28.10\` to match the latest read-side OSS surface (PR #198).

## Changes

| dep | from | to |
|---|---|---|
| \`@owneraio/finp2p-client\` | \`^0.28.0\` | \`^0.28.10\` |
| \`@owneraio/finp2p-nodejs-skeleton-adapter\` | \`^0.28.9\` | \`^0.28.15\` |
| \`@owneraio/adapter-tests\` (dev) | \`^0.28.2\` | unchanged (latest) |
| sample-adapter version | \`0.28.0\` | \`0.28.1\` |

Lockfile regenerated: skeleton resolves to 0.28.15, finp2p-client to 0.28.10.

## Test plan

- [x] 38/38 sample-adapter tests green
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)