### PR TITLE
vanilla-service: import issue/redeem tx after omnibus distribute/reclaim (0.28.5)

### DIFF
--- a/vanilla-service/package-lock.json
+++ b/vanilla-service/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@owneraio/finp2p-vanilla-service",
-  "version": "0.28.4",
+  "version": "0.28.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-vanilla-service",
-      "version": "0.28.4",
+      "version": "0.28.5",
       "license": "TBD",
       "dependencies": {
+        "@owneraio/finp2p-client": "^0.28.12",
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.15",
         "bs58": "^6.0.0",
         "pg": "^8.15.6",
@@ -1407,11 +1408,10 @@
       }
     },
     "node_modules/@owneraio/finp2p-client": {
-      "version": "0.28.7",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-client/0.28.7/55adcf40750476d6542eba321e1ffdde355c1411",
-      "integrity": "sha512-VeuXp5A0VLx+UHQCrrzszdnUU9yytkm7Oym1zViaLRIumlPSBEpZ9V6vJD5CO2PScwrDHgisANGPZGJfsuMlRg==",
+      "version": "0.28.12",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-client/0.28.12/24845c014328dc66358a33c890a7c7c0cf91b629",
+      "integrity": "sha512-ReaXR7zbrtlBECm+N+ZL/QUB3H5ptCyz3k+9Qz4uvsgKBVr3Q8NCvf3ikdbAb1f8JsM45feBiz3YdnV7GSmtrg==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "axios": "^1.12.2",
         "graphql": "^16.8.1",
@@ -2755,7 +2755,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
       "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -5692,7 +5691,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
       "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -5702,7 +5700,6 @@
       "resolved": "https://registry.npmjs.org/graphql-import-node/-/graphql-import-node-0.0.5.tgz",
       "integrity": "sha512-OXbou9fqh9/Lm7vwXT0XoRN9J5+WCYKnbiTalgFDvkQERITRmcfncZs6aVABedd5B85yQU5EULS4a5pnbpuI0Q==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "graphql": "*"
       }
@@ -8001,7 +7998,6 @@
       "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.14.0.tgz",
       "integrity": "sha512-PshIdm1NgdLvb05zp8LqRQMNSKzIlPkyMxYFxwyHR+UlKD4t2nUjkDhNxeRbhRSEd3x5EUNh2w5sJYwkhOH4fg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "openapi-typescript-helpers": "^0.0.15"
       }
@@ -8010,8 +8006,7 @@
       "version": "0.0.15",
       "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.15.tgz",
       "integrity": "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -8597,7 +8592,6 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
       "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }

--- a/vanilla-service/package.json
+++ b/vanilla-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-vanilla-service",
-  "version": "0.28.4",
+  "version": "0.28.5",
   "description": "Vanilla DB ledger service for FinP2P adapters — per-investor balance segregation in PostgreSQL",
   "main": "./dist/index.js",
   "types": "dist/index.d.ts",
@@ -20,6 +20,7 @@
   "author": "",
   "license": "TBD",
   "dependencies": {
+    "@owneraio/finp2p-client": "^0.28.12",
     "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.15",
     "bs58": "^6.0.0",
     "pg": "^8.15.6",

--- a/vanilla-service/src/service.ts
+++ b/vanilla-service/src/service.ts
@@ -7,6 +7,7 @@ import {
   TokenService, ValidationError,
   failedReceiptOperation, successfulAssetCreation, successfulReceiptOperation,
 } from '@owneraio/finp2p-nodejs-skeleton-adapter';
+import { FinP2PClient } from '@owneraio/finp2p-client';
 import { AssetDelegate, DistributionService, DistributionStatus, EscrowDelegate, InboundTransferVerificationError, OmnibusDelegate, TransferDelegate } from './interfaces';
 import { LedgerStorage } from './storage';
 import { getLogger } from './logger';
@@ -22,6 +23,7 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
     private assetDelegate?: AssetDelegate,
     private escrowDelegate?: EscrowDelegate,
     private omnibusDelegate?: OmnibusDelegate,
+    private finP2PClient?: FinP2PClient,
   ) {}
 
   // ─── TokenService ─────────────────────────────────────────────────────
