### PR TITLE
finp2p-client: flows.ts cleanup + redemption fix (0.28.12)

### DIFF
--- a/finp2p-client/package-lock.json
+++ b/finp2p-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.28.10",
+  "version": "0.28.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-client",
-      "version": "0.28.10",
+      "version": "0.28.11",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.12.2",

--- a/finp2p-client/package-lock.json
+++ b/finp2p-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.28.11",
+  "version": "0.28.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-client",
-      "version": "0.28.11",
+      "version": "0.28.12",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.12.2",

--- a/finp2p-client/package.json
+++ b/finp2p-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.28.11",
+  "version": "0.28.12",
   "description": "FinP2P API Client",
   "homepage": "https://ownera.io/",
   "main": "./dist/index.js",

--- a/finp2p-client/package.json
+++ b/finp2p-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.28.10",
+  "version": "0.28.11",
   "description": "FinP2P API Client",
   "homepage": "https://ownera.io/",
   "main": "./dist/index.js",

--- a/finp2p-client/src/client.ts
+++ b/finp2p-client/src/client.ts
@@ -18,6 +18,10 @@ export class FinP2PClient {
 
   // ── Owner / Profile ──
 
+  async createOwner() {
+    return this.finAPIClient.createOwner();
+  }
+
   async createAsset(...args: Parameters<FinAPIClient['createAsset']>) {
     return this.finAPIClient.createAsset(...args);
   }

--- a/finp2p-client/src/flows.ts
+++ b/finp2p-client/src/flows.ts
@@ -769,8 +769,6 @@ export async function executeRedemptionIntent(client: FinP2PClient, params: Exec
       nonce: hexNonce(),
       issuer: params.issuer.id,
       seller: params.seller.id,
-      // `redemptionIntentExecution.asset` requires both source (seller's holdings)
-      // and destination (optional account on issuer side, asset-only here).
       asset: {
         term: { amount: String(params.assetAmount) },
         instruction: {
@@ -780,6 +778,7 @@ export async function executeRedemptionIntent(client: FinP2PClient, params: Exec
           },
           destinationAccount: {
             asset: finp2pAsset(params.asset),
+            account: finIdAccount(params.issuer.finId, assetOrgId, params.issuer.custodianOrgId),
           },
         },
       },

--- a/finp2p-client/src/flows.ts
+++ b/finp2p-client/src/flows.ts
@@ -121,12 +121,18 @@ export interface CreateAssetParams {
   intentTypes?: Array<'primarySale' | 'buyingIntent' | 'sellingIntent' | 'loanIntent' | 'redemptionIntent' | 'privateOfferIntent' | 'requestForTransferIntent'>;
   /** Logical ledger name, must match the ledgerName registered via /ledger/bind */
   ledger: string;
+  /**
+   * On-chain bind triple. All three (`network`, `tokenId`, `standard`) must be
+   * supplied together to bind to an existing on-chain token; omit all three
+   * for a virtual asset where the ledger record is allocated server-side.
+   * Partial input throws.
+   */
   /** CAIP-2 chain id, e.g. 'eip155:11155111' (Sepolia) */
-  network: string;
+  network?: string;
   /** Token identifier on the ledger (e.g. ERC-20 contract address) */
-  tokenId: string;
+  tokenId?: string;
   /** Token standard, e.g. 'erc20' */
-  standard: string;
+  standard?: string;
   assetPolicies?: FinAPIComponents['schemas']['assetPolicies'];
   /** @deprecated use `metadata` instead */
   config?: string;
@@ -176,6 +182,13 @@ export async function updateAsset(client: FinP2PClient, id: string, params: Upda
 }
 
 export async function createAsset(client: FinP2PClient, params: CreateAssetParams): Promise<string> {
+  const { network, tokenId, standard } = params;
+  const hasAny = network || tokenId || standard;
+  const hasAll = network && tokenId && standard;
+  if (hasAny && !hasAll) {
+    throw new Error(`createAsset: bind requires all of network/tokenId/standard, got ${JSON.stringify({ network, tokenId, standard })}`);
+  }
+
   const res = await unwrapOperation<{ id: string }>(client, client.createAsset({
     name: params.name,
     type: params.type,
@@ -185,12 +198,14 @@ export async function createAsset(client: FinP2PClient, params: CreateAssetParam
     intentTypes: params.intentTypes,
     ledgerAssetBinding: {
       ledger: params.ledger,
-      bind: {
-        assetIdentifierType: 'CAIP-19' as const,
-        network: params.network,
-        tokenId: params.tokenId,
-        standard: params.standard,
-      },
+      ...(hasAll ? {
+        bind: {
+          assetIdentifierType: 'CAIP-19' as const,
+          network,
+          tokenId,
+          standard,
+        },
+      } : {}),
     },
     assetPolicies: params.assetPolicies,
     config: params.config,

--- a/finp2p-client/src/flows.ts
+++ b/finp2p-client/src/flows.ts
@@ -50,39 +50,61 @@ function requireSettlementOrgId(value: string | undefined, side: string): string
 type FetchResult = { data?: unknown; error?: unknown };
 
 /**
- * Resolve an openapi-fetch result to its success body, polling through any
- * async (cid-bearing) `operationBase` response so the synchronous and
- * deferred paths produce the same shape. Throws on `.error` or empty data.
+ * Wrap an openapi-fetch call promise and resolve to its success body, polling
+ * through any async (cid-bearing) `operationBase` response so the synchronous
+ * and deferred paths produce the same shape. Throws on `.error` or empty data.
  *
  * `T` is the **post-completion** body shape — pass it explicitly because
  * openapi-fetch's `data` type unions the 200 success shape with the 202
  * `operationBase`, and we want the caller to commit to the success
  * variant. For example:
  *
- *   const res = await unwrap<{ id: string }>(client, result, 'createAsset');
+ *   const res = await unwrapOperation<{ id: string }>(client, client.createAsset(...));
  *   const id = res.id;
  */
-async function unwrap<T>(
+async function unwrapOperation<T>(
   client: FinP2PClient,
-  result: FetchResult,
-  label: string,
+  call: Promise<FetchResult>,
 ): Promise<T> {
+  const result = await call;
   if (result.error) {
-    throw new Error(`${label}: ${JSON.stringify(result.error)}`);
+    throw new Error(JSON.stringify(result.error));
   }
   const data = result.data;
   if (data == null) {
-    throw new Error(`${label}: empty response`);
+    throw new Error('empty response');
   }
-  const pending = data as { cid?: string; id?: string };
-  if (pending.cid && !pending.id) {
+  const op = data as { cid?: string; id?: string };
+  if (op.cid && !op.id) {
     // Async: the API returned an `operationBase` (cid only). Poll until the
     // operation completes and unwrap the nested `.response` so the polled
     // path produces the same shape as the synchronous path.
-    const completed = await client.waitForOperationCompletion(pending.cid, OP_TIMEOUT);
+    const completed = await client.waitForOperationCompletion(op.cid, OP_TIMEOUT);
     return ((completed as { response?: unknown }).response ?? completed) as T;
   }
   return data as T;
+}
+
+// ── Owner / Profile ──
+
+export interface Investor {
+  id: string;
+  finId: string;
+  orgId: string;
+  custodianOrgId: string;
+}
+
+export async function createOwner(
+  client: FinP2PClient,
+  orgId: string,
+  custodianOrgId: string,
+): Promise<Investor> {
+  const owner = await unwrapOperation<{ id: string }>(client, client.createOwner());
+  const account = await unwrapOperation<{ finId: string }>(
+    client,
+    client.createOwnerAccount(owner.id, { orgId: custodianOrgId }),
+  );
+  return { id: owner.id, finId: account.finId, orgId, custodianOrgId };
 }
 
 // ── Asset creation ──
@@ -150,12 +172,11 @@ export interface UpdateAssetParams {
 }
 
 export async function updateAsset(client: FinP2PClient, id: string, params: UpdateAssetParams): Promise<void> {
-  const result = await client.updateAsset(id, params);
-  await unwrap<unknown>(client, result, 'updateAsset');
+  await unwrapOperation<unknown>(client, client.updateAsset(id, params));
 }
 
 export async function createAsset(client: FinP2PClient, params: CreateAssetParams): Promise<string> {
-  const result = await client.createAsset({
+  const res = await unwrapOperation<{ id: string }>(client, client.createAsset({
     name: params.name,
     type: params.type,
     issuerId: params.issuerId,
@@ -180,9 +201,7 @@ export async function createAsset(client: FinP2PClient, params: CreateAssetParam
     allowPolicyDefaultFallback: params.allowPolicyDefaultFallback,
     decimalPlaces: params.decimalPlaces,
     autoShare: params.autoShare,
-  });
-
-  const res = await unwrap<{ id: string }>(client, result, 'createAsset');
+  }));
   if (!res.id) throw new Error('Failed to create asset');
   return res.id;
 }
@@ -204,7 +223,7 @@ export async function createPrimarySale(client: FinP2PClient, params: PrimarySal
   const assetOrgId = extractOrgId(params.asset.id);
   const { start, end } = intentWindow();
 
-  const result = await client.createIntent(params.asset.id, {
+  const res = await unwrapOperation<{ id: string }>(client, client.createIntent(params.asset.id, {
     start, end,
     intent: {
       type: 'primarySale',
@@ -228,9 +247,7 @@ export async function createPrimarySale(client: FinP2PClient, params: PrimarySal
         },
       }],
     },
-  });
-
-  const res = await unwrap<{ id: string }>(client, result, 'createPrimarySale');
+  }));
   if (!res.id) throw new Error('Failed to create primary sale intent');
   return res.id;
 }
@@ -250,7 +267,7 @@ export async function createSellingIntent(client: FinP2PClient, params: SellingI
   const assetOrgId = extractOrgId(params.asset.id);
   const { start, end } = intentWindow();
 
-  const result = await client.createIntent(params.asset.id, {
+  const res = await unwrapOperation<{ id: string }>(client, client.createIntent(params.asset.id, {
     start, end,
     intent: {
       type: 'sellingIntent',
@@ -275,9 +292,7 @@ export async function createSellingIntent(client: FinP2PClient, params: SellingI
       }],
       signaturePolicy: { type: 'manualPolicy' },
     },
-  });
-
-  const res = await unwrap<{ id: string }>(client, result, 'createSellingIntent');
+  }));
   if (!res.id) throw new Error('Failed to create selling intent');
   return res.id;
 }
@@ -297,7 +312,7 @@ export async function createBuyingIntent(client: FinP2PClient, params: BuyingInt
   const assetOrgId = extractOrgId(params.asset.id);
   const { start, end } = intentWindow();
 
-  const result = await client.createIntent(params.asset.id, {
+  const res = await unwrapOperation<{ id: string }>(client, client.createIntent(params.asset.id, {
     start, end,
     intent: {
       type: 'buyingIntent',
@@ -322,9 +337,7 @@ export async function createBuyingIntent(client: FinP2PClient, params: BuyingInt
       },
       signaturePolicy: { type: 'manualPolicy' },
     },
-  });
-
-  const res = await unwrap<{ id: string }>(client, result, 'createBuyingIntent');
+  }));
   if (!res.id) throw new Error('Failed to create buying intent');
   return res.id;
 }
@@ -344,7 +357,7 @@ export async function createRedemptionIntent(client: FinP2PClient, params: Redem
   const assetOrgId = extractOrgId(params.asset.id);
   const { start, end } = intentWindow();
 
-  const result = await client.createIntent(params.asset.id, {
+  const res = await unwrapOperation<{ id: string }>(client, client.createIntent(params.asset.id, {
     start, end,
     intent: {
       type: 'redemptionIntent',
@@ -369,9 +382,7 @@ export async function createRedemptionIntent(client: FinP2PClient, params: Redem
       }],
       signaturePolicy: { type: 'manualPolicy' },
     },
-  });
-
-  const res = await unwrap<{ id: string }>(client, result, 'createRedemptionIntent');
+  }));
   if (!res.id) throw new Error('Failed to create redemption intent');
   return res.id;
 }
@@ -424,7 +435,7 @@ export async function createLoanIntent(client: FinP2PClient, params: LoanIntentP
     }
     : undefined;
 
-  const result = await client.createIntent(params.asset.id, {
+  const res = await unwrapOperation<{ id: string }>(client, client.createIntent(params.asset.id, {
     start, end,
     intent: {
       type: 'loanIntent',
@@ -447,9 +458,7 @@ export async function createLoanIntent(client: FinP2PClient, params: LoanIntentP
       }],
       loanInstruction,
     },
-  });
-
-  const res = await unwrap<{ id: string }>(client, result, 'createLoanIntent');
+  }));
   if (!res.id) throw new Error('Failed to create loan intent');
   return res.id;
 }
@@ -490,7 +499,7 @@ export async function createRequestForTransferIntent(
       },
     };
 
-  const result = await client.createIntent(params.asset.id, {
+  const res = await unwrapOperation<{ id: string }>(client, client.createIntent(params.asset.id, {
     start, end,
     intent: {
       type: 'requestForTransferIntent',
@@ -502,9 +511,7 @@ export async function createRequestForTransferIntent(
       },
       signaturePolicy: { type: 'manualPolicy' },
     },
-  });
-
-  const res = await unwrap<{ id: string }>(client, result, 'createRequestForTransferIntent');
+  }));
   if (!res.id) throw new Error('Failed to create request-for-transfer intent');
   return res.id;
 }
@@ -541,7 +548,7 @@ export async function executePrimarySale(client: FinP2PClient, params: ExecutePr
   const buyerSettlementOrgId  = requireSettlementOrgId(params.buyerSettlementOrgId  ?? params.settlementOrgId,  'buyer');
   const sellerSettlementOrgId = requireSettlementOrgId(params.sellerSettlementOrgId ?? params.settlementOrgId, 'seller');
 
-  const result = await client.executeIntent({
+  const res = await unwrapOperation<{ executionPlanId: string }>(client, client.executeIntent({
     user: params.seller.id,
     intentId: params.intentId,
     executionId: params.executionId,
@@ -578,9 +585,7 @@ export async function executePrimarySale(client: FinP2PClient, params: ExecutePr
         },
       },
     },
-  });
-
-  const res = await unwrap<{ executionPlanId: string }>(client, result, 'executePrimarySale');
+  }));
   if (!res.executionPlanId) throw new Error('Failed to execute primary sale');
   return res.executionPlanId;
 }
@@ -609,7 +614,7 @@ export async function executeSellingIntent(client: FinP2PClient, params: Execute
   const buyerSettlementOrgId  = requireSettlementOrgId(params.buyerSettlementOrgId  ?? params.settlementOrgId,  'buyer');
   const sellerSettlementOrgId = requireSettlementOrgId(params.sellerSettlementOrgId ?? params.settlementOrgId, 'seller');
 
-  const result = await client.executeIntent({
+  const res = await unwrapOperation<{ executionPlanId: string }>(client, client.executeIntent({
     user: params.seller.id,
     intentId: params.intentId,
     executionId: params.executionId,
@@ -644,9 +649,7 @@ export async function executeSellingIntent(client: FinP2PClient, params: Execute
         },
       },
     },
-  });
-
-  const res = await unwrap<{ executionPlanId: string }>(client, result, 'executeSellingIntent');
+  }));
   if (!res.executionPlanId) throw new Error('Failed to execute selling intent');
   return res.executionPlanId;
 }
