### PR TITLE
skeleton: decouple EIP712 verifier from finId-as-pubkey (0.28.18)

### DIFF
--- a/adapter-tests/package-lock.json
+++ b/adapter-tests/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@owneraio/adapter-tests",
-  "version": "0.28.2",
+  "version": "0.28.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/adapter-tests",
-      "version": "0.28.2",
+      "version": "0.28.3",
       "license": "ISC",
       "dependencies": {
-        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.10",
+        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.18",
         "axios": "^1.12.2",
         "secp256k1": "^3.7.1",
         "yaml": "^2.8.1",
@@ -1773,9 +1773,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-nodejs-skeleton-adapter": {
-      "version": "0.28.10",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.10/6b3aef3c1708423a7741787762363935f4b569e2",
-      "integrity": "sha512-5XjeH/fNjs05eVgGAaLVKQkXlaohTLc0wHPS1fMvuSiDNxKaGvEqyZEWu0vyZZiGhNWLN+hP505p9D+ak4hLxg==",
+      "version": "0.28.18",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.18/849be676bbe17373d889f7cee12e7a2387a548cb",
+      "integrity": "sha512-5GrUI2vs1UspUv265KtStBTaUmN8BImfmtKwyiJJ/ZtVzS7/2FCQ0Vd+42oyMS8xVkcaRcgAuqPcq4PhzT+p1g==",
       "license": "TBD",
       "dependencies": {
         "axios": "1.11.0",

--- a/adapter-tests/package.json
+++ b/adapter-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/adapter-tests",
-  "version": "0.28.2",
+  "version": "0.28.3",
   "description": "",
   "main": "./dist/index.js",
   "types": "dist/index.d.ts",
@@ -15,7 +15,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.10",
+    "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.18",
     "axios": "^1.12.2",
     "secp256k1": "^3.7.1",
     "yaml": "^2.8.1",

--- a/skeleton/package-lock.json
+++ b/skeleton/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-  "version": "0.28.17",
+  "version": "0.28.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-      "version": "0.28.17",
+      "version": "0.28.18",
       "license": "TBD",
       "dependencies": {
         "axios": "1.11.0",

--- a/skeleton/package.json
+++ b/skeleton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-  "version": "0.28.17",
+  "version": "0.28.18",
   "description": "",
   "homepage": "https://ownera.io/",
   "main": "dist/index.js",

--- a/skeleton/src/helpers/eip712.ts
+++ b/skeleton/src/helpers/eip712.ts
@@ -1,4 +1,4 @@
-import { Signer, TypedDataEncoder, verifyTypedData, Wallet, TypedDataField, computeAddress } from 'ethers';
+import { Signer, TypedDataEncoder, verifyTypedData, Wallet, TypedDataField } from 'ethers';
 
 
 export const EIP712_DOMAIN = {
@@ -6,10 +6,6 @@ export const EIP712_DOMAIN = {
   version: '1',
   chainId: 1,
   verifyingContract: '0x0000000000000000000000000000000000000000',
-};
-
-export const finIdToAddress = (finId: string): string => {
-  return computeAddress(`0x${finId}`);
 };
 
 export const signEIP712 = (chainId: bigint | number, verifyingContract: string, types: Record<string, Array<TypedDataField>>, message: Record<string, any>, signer: Signer) => {
@@ -26,10 +22,17 @@ export const hashEIP712 = (chainId: bigint | number, verifyingContract: string, 
   return TypedDataEncoder.hash(domain, types, message);
 };
 
-export const verifyEIP712 = (chainId: bigint | number, verifyingContract: string, types: Record<string, Array<TypedDataField>>, message: Record<string, any>, signerFinId: string, signature: string) => {
-  const signerAddress = finIdToAddress(signerFinId);
+/**
+ * Verify an EIP712 signature against the expected signer address.
+ *
+ * `signerAddress` is the ledger account bound to the signer's finId via
+ * the AccountMappingService (`ledgerAccountId` field) — NOT a value
+ * derived from the finId itself. Callers are responsible for resolving
+ * the mapping before invoking this verifier.
+ */
+export const verifyEIP712 = (chainId: bigint | number, verifyingContract: string, types: Record<string, Array<TypedDataField>>, message: Record<string, any>, signerAddress: string, signature: string) => {
   const domain = { ...EIP712_DOMAIN, chainId, verifyingContract };
-  const address = verifyTypedData(domain, types, message, signature);
-  return address.toLowerCase() === signerAddress.toLowerCase();
+  const recovered = verifyTypedData(domain, types, message, signature);
+  return recovered.toLowerCase() === signerAddress.toLowerCase();
 };
 

--- a/skeleton/src/services/verify.ts
+++ b/skeleton/src/services/verify.ts
@@ -2,11 +2,32 @@ import { Signature } from '../models';
 import { logger, hashEIP712, verifyEIP712, verifySecp } from '../helpers';
 
 
-export const verifySignature = async (sgn: Signature, signerFinId: string): Promise<boolean> => {
-  const { signature, template, hashFunc } = sgn;
+/**
+ * Identifier needed to verify a signature.
+ *
+ * - `finId`: the FinP2P account id (used by the secp256k1 / hashList branch,
+ *   which treats it as a compressed pubkey hex).
+ * - `ledgerAccountId`: the ledger account (e.g. Ethereum 0x… address) bound
+ *   to that finId via AccountMappingService — required by the EIP712 branch.
+ *
+ * Callers are expected to resolve `ledgerAccountId` from the mapping before
+ * invoking this verifier. The skeleton no longer derives an address from
+ * the finId itself.
+ */
+export interface SignerRef {
+  finId: string;
+  ledgerAccountId?: string;
+}
+
+export const verifySignature = async (sgn: Signature, signer: SignerRef): Promise<boolean> => {
+  const { signature, template } = sgn;
 
   switch (template.type) {
     case 'EIP712': {
+      if (!signer.ledgerAccountId) {
+        logger.warning('EIP712 verification requires signer.ledgerAccountId (bound via AccountMappingService)');
+        return false;
+      }
       const { domain: { chainId, verifyingContract }, message, types, hash: actualHash } = template;
 
       const expectedHash = hashEIP712(chainId, verifyingContract, types, message);
@@ -15,19 +36,18 @@ export const verifySignature = async (sgn: Signature, signerFinId: string): Prom
         return false;
       }
 
-      if (!verifyEIP712(chainId, verifyingContract, types, message, signerFinId, `0x${signature}`)) {
+      if (!verifyEIP712(chainId, verifyingContract, types, message, signer.ledgerAccountId, `0x${signature}`)) {
         logger.warning('EIP712 signature not verified');
         return false;
       }
       return true;
-
     }
     case 'hashList': {
       const { hash } = template;
       if (!verifySecp(
         Buffer.from(hash, 'hex'),
         Buffer.from(signature, 'hex'),
-        Buffer.from(signerFinId, 'hex'),
+        Buffer.from(signer.finId, 'hex'),
       )) {
         logger.warning('hashList signature not verified');
         return false;


### PR DESCRIPTION
## Summary
Stop deriving the EIP712 signer address from the finId (which assumed `finId = compressed secp256k1 pubkey hex` and ran it through `ethers.computeAddress`). The ledger wallet is now resolved from `AccountMappingService`'s `ledgerAccountId` field — the explicit binding mechanism the framework already exposes — and passed into the verifier by the caller.

## API changes (breaking)
- **Removed** `finIdToAddress` (was only used internally by `verifyEIP712`).
- **Signature change** `verifyEIP712(..., signerFinId, signature)` → `verifyEIP712(..., signerAddress, signature)`.
- **Signature change** `verifySignature(sgn, signerFinId)` → `verifySignature(sgn, signer)` where `signer: { finId: string; ledgerAccountId?: string }`.
  - EIP712 branch requires `signer.ledgerAccountId` (warns + returns false if missing).
  - hashList branch continues to use `signer.finId` as a secp256k1 pubkey — intentional; the directive is specifically about EIP712 + ledger wallet separation.

No in-tree consumers call these from un-commented code. Downstream callers (e.g. ethereum adapter) need to resolve `ledgerAccountId` from the mapping store before calling `verifySignature` / `verifyEIP712`.

Bump 0.28.17 → 0.28.18.

## Test plan
- [x] `npm run build` clean
- [ ] CI green
- [ ] Downstream adapter update: resolve `ledgerAccountId` via `AccountMappingService` before verifySignature

🤖 Generated with [Claude Code](https://claude.com/claude-code)