### PR TITLE
vanilla-service: flushDistributions endpoint to reclaim all distributed accounts (0.28.6)

### DIFF
--- a/vanilla-service/package-lock.json
+++ b/vanilla-service/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-vanilla-service",
-  "version": "0.28.5",
+  "version": "0.28.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-vanilla-service",
-      "version": "0.28.5",
+      "version": "0.28.6",
       "license": "TBD",
       "dependencies": {
         "@owneraio/finp2p-client": "^0.28.12",

--- a/vanilla-service/package.json
+++ b/vanilla-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-vanilla-service",
-  "version": "0.28.5",
+  "version": "0.28.6",
   "description": "Vanilla DB ledger service for FinP2P adapters — per-investor balance segregation in PostgreSQL",
   "main": "./dist/index.js",
   "types": "dist/index.d.ts",

--- a/vanilla-service/src/interfaces.ts
+++ b/vanilla-service/src/interfaces.ts
@@ -134,4 +134,10 @@ export interface DistributionService {
   getDistributionStatus(assetId: string, assetType: AssetType): Promise<DistributionStatus>;
   distribute(finId: string, assetId: string, assetType: AssetType, amount: string): Promise<void>;
   reclaim(finId: string, assetId: string, assetType: AssetType, amount: string): Promise<void>;
+  /**
+   * Reclaim every per-investor account back to omnibus for the given asset.
+   * Each account is reclaimed sequentially (each reclaim emits its own
+   * router-side `redeem` import-tx) and the post-flush status is returned.
+   */
+  flushDistributions(assetId: string, assetType: AssetType): Promise<DistributionStatus>;
 }

--- a/vanilla-service/src/routes.ts
+++ b/vanilla-service/src/routes.ts
@@ -8,6 +8,7 @@ import { DistributionService } from './interfaces';
  *   GET  /distribution/status      — read-only omnibus vs distributed balance
  *   POST /distribution/distribute  — allocate omnibus value to investor
  *   POST /distribution/reclaim     — return investor value to undistributed pool
+ *   POST /distribution/flush       — reclaim every per-investor account back to omnibus
  */
 export function registerDistributionRoutes(
   app: Application,
@@ -68,6 +69,21 @@ export function registerDistributionRoutes(
       }
       await distributionService.reclaim(finId, assetId, assetType ?? 'finp2p', amount);
       res.json({ status: 'ok' });
+    } catch (e: any) {
+      const code = e instanceof BusinessError ? 409 : 500;
+      res.status(code).json({ error: e.message });
+    }
+  });
+
+  app.post('/distribution/flush', async (req, res) => {
+    try {
+      const { assetId, assetType } = req.body;
+      if (!assetId) {
+        res.status(400).json({ error: 'assetId is required' });
+        return;
+      }
+      const status = await distributionService.flushDistributions(assetId, assetType ?? 'finp2p');
+      res.json(status);
     } catch (e: any) {
       const code = e instanceof BusinessError ? 409 : 500;
       res.status(code).json({ error: e.message });

--- a/vanilla-service/src/service.ts
+++ b/vanilla-service/src/service.ts
@@ -419,6 +419,15 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
     await this.importTransaction('redeem', finId, assetId, amount, txId, createdAt);
   }
 
+  async flushDistributions(assetId: string, assetType: AssetType): Promise<DistributionStatus> {
+    const accounts = await this.storage.listDistributedAccounts(OMNIBUS_FIN_ID, assetId, assetType);
+    getLogger().info(`Flushing ${accounts.length} distributed accounts for asset ${assetId}`);
+    for (const { finId, balance } of accounts) {
+      await this.reclaim(finId, assetId, assetType, balance);
+    }
+    return this.getDistributionStatus(assetId, assetType);
+  }
+
   // ─── InboundTransferHook ─────────────────────────────────────────────
 
   async onPlannedInboundTransfer(_idempotencyKey: string, ctx: PlannedInboundTransferContext): Promise<void> {

--- a/vanilla-service/src/storage.ts
+++ b/vanilla-service/src/storage.ts
@@ -123,6 +123,24 @@ export class LedgerStorage {
   }
 
   /**
+   * Returns all per-investor accounts with positive balances for an asset,
+   * excluding the omnibus account itself. Used to enumerate what would be
+   * touched by a bulk flush back into omnibus.
+   */
+  async listDistributedAccounts(
+    omnibusFinId: string, assetId: string, assetType: string = 'finp2p',
+  ): Promise<{ finId: string; balance: string }[]> {
+    const result = await this.pool.query(
+      `SELECT fin_id AS "finId", balance::TEXT AS balance
+       FROM ${this.schema}.accounts
+       WHERE asset_id = $1 AND asset_type = $2 AND fin_id != $3 AND balance > 0
+       ORDER BY fin_id`,
+      [assetId, assetType, omnibusFinId],
+    );
+    return result.rows;
+  }
+
+  /**
    * Returns the sum of balances for all accounts matching the asset,
    * excluding a specific finId (e.g. the omnibus account).
    */


### PR DESCRIPTION
## Summary
- Add a way to reclaim every per-investor distribution back to omnibus in one shot. Each per-account reclaim still goes through the existing `reclaim()` path, so each emits its own router-side `redeem` import-tx and the router's investor-balance projection ends up consistent with omnibus holding the full on-chain balance and zero distributed.
- New storage query `listDistributedAccounts(omnibusFinId, assetId, assetType)` returns `{ finId, balance }[]` for accounts with `balance > 0`.
- `DistributionService.flushDistributions(assetId, assetType)` iterates and calls `reclaim()` per account, then returns the post-flush `DistributionStatus`.
- New route `POST /distribution/flush` taking `{ assetId, assetType? }`.
- Bump 0.28.5 → 0.28.6.

## Test plan
- [x] `npm run build` clean
- [ ] CI green
- [ ] Manual: distribute to multiple investors → flush → confirm omnibus balance fully recovered, distributed = 0, redeem txs visible router-side

🤖 Generated with [Claude Code](https://claude.com/claude-code)