@@ -675,7 +678,7 @@ export async function executeBuyingIntent(client: FinP2PClient, params: ExecuteB
   const buyerSettlementOrgId  = requireSettlementOrgId(params.buyerSettlementOrgId  ?? params.settlementOrgId,  'buyer');
   const sellerSettlementOrgId = requireSettlementOrgId(params.sellerSettlementOrgId ?? params.settlementOrgId, 'seller');
 
-  const result = await client.executeIntent({
+  const res = await unwrapOperation<{ executionPlanId: string }>(client, client.executeIntent({
     user: params.buyer.id,
     intentId: params.intentId,
     executionId: params.executionId,
@@ -710,9 +713,7 @@ export async function executeBuyingIntent(client: FinP2PClient, params: ExecuteB
         },
       },
     },
-  });
-
-  const res = await unwrap<{ executionPlanId: string }>(client, result, 'executeBuyingIntent');
+  }));
   if (!res.executionPlanId) throw new Error('Failed to execute buying intent');
   return res.executionPlanId;
 }
@@ -744,7 +745,7 @@ export async function executeRedemptionIntent(client: FinP2PClient, params: Exec
   const issuerSettlementOrgId = requireSettlementOrgId(params.issuerSettlementOrgId ?? params.settlementOrgId, 'issuer');
   const sellerSettlementOrgId = requireSettlementOrgId(params.sellerSettlementOrgId ?? params.settlementOrgId, 'seller');
 
-  const result = await client.executeIntent({
+  const res = await unwrapOperation<{ executionPlanId: string }>(client, client.executeIntent({
     user: params.issuer.id,
     intentId: params.intentId,
     executionId: params.executionId,
@@ -781,9 +782,7 @@ export async function executeRedemptionIntent(client: FinP2PClient, params: Exec
         },
       },
     },
-  });
-
-  const res = await unwrap<{ executionPlanId: string }>(client, result, 'executeRedemptionIntent');
+  }));
   if (!res.executionPlanId) throw new Error('Failed to execute redemption intent');
   return res.executionPlanId;
 }