@@ -406,6 +408,7 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
       idempotency_key: `distribute:${finId}:${assetId}:${Date.now()}`,
       operation_type: 'distribute',
     }, assetType);
+    await this.pushImportTx('issue', finId, assetId, amount);
   }
 
   async reclaim(finId: string, assetId: string, assetType: AssetType, amount: string): Promise<void> {
@@ -413,6 +416,57 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
       idempotency_key: `reclaim:${finId}:${assetId}:${Date.now()}`,
       operation_type: 'reclaim',
     }, assetType);
+    await this.pushImportTx('redeem', finId, assetId, amount);
+  }
+
+  /**
+   * Push an `issue`/`redeem` transaction to the router so the investor's
+   * balance projection on the FinP2P side reflects the local move. Best-effort:
+   * the local move already succeeded, so failures are logged but not thrown.
+   */
+  private async pushImportTx(
+    operationType: 'issue' | 'redeem',
+    finId: string,
+    assetId: string,
+    quantity: string,
+  ): Promise<void> {
+    if (!this.finP2PClient) return;
+    try {
+      const ossAsset = await this.finP2PClient.getAsset(assetId);
+      const ledgerIdentifier = ossAsset.ledgerAssetInfo.ledgerIdentifier;
+      if (!ledgerIdentifier) {
+        getLogger().warn(`Skipping ${operationType} import — asset ${assetId} has no ledgerIdentifier`);
+        return;
+      }
+      const txId = generateCid();
+      const finp2pAccount = {
+        account: { finId },
+        asset: {
+          id: assetId,
+          ledgerIdentifier: { assetIdentifierType: 'CAIP-19' as const, ...ledgerIdentifier },
+        },
+      };
+      const tx = {
+        id: txId,
+        quantity,
+        timestamp: Math.floor(Date.now() / 1000),
+        operationType,
+        transactionDetails: { transactionId: txId },
+        ...(operationType === 'issue'
+          ? { destination: { finp2pAccount } }
+          : { source: { finp2pAccount } }),
+      };
+      const result = await this.finP2PClient.importTransactions([tx]);
+      if ((result as any)?.error) {
+        getLogger().error(`importTransactions rejected for ${operationType}`, {
+          finId, assetId, quantity, error: (result as any).error,
+        });
+      }
+    } catch (err: any) {
+      getLogger().error(`importTransactions failed for ${operationType}`, {
+        finId, assetId, quantity, message: err?.message ?? String(err),
+      });
+    }
   }
 
   // ─── InboundTransferHook ─────────────────────────────────────────────

--- a/vanilla-service/src/service.ts
+++ b/vanilla-service/src/service.ts
@@ -11,7 +11,7 @@ import { FinP2PClient } from '@owneraio/finp2p-client';
 import { AssetDelegate, DistributionService, DistributionStatus, EscrowDelegate, InboundTransferVerificationError, OmnibusDelegate, TransferDelegate } from './interfaces';
 import { LedgerStorage } from './storage';
 import { getLogger } from './logger';
-import { buildReceipt, generateCid } from './utils';
+import { buildReceipt, generateCid, generateIdempotencyKey } from './utils';
 
 /** Well-known finId prefix for omnibus accounts in the local ledger. */
 const OMNIBUS_FIN_ID = '__omnibus__';
