### PR TITLE
skeleton: log operation errors in executeAndFinalize (0.28.16)

### DIFF
--- a/skeleton/package-lock.json
+++ b/skeleton/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-  "version": "0.28.15",
+  "version": "0.28.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-      "version": "0.28.15",
+      "version": "0.28.16",
       "license": "TBD",
       "dependencies": {
         "axios": "1.11.0",

--- a/skeleton/package.json
+++ b/skeleton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-  "version": "0.28.15",
+  "version": "0.28.16",
   "description": "",
   "homepage": "https://ownera.io/",
   "main": "dist/index.js",

--- a/skeleton/src/workflows/service.ts
+++ b/skeleton/src/workflows/service.ts
@@ -194,6 +194,7 @@ async function executeAndFinalize(
     const outputs: OperationStatus = await method(...args);
     await finalize(storage, finP2PClient, cid, dbStatus(outputs), outputs);
   } catch (error: any) {
+    logger.error('Operation failed', { method: methodName, cid, ...describeError(error) });
     const wrp = wrappedResponse(methodName, opMetadata, [cid, 1, String(error)]);
     await finalize(storage, finP2PClient, cid, 'failed', wrp);
   }


### PR DESCRIPTION
## Summary
- The catch around the wrapped service method in `executeAndFinalize` swallowed the error — it persisted `String(error)` and sent a failed callback, but never logged. Sibling catches in `finalize` (persist failure, callback rejected, callback throw) all `logger.error(...)` it.
- Add `logger.error('Operation failed', { method: methodName, cid, ...describeError(error) })` so failures from `createAsset`/`hold`/`release`/`proposeInstructionApproval`/etc. surface in adapter logs alongside the existing recovery + callback log lines instead of being trapped in the operations table.
- Bump 0.28.15 → 0.28.16.

## Test plan
- [x] `npm run build` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)