@@ -805,7 +804,7 @@ export async function executeLoanIntent(client: FinP2PClient, params: ExecuteLoa
   const assetOrgId = extractOrgId(params.asset.id);
   const user = params.executorType === 'borrower' ? params.borrower.id : params.lender.id;
 
-  const result = await client.executeIntent({
+  const res = await unwrapOperation<{ executionPlanId: string }>(client, client.executeIntent({
     user,
     intentId: params.intentId,
     executionId: params.executionId,
@@ -842,9 +841,7 @@ export async function executeLoanIntent(client: FinP2PClient, params: ExecuteLoa
         },
       },
     },
-  });
-
-  const res = await unwrap<{ executionPlanId: string }>(client, result, 'executeLoanIntent');
+  }));
   if (!res.executionPlanId) throw new Error('Failed to execute loan intent');
   return res.executionPlanId;
 }
@@ -888,7 +885,7 @@ export async function executeRequestForTransferIntent(
   // `request`: receiver initiated → sender executes
   const user = params.action === 'send' ? params.receiver.id : params.sender.id;
 
-  const result = await client.executeIntent({
+  const res = await unwrapOperation<{ executionPlanId: string }>(client, client.executeIntent({
     user,
     intentId: params.intentId,
     executionId: params.executionId,
@@ -912,9 +909,7 @@ export async function executeRequestForTransferIntent(
         },
       },
     },
-  });
-
-  const res = await unwrap<{ executionPlanId: string }>(client, result, 'executeRequestForTransferIntent');
+  }));
   if (!res.executionPlanId) throw new Error('Failed to execute request-for-transfer intent');
   return res.executionPlanId;
 }