@@ -405,7 +405,7 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
   async distribute(finId: string, assetId: string, assetType: AssetType, amount: string): Promise<void> {
     await this.storage.ensureAccount(finId, assetId, assetType);
     const { id: txId, created_at: createdAt } = await this.storage.move(OMNIBUS_FIN_ID, finId, amount, assetId, {
-      idempotency_key: `distribute:${finId}:${assetId}:${Date.now()}`,
+      idempotency_key: generateIdempotencyKey(),
       operation_type: 'distribute',
     }, assetType);
     await this.importTransaction('issue', finId, assetId, amount, txId, createdAt);
@@ -413,7 +413,7 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
 
   async reclaim(finId: string, assetId: string, assetType: AssetType, amount: string): Promise<void> {
     const { id: txId, created_at: createdAt } = await this.storage.move(finId, OMNIBUS_FIN_ID, amount, assetId, {
-      idempotency_key: `reclaim:${finId}:${assetId}:${Date.now()}`,
+      idempotency_key: generateIdempotencyKey(),
       operation_type: 'reclaim',
     }, assetType);
     await this.importTransaction('redeem', finId, assetId, amount, txId, createdAt);

--- a/vanilla-service/src/service.ts
+++ b/vanilla-service/src/service.ts
@@ -408,7 +408,7 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
       idempotency_key: `distribute:${finId}:${assetId}:${Date.now()}`,
       operation_type: 'distribute',
     }, assetType);
-    await this.pushImportTx('issue', finId, assetId, amount);
+    await this.importTransaction('issue', finId, assetId, amount);
   }
 
   async reclaim(finId: string, assetId: string, assetType: AssetType, amount: string): Promise<void> {
@@ -416,7 +416,7 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
       idempotency_key: `reclaim:${finId}:${assetId}:${Date.now()}`,
       operation_type: 'reclaim',
     }, assetType);
-    await this.pushImportTx('redeem', finId, assetId, amount);
+    await this.importTransaction('redeem', finId, assetId, amount);
   }
 
   /**
@@ -424,7 +424,7 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
    * balance projection on the FinP2P side reflects the local move. Best-effort:
    * the local move already succeeded, so failures are logged but not thrown.
    */