--- a/finp2p-client/src/flows.ts
+++ b/finp2p-client/src/flows.ts
@@ -47,15 +47,42 @@ function requireSettlementOrgId(value: string | undefined, side: string): string
   return value;
 }
 
-async function unwrap(client: FinP2PClient, result: any, label: string): Promise<any> {
+type FetchResult = { data?: unknown; error?: unknown };
+
+/**
+ * Resolve an openapi-fetch result to its success body, polling through any
+ * async (cid-bearing) `operationBase` response so the synchronous and
+ * deferred paths produce the same shape. Throws on `.error` or empty data.
+ *
+ * `T` is the **post-completion** body shape — pass it explicitly because
+ * openapi-fetch's `data` type unions the 200 success shape with the 202
+ * `operationBase`, and we want the caller to commit to the success
+ * variant. For example:
+ *
+ *   const res = await unwrap<{ id: string }>(client, result, 'createAsset');
+ *   const id = res.id;
+ */
+async function unwrap<T>(
+  client: FinP2PClient,
+  result: FetchResult,
+  label: string,
+): Promise<T> {
   if (result.error) {
     throw new Error(`${label}: ${JSON.stringify(result.error)}`);
   }
   const data = result.data;
-  if (data?.cid && !data.id) {
-    return client.waitForOperationCompletion(data.cid, OP_TIMEOUT);
+  if (data == null) {
+    throw new Error(`${label}: empty response`);
   }
-  return data;
+  const pending = data as { cid?: string; id?: string };
+  if (pending.cid && !pending.id) {
+    // Async: the API returned an `operationBase` (cid only). Poll until the
+    // operation completes and unwrap the nested `.response` so the polled
+    // path produces the same shape as the synchronous path.
+    const completed = await client.waitForOperationCompletion(pending.cid, OP_TIMEOUT);
+    return ((completed as { response?: unknown }).response ?? completed) as T;
+  }
+  return data as T;
 }
 
 // ── Asset creation ──
@@ -124,7 +151,7 @@ export interface UpdateAssetParams {
 
 export async function updateAsset(client: FinP2PClient, id: string, params: UpdateAssetParams): Promise<void> {
   const result = await client.updateAsset(id, params);
-  await unwrap(client, result, 'updateAsset');
+  await unwrap<unknown>(client, result, 'updateAsset');
 }
 
 export async function createAsset(client: FinP2PClient, params: CreateAssetParams): Promise<string> {
@@ -155,10 +182,9 @@ export async function createAsset(client: FinP2PClient, params: CreateAssetParam
     autoShare: params.autoShare,
   });
 
-  const res = await unwrap(client, result, 'createAsset');
-  const assetId = res?.id;
-  if (!assetId) throw new Error('Failed to create asset');
-  return assetId;
+  const res = await unwrap<{ id: string }>(client, result, 'createAsset');
+  if (!res.id) throw new Error('Failed to create asset');
+  return res.id;
 }
 
 // ── Intent creation ──
@@ -204,10 +230,9 @@ export async function createPrimarySale(client: FinP2PClient, params: PrimarySal
     },
   });
 
-  const res = await unwrap(client, result, 'createPrimarySale');
-  const intentId = res?.id;
-  if (!intentId) throw new Error('Failed to create primary sale intent');
-  return intentId;
+  const res = await unwrap<{ id: string }>(client, result, 'createPrimarySale');
+  if (!res.id) throw new Error('Failed to create primary sale intent');
+  return res.id;
 }
 
 export interface SellingIntentParams {
@@ -252,10 +277,9 @@ export async function createSellingIntent(client: FinP2PClient, params: SellingI
     },
   });
 
-  const res = await unwrap(client, result, 'createSellingIntent');
-  const intentId = res?.id;
-  if (!intentId) throw new Error('Failed to create selling intent');
-  return intentId;
+  const res = await unwrap<{ id: string }>(client, result, 'createSellingIntent');
+  if (!res.id) throw new Error('Failed to create selling intent');
+  return res.id;
 }
 
 export interface BuyingIntentParams {
@@ -300,10 +324,9 @@ export async function createBuyingIntent(client: FinP2PClient, params: BuyingInt
     },
   });
 
-  const res = await unwrap(client, result, 'createBuyingIntent');
-  const intentId = res?.id;
-  if (!intentId) throw new Error('Failed to create buying intent');
-  return intentId;
+  const res = await unwrap<{ id: string }>(client, result, 'createBuyingIntent');
+  if (!res.id) throw new Error('Failed to create buying intent');
+  return res.id;
 }
 
 export interface RedemptionIntentParams {
@@ -348,10 +371,9 @@ export async function createRedemptionIntent(client: FinP2PClient, params: Redem
     },
   });
 