-  private async pushImportTx(
+  private async importTransaction(
     operationType: 'issue' | 'redeem',
     finId: string,
     assetId: string,

--- a/vanilla-service/src/service.ts
+++ b/vanilla-service/src/service.ts
@@ -404,19 +404,19 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
 
   async distribute(finId: string, assetId: string, assetType: AssetType, amount: string): Promise<void> {
     await this.storage.ensureAccount(finId, assetId, assetType);
-    await this.storage.move(OMNIBUS_FIN_ID, finId, amount, assetId, {
+    const tx = await this.storage.move(OMNIBUS_FIN_ID, finId, amount, assetId, {
       idempotency_key: `distribute:${finId}:${assetId}:${Date.now()}`,
       operation_type: 'distribute',
     }, assetType);
-    await this.importTransaction('issue', finId, assetId, amount);
+    await this.importTransaction('issue', finId, assetId, amount, tx);
   }
 
   async reclaim(finId: string, assetId: string, assetType: AssetType, amount: string): Promise<void> {
-    await this.storage.move(finId, OMNIBUS_FIN_ID, amount, assetId, {
+    const tx = await this.storage.move(finId, OMNIBUS_FIN_ID, amount, assetId, {
       idempotency_key: `reclaim:${finId}:${assetId}:${Date.now()}`,
       operation_type: 'reclaim',
     }, assetType);
-    await this.importTransaction('redeem', finId, assetId, amount);
+    await this.importTransaction('redeem', finId, assetId, amount, tx);
   }
 
   /**
@@ -429,6 +429,7 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
     finId: string,
     assetId: string,
     quantity: string,
+    ledgerTx: { id: string; created_at: Date },
   ): Promise<void> {
     if (!this.finP2PClient) return;
     try {
@@ -438,7 +439,6 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
         getLogger().warn(`Skipping ${operationType} import — asset ${assetId} has no ledgerIdentifier`);
         return;
       }
-      const txId = generateCid();
       const finp2pAccount = {
         account: { finId },
         asset: {
@@ -447,11 +447,11 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
         },
       };
       const tx = {
-        id: txId,
+        id: ledgerTx.id,
         quantity,
-        timestamp: Math.floor(Date.now() / 1000),
+        timestamp: Math.floor(ledgerTx.created_at.getTime() / 1000),
         operationType,
-        transactionDetails: { transactionId: txId },
+        transactionDetails: { transactionId: ledgerTx.id },
         ...(operationType === 'issue'
           ? { destination: { finp2pAccount } }
           : { source: { finp2pAccount } }),

--- a/vanilla-service/src/service.ts
+++ b/vanilla-service/src/service.ts
@@ -419,11 +419,40 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
     await this.importTransaction('redeem', finId, assetId, amount, txId, createdAt);
   }
 
-  /**
-   * Push an `issue`/`redeem` transaction to the router so the investor's
-   * balance projection on the FinP2P side reflects the local move. Best-effort:
-   * the local move already succeeded, so failures are logged but not thrown.
-   */
+  // ─── InboundTransferHook ─────────────────────────────────────────────
+
+  async onPlannedInboundTransfer(_idempotencyKey: string, ctx: PlannedInboundTransferContext): Promise<void> {
+    const { destinationFinId, asset } = ctx;
+    await this.storage.ensureAccount(destinationFinId, asset.assetId, asset.assetType);
+  }
+
+  async onInboundTransfer(idempotencyKey: string, ctx: InboundTransferContext): Promise<void> {
+    const { planId, instructionSequence, sourceFinId, destinationFinId, asset, amount, result } = ctx;
+
+    if (result.type === 'error') {
+      return;
+    }
+
+    if (this.transferDelegate?.onInboundTransfer) {
+      const exCtx = { planId, sequence: instructionSequence };
+      await this.transferDelegate.onInboundTransfer(
+        result.transactionId,
+        { finId: sourceFinId },
+        asset,
+        { finId: destinationFinId },
+        amount, exCtx,
+      );
+    }
+
+    await this.storage.ensureAccount(destinationFinId, asset.assetId, asset.assetType);
+    await this.storage.credit(destinationFinId, amount, asset.assetId, {
+      idempotency_key: idempotencyKey,
+      operation_type: 'transfer',
+      execution_context: { planId, sequence: instructionSequence },
+      transaction_id: result.transactionId,
+    }, asset.assetType);
+  }
+
   private async importTransaction(
     operationType: 'issue' | 'redeem',
     finId: string,
@@ -468,39 +497,5 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
         finId, assetId, quantity, message: err?.message ?? String(err),
       });
     }
-  }
-
-  // ─── InboundTransferHook ─────────────────────────────────────────────
-
-  async onPlannedInboundTransfer(_idempotencyKey: string, ctx: PlannedInboundTransferContext): Promise<void> {
-    const { destinationFinId, asset } = ctx;
-    await this.storage.ensureAccount(destinationFinId, asset.assetId, asset.assetType);
-  }
-
-  async onInboundTransfer(idempotencyKey: string, ctx: InboundTransferContext): Promise<void> {
-    const { planId, instructionSequence, sourceFinId, destinationFinId, asset, amount, result } = ctx;
-
-    if (result.type === 'error') {
-      return;
-    }
-
-    if (this.transferDelegate?.onInboundTransfer) {
-      const exCtx = { planId, sequence: instructionSequence };
-      await this.transferDelegate.onInboundTransfer(
-        result.transactionId,
-        { finId: sourceFinId },
-        asset,
-        { finId: destinationFinId },
-        amount, exCtx,
-      );
-    }
-
-    await this.storage.ensureAccount(destinationFinId, asset.assetId, asset.assetType);
-    await this.storage.credit(destinationFinId, amount, asset.assetId, {
-      idempotency_key: idempotencyKey,
-      operation_type: 'transfer',
-      execution_context: { planId, sequence: instructionSequence },
-      transaction_id: result.transactionId,
-    }, asset.assetType);
   }
 }

--- a/vanilla-service/src/service.ts
+++ b/vanilla-service/src/service.ts
@@ -404,19 +404,19 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
 
   async distribute(finId: string, assetId: string, assetType: AssetType, amount: string): Promise<void> {
     await this.storage.ensureAccount(finId, assetId, assetType);
-    const tx = await this.storage.move(OMNIBUS_FIN_ID, finId, amount, assetId, {
+    const { id: txId, created_at: createdAt } = await this.storage.move(OMNIBUS_FIN_ID, finId, amount, assetId, {
       idempotency_key: `distribute:${finId}:${assetId}:${Date.now()}`,
       operation_type: 'distribute',
     }, assetType);
-    await this.importTransaction('issue', finId, assetId, amount, tx);
+    await this.importTransaction('issue', finId, assetId, amount, txId, createdAt);
   }
 
   async reclaim(finId: string, assetId: string, assetType: AssetType, amount: string): Promise<void> {
-    const tx = await this.storage.move(finId, OMNIBUS_FIN_ID, amount, assetId, {
+    const { id: txId, created_at: createdAt } = await this.storage.move(finId, OMNIBUS_FIN_ID, amount, assetId, {
       idempotency_key: `reclaim:${finId}:${assetId}:${Date.now()}`,
       operation_type: 'reclaim',
     }, assetType);
-    await this.importTransaction('redeem', finId, assetId, amount, tx);
+    await this.importTransaction('redeem', finId, assetId, amount, txId, createdAt);
   }
 
   /**
@@ -429,7 +429,8 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
     finId: string,
     assetId: string,
     quantity: string,
-    ledgerTx: { id: string; created_at: Date },
+    txId: string,
+    createdAt: Date,
   ): Promise<void> {
     if (!this.finP2PClient) return;
     try {
@@ -447,11 +448,11 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
         },
       };
       const tx = {
-        id: ledgerTx.id,
+        id: txId,
         quantity,
-        timestamp: Math.floor(ledgerTx.created_at.getTime() / 1000),
+        timestamp: Math.floor(createdAt.getTime() / 1000),
         operationType,
-        transactionDetails: { transactionId: ledgerTx.id },
+        transactionDetails: { transactionId: txId },
         ...(operationType === 'issue'
           ? { destination: { finp2pAccount } }
           : { source: { finp2pAccount } }),

--- a/vanilla-service/src/utils.ts
+++ b/vanilla-service/src/utils.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from 'node:crypto';
+import { randomBytes, randomUUID } from 'node:crypto';
 import bs58 from 'bs58';
 import {
   Asset, Destination, ExecutionContext, OperationType, Receipt, Source,
@@ -6,6 +6,8 @@ import {
 import { LedgerTransaction } from './storage';
 
 export const generateCid = (): string => bs58.encode(Uint8Array.from(randomBytes(64)));
+
+export const generateIdempotencyKey = (): string => randomUUID();
 
 export function buildReceipt(
   tx: LedgerTransaction,


### PR DESCRIPTION
## Summary
- `distribute()` / `reclaim()` only updated the local DB; the router had no way to learn about the per-investor balance change so its projection drifted.
- Take an optional `FinP2PClient` at construction. When set, after a successful local move, push an `issue` (distribute) or `redeem` (reclaim) transaction via `client.importTransactions([...])`. Asset's `ledgerIdentifier` is fetched from OSS via `client.getAsset(assetId)` to satisfy the wire schema.
- Best-effort: failures are logged, not thrown — the local DB is already consistent.
- Adds `@owneraio/finp2p-client@^0.28.12` as a direct dep. Bump 0.28.4 → 0.28.5.

## Test plan
- [x] `npm run build` clean
- [ ] CI green
- [ ] Manual / e2e: confirm router-side investor balance reflects distribute

🤖 Generated with [Claude Code](https://claude.com/claude-code)