-  const res = await unwrap(client, result, 'createRedemptionIntent');
-  const intentId = res?.id;
-  if (!intentId) throw new Error('Failed to create redemption intent');
-  return intentId;
+  const res = await unwrap<{ id: string }>(client, result, 'createRedemptionIntent');
+  if (!res.id) throw new Error('Failed to create redemption intent');
+  return res.id;
 }
 
 /** Loan-specific conditions (required when `loanInstruction` is provided). */
@@ -427,10 +449,9 @@ export async function createLoanIntent(client: FinP2PClient, params: LoanIntentP
     },
   });
 
-  const res = await unwrap(client, result, 'createLoanIntent');
-  const intentId = res?.id;
-  if (!intentId) throw new Error('Failed to create loan intent');
-  return intentId;
+  const res = await unwrap<{ id: string }>(client, result, 'createLoanIntent');
+  if (!res.id) throw new Error('Failed to create loan intent');
+  return res.id;
 }
 
 export interface RequestForTransferIntentParams {
@@ -483,10 +504,9 @@ export async function createRequestForTransferIntent(
     },
   });
 
-  const res = await unwrap(client, result, 'createRequestForTransferIntent');
-  const intentId = res?.id;
-  if (!intentId) throw new Error('Failed to create request-for-transfer intent');
-  return intentId;
+  const res = await unwrap<{ id: string }>(client, result, 'createRequestForTransferIntent');
+  if (!res.id) throw new Error('Failed to create request-for-transfer intent');
+  return res.id;
 }
 
 // ── Intent execution ──
@@ -560,10 +580,9 @@ export async function executePrimarySale(client: FinP2PClient, params: ExecutePr
     },
   });
 
-  const res = await unwrap(client, result, 'executePrimarySale');
-  const planId = res?.executionPlanId ?? res?.response?.executionPlanId;
-  if (!planId) throw new Error('Failed to execute primary sale');
-  return planId;
+  const res = await unwrap<{ executionPlanId: string }>(client, result, 'executePrimarySale');
+  if (!res.executionPlanId) throw new Error('Failed to execute primary sale');
+  return res.executionPlanId;
 }
 
 export interface ExecuteSellingIntentParams {
@@ -627,10 +646,9 @@ export async function executeSellingIntent(client: FinP2PClient, params: Execute
     },
   });
 
-  const res = await unwrap(client, result, 'executeSellingIntent');
-  const planId = res?.executionPlanId ?? res?.response?.executionPlanId;
-  if (!planId) throw new Error('Failed to execute selling intent');
-  return planId;
+  const res = await unwrap<{ executionPlanId: string }>(client, result, 'executeSellingIntent');
+  if (!res.executionPlanId) throw new Error('Failed to execute selling intent');
+  return res.executionPlanId;
 }
 
 export interface ExecuteBuyingIntentParams {
@@ -694,10 +712,9 @@ export async function executeBuyingIntent(client: FinP2PClient, params: ExecuteB
     },
   });
 
-  const res = await unwrap(client, result, 'executeBuyingIntent');
-  const planId = res?.executionPlanId ?? res?.response?.executionPlanId;
-  if (!planId) throw new Error('Failed to execute buying intent');
-  return planId;
+  const res = await unwrap<{ executionPlanId: string }>(client, result, 'executeBuyingIntent');
+  if (!res.executionPlanId) throw new Error('Failed to execute buying intent');
+  return res.executionPlanId;
 }
 
 export interface ExecuteRedemptionIntentParams {
@@ -766,10 +783,9 @@ export async function executeRedemptionIntent(client: FinP2PClient, params: Exec
     },
   });
 
-  const res = await unwrap(client, result, 'executeRedemptionIntent');
-  const planId = res?.executionPlanId ?? res?.response?.executionPlanId;
-  if (!planId) throw new Error('Failed to execute redemption intent');
-  return planId;
+  const res = await unwrap<{ executionPlanId: string }>(client, result, 'executeRedemptionIntent');
+  if (!res.executionPlanId) throw new Error('Failed to execute redemption intent');
+  return res.executionPlanId;
 }
 
 export interface ExecuteLoanIntentParams {
@@ -828,10 +844,9 @@ export async function executeLoanIntent(client: FinP2PClient, params: ExecuteLoa
     },
   });
 
-  const res = await unwrap(client, result, 'executeLoanIntent');
-  const planId = res?.executionPlanId ?? res?.response?.executionPlanId;
-  if (!planId) throw new Error('Failed to execute loan intent');
-  return planId;
+  const res = await unwrap<{ executionPlanId: string }>(client, result, 'executeLoanIntent');
+  if (!res.executionPlanId) throw new Error('Failed to execute loan intent');
+  return res.executionPlanId;
 }
 
 export interface ExecuteRequestForTransferIntentParams {
@@ -899,8 +914,7 @@ export async function executeRequestForTransferIntent(
     },
   });
 
-  const res = await unwrap(client, result, 'executeRequestForTransferIntent');
-  const planId = res?.executionPlanId ?? res?.response?.executionPlanId;
-  if (!planId) throw new Error('Failed to execute request-for-transfer intent');
-  return planId;
+  const res = await unwrap<{ executionPlanId: string }>(client, result, 'executeRequestForTransferIntent');
+  if (!res.executionPlanId) throw new Error('Failed to execute request-for-transfer intent');
+  return res.executionPlanId;
 }


### PR DESCRIPTION
## Summary
- **`unwrap` → `unwrapOperation<T>`**: rename the helper, take the openapi-fetch call promise directly (callers lose the `const result = await client.X(...)` bookkeeping line), and parameterize each call site with the success-body shape (`{ id }` for create/intent helpers, `{ executionPlanId }` for execute helpers). Drops the `?? res?.response?.executionPlanId` fallbacks since the helper flattens polled `operationBase.response` automatically. Label argument removed — error body + stack trace already carry enough context.
- **`createOwner` flow + `Investor` type**: new high-level helper that creates an owner and an account in two calls and returns `{ id, finId, orgId, custodianOrgId }`. Adds a matching `client.createOwner()` delegate on `FinP2PClient`.
- **`createAsset` virtual assets**: `network` / `tokenId` / `standard` are now optional on `CreateAssetParams`. Emit the `bind` block only when all three are supplied; partial input throws. Lets callers create virtual assets (e.g. mint-on-demand primary-sale) through the flow helper instead of dropping to the low-level client method.
- **`executeRedemptionIntent` runtime fix**: spec marks `asset.instruction.destinationAccount` as `finp2pAssetAccountOptional`, but the live router rejects omission with HTTP 4003. Now populated with the issuer's FinId on the asset-binding org.
- Bump 0.28.10 → 0.28.12.

## Test plan
- [x] `npm run build` clean
- [ ] CI green
- [ ] e2e (consumers) — primary sale's account-less source side untested at runtime; will catch in consumers

🤖 Generated with [Claude Code](https://claude.com/claude-code)