### PR TITLE
adapter-tests: register finId → ledgerAccountId in fixtures (0.28.4)

### DIFF
--- a/adapter-tests/package-lock.json
+++ b/adapter-tests/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/adapter-tests",
-  "version": "0.28.5",
+  "version": "0.28.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/adapter-tests",
-      "version": "0.28.5",
+      "version": "0.28.6",
       "license": "ISC",
       "dependencies": {
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.10",

--- a/adapter-tests/package-lock.json
+++ b/adapter-tests/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "@owneraio/adapter-tests",
-  "version": "0.28.2",
+  "version": "0.28.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/adapter-tests",
-      "version": "0.28.2",
+      "version": "0.28.4",
       "license": "ISC",
       "dependencies": {
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.10",
         "axios": "^1.12.2",
+        "ethers": "^6.11.1",
         "secp256k1": "^3.7.1",
         "yaml": "^2.8.1",
         "zod": "^4.1.12"

--- a/adapter-tests/package-lock.json
+++ b/adapter-tests/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/adapter-tests",
-  "version": "0.28.4",
+  "version": "0.28.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/adapter-tests",
-      "version": "0.28.4",
+      "version": "0.28.5",
       "license": "ISC",
       "dependencies": {
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.10",

--- a/adapter-tests/package-lock.json
+++ b/adapter-tests/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/adapter-tests",
-  "version": "0.28.6",
+  "version": "0.28.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/adapter-tests",
-      "version": "0.28.6",
+      "version": "0.28.7",
       "license": "ISC",
       "dependencies": {
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.10",

--- a/adapter-tests/package.json
+++ b/adapter-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/adapter-tests",
-  "version": "0.28.6",
+  "version": "0.28.7",
   "description": "",
   "main": "./dist/index.js",
   "types": "dist/index.d.ts",

--- a/adapter-tests/package.json
+++ b/adapter-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/adapter-tests",
-  "version": "0.28.5",
+  "version": "0.28.6",
   "description": "",
   "main": "./dist/index.js",
   "types": "dist/index.d.ts",

--- a/adapter-tests/package.json
+++ b/adapter-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/adapter-tests",
-  "version": "0.28.4",
+  "version": "0.28.5",
   "description": "",
   "main": "./dist/index.js",
   "types": "dist/index.d.ts",

--- a/adapter-tests/package.json
+++ b/adapter-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/adapter-tests",
-  "version": "0.28.2",
+  "version": "0.28.4",
   "description": "",
   "main": "./dist/index.js",
   "types": "dist/index.d.ts",
@@ -17,6 +17,7 @@
   "dependencies": {
     "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.10",
     "axios": "^1.12.2",
+    "ethers": "^6.11.1",
     "secp256k1": "^3.7.1",
     "yaml": "^2.8.1",
     "zod": "^4.1.12"

--- a/adapter-tests/src/api/api.ts
+++ b/adapter-tests/src/api/api.ts
@@ -99,13 +99,24 @@ export class LedgerAPIClient {
 
   public readonly callbackServer: CallbackServer | undefined;
 
-  constructor(host: string, callbackServer?: CallbackServer) {
+  /**
+   * @param host        Base URL the DLT adapter API lives at (e.g. `http://host:port/api`).
+   *                    Used by tokens / escrow / payments / plan / common.
+   * @param callbackServer Optional CallbackServer for async-callback flows.
+   * @param baseAddress Optional separate base URL for mapping endpoints
+   *                    (e.g. `http://host:port` with no `/api` suffix).
+   *                    Defaults to `host`. The mapping mount point can sit
+   *                    outside the DLT adapter API base path; sample-adapter
+   *                    exposes both `global.serverAddress` and
+   *                    `global.serverBaseAddress` for that reason.
+   */
+  constructor(host: string, callbackServer?: CallbackServer, baseAddress?: string) {
     this.tokens = new TokensLedgerAPI(host);
     this.escrow = new EscrowLedgerAPI(host);
     this.payments = new PaymentsLedgerAPI(host);
     this.plan = new PlanLedgerAPI(host);
     this.common = new CommonLedgerAPI(host);
-    this.mapping = new MappingLedgerAPI(host);
+    this.mapping = new MappingLedgerAPI(baseAddress ?? host);
     this.callbackServer = callbackServer;
   }
 

--- a/adapter-tests/src/api/api.ts
+++ b/adapter-tests/src/api/api.ts
@@ -4,6 +4,7 @@ import { ClientError } from '../utils/error';
 import { OpenAPIValidator } from '../utils/openapi-validator';
 import { sleep } from '../utils/utils';
 import { ClientBase } from './base';
+import { MappingLedgerAPI } from './mapping';
 
 export class TokensLedgerAPI extends ClientBase {
 
@@ -94,6 +95,8 @@ export class LedgerAPIClient {
 
   public readonly common: CommonLedgerAPI;
 
+  public readonly mapping: MappingLedgerAPI;
+
   public readonly callbackServer: CallbackServer | undefined;
 
   constructor(host: string, callbackServer?: CallbackServer) {
@@ -102,6 +105,7 @@ export class LedgerAPIClient {
     this.payments = new PaymentsLedgerAPI(host);
     this.plan = new PlanLedgerAPI(host);
     this.common = new CommonLedgerAPI(host);
+    this.mapping = new MappingLedgerAPI(host);
     this.callbackServer = callbackServer;
   }
 

--- a/adapter-tests/src/business-logic.test.ts
+++ b/adapter-tests/src/business-logic.test.ts
@@ -19,14 +19,14 @@ export function businessLogicTests() {
       // @ts-ignore
       orgId = global.orgId;
 
-      builder = new TestDataBuilder(orgId, 1, ADDRESSES.ZERO_ADDRESS);
+      builder = new TestDataBuilder(orgId, 1, ADDRESSES.ZERO_ADDRESS, client);
       fixtures = new TestFixtures(client, builder);
     });
 
     describe('Rollback Operations', () => {
       test('should rollback held funds and restore balance', async () => {
-        const buyer = builder.buildActor(ACTOR_NAMES.BUYER);
-        const seller = builder.buildActor(ACTOR_NAMES.SELLER);
+        const buyer = await builder.buildActor(ACTOR_NAMES.BUYER);
+        const seller = await builder.buildActor(ACTOR_NAMES.SELLER);
 
         const initialBalance = 1000;
         const holdAmount = 500;
@@ -67,7 +67,7 @@ export function businessLogicTests() {
       });
 
       test('should fail when rolling back non-existent hold', async () => {
-        const buyer = builder.buildActor(ACTOR_NAMES.BUYER);
+        const buyer = await builder.buildActor(ACTOR_NAMES.BUYER);
 
         const { asset } = await fixtures.setupFiatAssetWithBalance({
           owner: buyer,
@@ -90,8 +90,8 @@ export function businessLogicTests() {
       });
 
       test('should fail when rolling back already released hold', async () => {
-        const buyer = builder.buildActor(ACTOR_NAMES.BUYER);
-        const seller = builder.buildActor(ACTOR_NAMES.SELLER);
+        const buyer = await builder.buildActor(ACTOR_NAMES.BUYER);
+        const seller = await builder.buildActor(ACTOR_NAMES.SELLER);
 
         const initialBalance = 1000;
         const holdAmount = 500;
@@ -140,8 +140,8 @@ export function businessLogicTests() {
       });
 
       test('should fail when rolling back already redeemed hold', async () => {
-        const investor = builder.buildActor(ACTOR_NAMES.INVESTOR);
-        const issuer = builder.buildActor(ACTOR_NAMES.ISSUER);
+        const investor = await builder.buildActor(ACTOR_NAMES.INVESTOR);
+        const issuer = await builder.buildActor(ACTOR_NAMES.ISSUER);
         const asset = builder.buildFinP2PAsset();
 
         const initialBalance = 100;
@@ -184,8 +184,8 @@ export function businessLogicTests() {
 
     describe('Double Operation Prevention', () => {
       test('should fail when trying to release twice', async () => {
-        const buyer = builder.buildActor(ACTOR_NAMES.BUYER);
-        const seller = builder.buildActor(ACTOR_NAMES.SELLER);
+        const buyer = await builder.buildActor(ACTOR_NAMES.BUYER);
+        const seller = await builder.buildActor(ACTOR_NAMES.SELLER);
 
         const initialBalance = 1000;
         const holdAmount = 500;
@@ -226,8 +226,8 @@ export function businessLogicTests() {
       });
 
       test('should fail when trying to redeem twice', async () => {
-        const investor = builder.buildActor(ACTOR_NAMES.INVESTOR);
-        const issuer = builder.buildActor(ACTOR_NAMES.ISSUER);
+        const investor = await builder.buildActor(ACTOR_NAMES.INVESTOR);
+        const issuer = await builder.buildActor(ACTOR_NAMES.ISSUER);
         const asset = builder.buildFinP2PAsset();
 
         await fixtures.setupRedemptionScenario({
@@ -259,8 +259,8 @@ export function businessLogicTests() {
       });
 
       test('should fail when trying to rollback twice', async () => {
-        const buyer = builder.buildActor(ACTOR_NAMES.BUYER);
-        const seller = builder.buildActor(ACTOR_NAMES.SELLER);
+        const buyer = await builder.buildActor(ACTOR_NAMES.BUYER);
+        const seller = await builder.buildActor(ACTOR_NAMES.SELLER);
 
         const { asset } = await fixtures.setupFiatAssetWithBalance({
           owner: buyer,
@@ -297,8 +297,8 @@ export function businessLogicTests() {
 
     describe('Invalid Operation ID Tests', () => {
       test('should fail release with non-existent operationId', async () => {
-        const buyer = builder.buildActor(ACTOR_NAMES.BUYER);
-        const seller = builder.buildActor(ACTOR_NAMES.SELLER);
+        const buyer = await builder.buildActor(ACTOR_NAMES.BUYER);
+        const seller = await builder.buildActor(ACTOR_NAMES.SELLER);
 
         const { asset } = await fixtures.setupFiatAssetWithBalance({
           owner: buyer,
@@ -321,8 +321,8 @@ export function businessLogicTests() {
       });
 
       test('should fail redeem with non-existent operationId', async () => {
-        const investor = builder.buildActor(ACTOR_NAMES.INVESTOR);
-        const issuer = builder.buildActor(ACTOR_NAMES.ISSUER);
+        const investor = await builder.buildActor(ACTOR_NAMES.INVESTOR);
+        const issuer = await builder.buildActor(ACTOR_NAMES.ISSUER);
         const asset = builder.buildFinP2PAsset();
 
         await fixtures.setupRedemptionScenario({
@@ -348,8 +348,8 @@ export function businessLogicTests() {
       });
 
       test('should fail redeem with mismatched operationId', async () => {
-        const investor = builder.buildActor(ACTOR_NAMES.INVESTOR);
-        const issuer = builder.buildActor(ACTOR_NAMES.ISSUER);
+        const investor = await builder.buildActor(ACTOR_NAMES.INVESTOR);
+        const issuer = await builder.buildActor(ACTOR_NAMES.ISSUER);
         const asset = builder.buildFinP2PAsset();
 
         await fixtures.setupRedemptionScenario({
@@ -390,7 +390,7 @@ export function businessLogicTests() {
 
     describe('Asset Lifecycle Tests', () => {
       test('should not allow operations on non-existent asset', async () => {
-        const actor = builder.buildActor('actor');
+        const actor = await builder.buildActor('actor');
         const nonExistentAsset = builder.buildFinP2PAsset();
 
         // Try to issue tokens for non-existent asset
@@ -409,7 +409,7 @@ export function businessLogicTests() {
       });
 
       test('should successfully create asset before issuing tokens', async () => {
-        const issuer = builder.buildActor(ACTOR_NAMES.ISSUER);
+        const issuer = await builder.buildActor(ACTOR_NAMES.ISSUER);
         const asset = builder.buildFinP2PAsset();
 
         // Create asset first
@@ -432,14 +432,14 @@ export function businessLogicTests() {
       });
 
       test('should handle multiple assets independently', async () => {
-        const owner = builder.buildActor('owner');
+        const owner = await builder.buildActor('owner');
         const asset1 = builder.buildFinP2PAsset();
         const asset2 = builder.buildFinP2PAsset();
 
         // Setup first asset with tokens
         await fixtures.setupIssuedTokens({
           issuer: owner,
-          buyer: builder.buildActor('buyer1'),
+          buyer: await builder.buildActor('buyer1'),
           asset: asset1,
           amount: 100,
           settlementAmount: 1000,
@@ -448,7 +448,7 @@ export function businessLogicTests() {
         // Setup second asset with tokens
         await fixtures.setupIssuedTokens({
           issuer: owner,
-          buyer: builder.buildActor('buyer2'),
+          buyer: await builder.buildActor('buyer2'),
           asset: asset2,
           amount: 200,
           settlementAmount: 2000,
@@ -462,15 +462,15 @@ export function businessLogicTests() {
 
     describe('Zero Amount Tests', () => {
       test('should handle transfer of zero tokens', async () => {
-        const seller = builder.buildActor(ACTOR_NAMES.SELLER);
-        const buyer = builder.buildActor(ACTOR_NAMES.BUYER);
+        const seller = await builder.buildActor(ACTOR_NAMES.SELLER);
+        const buyer = await builder.buildActor(ACTOR_NAMES.BUYER);
         const asset = builder.buildFinP2PAsset();
 
         const initialBalance = 100;
 
         await fixtures.setupIssuedTokens({
           issuer: seller,
-          buyer: builder.buildActor('primaryBuyer'),
+          buyer: await builder.buildActor('primaryBuyer'),
           asset,
           amount: initialBalance,
           settlementAmount: 1000,
@@ -499,8 +499,8 @@ export function businessLogicTests() {
       });
 
       test('should handle hold of zero amount', async () => {
-        const buyer = builder.buildActor(ACTOR_NAMES.BUYER);
-        const seller = builder.buildActor(ACTOR_NAMES.SELLER);
+        const buyer = await builder.buildActor(ACTOR_NAMES.BUYER);
+        const seller = await builder.buildActor(ACTOR_NAMES.SELLER);
 
         const { asset } = await fixtures.setupFiatAssetWithBalance({
           owner: buyer,
@@ -533,9 +533,9 @@ export function businessLogicTests() {
 
     describe('Wrong Actor Tests', () => {
       test('should fail when releasing with wrong source', async () => {
-        const buyer = builder.buildActor(ACTOR_NAMES.BUYER);
-        const seller = builder.buildActor(ACTOR_NAMES.SELLER);
-        const attacker = builder.buildActor('attacker');
+        const buyer = await builder.buildActor(ACTOR_NAMES.BUYER);
+        const seller = await builder.buildActor(ACTOR_NAMES.SELLER);
+        const attacker = await builder.buildActor('attacker');
 
         const { asset } = await fixtures.setupFiatAssetWithBalance({
           owner: buyer,
@@ -571,15 +571,15 @@ export function businessLogicTests() {
       });
 
       test('should fail when transferring from wrong account', async () => {
-        const owner = builder.buildActor('owner');
-        const attacker = builder.buildActor('attacker');
-        const recipient = builder.buildActor('recipient');
+        const owner = await builder.buildActor('owner');
+        const attacker = await builder.buildActor('attacker');
+        const recipient = await builder.buildActor('recipient');
         const asset = builder.buildFinP2PAsset();
 
         // Setup owner with tokens
         await fixtures.setupIssuedTokens({
           issuer: owner,
-          buyer: builder.buildActor('buyer'),
+          buyer: await builder.buildActor('buyer'),
           asset,
           amount: 100,
           settlementAmount: 1000,
@@ -608,8 +608,8 @@ export function businessLogicTests() {
 
     describe('Partial Release Tests', () => {
       test('should allow partial release of held funds', async () => {
-        const buyer = builder.buildActor(ACTOR_NAMES.BUYER);
-        const seller = builder.buildActor(ACTOR_NAMES.SELLER);
+        const buyer = await builder.buildActor(ACTOR_NAMES.BUYER);
+        const seller = await builder.buildActor(ACTOR_NAMES.SELLER);
 
         const initialBalance = 1000;
         const holdAmount = 500;

--- a/adapter-tests/src/business-logic.test.ts
+++ b/adapter-tests/src/business-logic.test.ts
@@ -5,7 +5,7 @@ import { TestFixtures } from './utils/test-fixtures';
 import { ADDRESSES, ACTOR_NAMES } from './utils/test-constants';
 import { generateId } from './utils/utils';
 
-export function businessLogicTests() {
+export function businessLogicTests(config: { mapping?: boolean } = {}) {
   describe('Business Logic - Negative Tests', () => {
 
     let client: LedgerAPIClient;
@@ -19,7 +19,7 @@ export function businessLogicTests() {
       // @ts-ignore
       orgId = global.orgId;
 
-      builder = new TestDataBuilder(orgId, 1, ADDRESSES.ZERO_ADDRESS, client);
+      builder = new TestDataBuilder(orgId, 1, ADDRESSES.ZERO_ADDRESS, config.mapping ? client : undefined);
       fixtures = new TestFixtures(client, builder);
     });
 

--- a/adapter-tests/src/business-logic.test.ts
+++ b/adapter-tests/src/business-logic.test.ts
@@ -15,7 +15,7 @@ export function businessLogicTests() {
 
     beforeAll(async () => {
       // @ts-ignore
-      client = new LedgerAPIClient(global.serverAddress, global.callbackServer);
+      client = new LedgerAPIClient(global.serverAddress, global.callbackServer, global.serverBaseAddress);
       // @ts-ignore
       orgId = global.orgId;
 

--- a/adapter-tests/src/escrow-operations.test.ts
+++ b/adapter-tests/src/escrow-operations.test.ts
@@ -18,14 +18,14 @@ describe('Escrow Operations', () => {
     // @ts-ignore
     orgId = global.orgId;
 
-    builder = new TestDataBuilder(orgId, 1, ADDRESSES.ZERO_ADDRESS);
+    builder = new TestDataBuilder(orgId, 1, ADDRESSES.ZERO_ADDRESS, client);
     fixtures = new TestFixtures(client, builder);
   });
 
   test('should hold and release funds', async () => {
     // Setup: Create actors and fiat asset with balance
-    const buyer = builder.buildActor(ACTOR_NAMES.BUYER);
-    const seller = builder.buildActor(ACTOR_NAMES.SELLER);
+    const buyer = await builder.buildActor(ACTOR_NAMES.BUYER);
+    const seller = await builder.buildActor(ACTOR_NAMES.SELLER);
 
     const scenario = SCENARIOS.ESCROW_HOLD_RELEASE;
 
@@ -87,8 +87,8 @@ describe('Escrow Operations', () => {
 
   test('should hold and redeem tokens', async () => {
     // Setup: Create actors and asset
-    const investor = builder.buildActor(ACTOR_NAMES.INVESTOR);
-    const issuer = builder.buildActor(ACTOR_NAMES.ISSUER);
+    const investor = await builder.buildActor(ACTOR_NAMES.INVESTOR);
+    const issuer = await builder.buildActor(ACTOR_NAMES.ISSUER);
     const asset = builder.buildFinP2PAsset();
 
     const scenario = SCENARIOS.ESCROW_HOLD_REDEEM;

--- a/adapter-tests/src/escrow-operations.test.ts
+++ b/adapter-tests/src/escrow-operations.test.ts
@@ -14,7 +14,7 @@ describe('Escrow Operations', () => {
 
   beforeAll(async () => {
     // @ts-ignore
-    client = new LedgerAPIClient(global.serverAddress, global.callbackServer);
+    client = new LedgerAPIClient(global.serverAddress, global.callbackServer, global.serverBaseAddress);
     // @ts-ignore
     orgId = global.orgId;
 

--- a/adapter-tests/src/index.ts
+++ b/adapter-tests/src/index.ts
@@ -12,9 +12,9 @@ export interface AdapterTestConfig {
 
 export function runAdapterTests(config?: AdapterTestConfig) {
   describe('FinP2P Adapter Test Suite', () => {
-    businessLogicTests();
-    tokenLifecycleTests();
-    insufficientBalanceTest();
+    businessLogicTests(config);
+    tokenLifecycleTests(config);
+    insufficientBalanceTest(config);
     if (config?.mapping) {
       mappingOperationsTests();
     }

--- a/adapter-tests/src/insufficient-balance.test.ts
+++ b/adapter-tests/src/insufficient-balance.test.ts
@@ -19,15 +19,15 @@ export function insufficientBalanceTest() {
       // @ts-ignore
       orgId = global.orgId;
 
-      builder = new TestDataBuilder(orgId, 1, ADDRESSES.ZERO_ADDRESS);
+      builder = new TestDataBuilder(orgId, 1, ADDRESSES.ZERO_ADDRESS, client);
       fixtures = new TestFixtures(client, builder);
     });
 
     describe('Transfer Insufficient Balance', () => {
       test('should fail when transferring more tokens than available balance', async () => {
         // Setup: Create issuer with limited balance
-        const issuer = builder.buildActor(ACTOR_NAMES.ISSUER);
-        const buyer = builder.buildActor(ACTOR_NAMES.BUYER);
+        const issuer = await builder.buildActor(ACTOR_NAMES.ISSUER);
+        const buyer = await builder.buildActor(ACTOR_NAMES.BUYER);
         const asset = builder.buildFinP2PAsset();
 
         const initialBalance = 100;
@@ -35,7 +35,7 @@ export function insufficientBalanceTest() {
         // Issue tokens to issuer
         await fixtures.setupIssuedTokens({
           issuer,
-          buyer: builder.buildActor('primaryBuyer'),
+          buyer: await builder.buildActor('primaryBuyer'),
           asset,
           amount: initialBalance,
           settlementAmount: 1000,
@@ -68,8 +68,8 @@ export function insufficientBalanceTest() {
       });
 
       test('should fail when transferring exact balance plus one', async () => {
-        const seller = builder.buildActor(ACTOR_NAMES.SELLER);
-        const buyer = builder.buildActor(ACTOR_NAMES.BUYER);
+        const seller = await builder.buildActor(ACTOR_NAMES.SELLER);
+        const buyer = await builder.buildActor(ACTOR_NAMES.BUYER);
         const asset = builder.buildFinP2PAsset();
 
         const exactBalance = 500;
@@ -77,7 +77,7 @@ export function insufficientBalanceTest() {
         // Issue exact balance
         await fixtures.setupIssuedTokens({
           issuer: seller,
-          buyer: builder.buildActor('primaryBuyer'),
+          buyer: await builder.buildActor('primaryBuyer'),
           asset,
           amount: exactBalance,
           settlementAmount: 5000,
@@ -105,8 +105,8 @@ export function insufficientBalanceTest() {
 
     describe('Redeem Insufficient Balance', () => {
       test('should fail when redeeming more tokens than available', async () => {
-        const investor = builder.buildActor(ACTOR_NAMES.INVESTOR);
-        const issuer = builder.buildActor(ACTOR_NAMES.ISSUER);
+        const investor = await builder.buildActor(ACTOR_NAMES.INVESTOR);
+        const issuer = await builder.buildActor(ACTOR_NAMES.ISSUER);
         const asset = builder.buildFinP2PAsset();
 
         const initialBalance = 100;
@@ -146,8 +146,8 @@ export function insufficientBalanceTest() {
       });
 
       test('should fail when redeeming from zero balance', async () => {
-        const investor = builder.buildActor(ACTOR_NAMES.INVESTOR);
-        const issuer = builder.buildActor(ACTOR_NAMES.ISSUER);
+        const investor = await builder.buildActor(ACTOR_NAMES.INVESTOR);
+        const issuer = await builder.buildActor(ACTOR_NAMES.ISSUER);
         const asset = builder.buildFinP2PAsset();
 
         // Create asset but don't issue any tokens to investor
@@ -184,8 +184,8 @@ export function insufficientBalanceTest() {
 
     describe('Hold Insufficient Balance', () => {
       test('should fail when holding more fiat than available balance', async () => {
-        const buyer = builder.buildActor(ACTOR_NAMES.BUYER);
-        const seller = builder.buildActor(ACTOR_NAMES.SELLER);
+        const buyer = await builder.buildActor(ACTOR_NAMES.BUYER);
+        const seller = await builder.buildActor(ACTOR_NAMES.SELLER);
 
         const initialBalance = 1000;
 
@@ -224,8 +224,8 @@ export function insufficientBalanceTest() {
       });
 
       test('should fail when holding from zero balance', async () => {
-        const buyer = builder.buildActor(ACTOR_NAMES.BUYER);
-        const seller = builder.buildActor(ACTOR_NAMES.SELLER);
+        const buyer = await builder.buildActor(ACTOR_NAMES.BUYER);
+        const seller = await builder.buildActor(ACTOR_NAMES.SELLER);
 
         // Create fiat asset with zero balance
         const { asset } = await fixtures.setupFiatAssetWithBalance({
@@ -261,8 +261,8 @@ export function insufficientBalanceTest() {
       });
 
       test('should fail when holding after partial consumption of balance', async () => {
-        const buyer = builder.buildActor(ACTOR_NAMES.BUYER);
-        const seller = builder.buildActor(ACTOR_NAMES.SELLER);
+        const buyer = await builder.buildActor(ACTOR_NAMES.BUYER);
+        const seller = await builder.buildActor(ACTOR_NAMES.SELLER);
 
         const initialBalance = 1000;
         const firstHoldAmount = 800;
@@ -315,9 +315,9 @@ export function insufficientBalanceTest() {
 
     describe('Multiple Operations - Insufficient Balance', () => {
       test('should fail when combined operations exceed balance', async () => {
-        const owner = builder.buildActor('owner');
-        const recipient1 = builder.buildActor('recipient1');
-        const recipient2 = builder.buildActor('recipient2');
+        const owner = await builder.buildActor('owner');
+        const recipient1 = await builder.buildActor('recipient1');
+        const recipient2 = await builder.buildActor('recipient2');
         const asset = builder.buildFinP2PAsset();
 
         const totalBalance = 100;
@@ -325,7 +325,7 @@ export function insufficientBalanceTest() {
         // Setup owner with limited balance
         await fixtures.setupIssuedTokens({
           issuer: owner,
-          buyer: builder.buildActor('primaryBuyer'),
+          buyer: await builder.buildActor('primaryBuyer'),
           asset,
           amount: totalBalance,
           settlementAmount: 1000,

--- a/adapter-tests/src/insufficient-balance.test.ts
+++ b/adapter-tests/src/insufficient-balance.test.ts
@@ -5,7 +5,7 @@ import { ADDRESSES, ACTOR_NAMES } from './utils/test-constants';
 import { generateId } from './utils/utils';
 import { TestHelpers } from './utils/test-assertions';
 
-export function insufficientBalanceTest() {
+export function insufficientBalanceTest(config: { mapping?: boolean } = {}) {
   describe('Insufficient Balance - Negative Tests', () => {
 
     let client: LedgerAPIClient;
@@ -19,7 +19,7 @@ export function insufficientBalanceTest() {
       // @ts-ignore
       orgId = global.orgId;
 
-      builder = new TestDataBuilder(orgId, 1, ADDRESSES.ZERO_ADDRESS, client);
+      builder = new TestDataBuilder(orgId, 1, ADDRESSES.ZERO_ADDRESS, config.mapping ? client : undefined);
       fixtures = new TestFixtures(client, builder);
     });
 

--- a/adapter-tests/src/insufficient-balance.test.ts
+++ b/adapter-tests/src/insufficient-balance.test.ts
@@ -15,7 +15,7 @@ export function insufficientBalanceTest() {
 
     beforeAll(async () => {
       // @ts-ignore
-      client = new LedgerAPIClient(global.serverAddress, global.callbackServer);
+      client = new LedgerAPIClient(global.serverAddress, global.callbackServer, global.serverBaseAddress);
       // @ts-ignore
       orgId = global.orgId;
 

--- a/adapter-tests/src/token-lifecycle.test.ts
+++ b/adapter-tests/src/token-lifecycle.test.ts
@@ -4,7 +4,7 @@ import { ReceiptAssertions, TestHelpers } from './utils/test-assertions';
 import { TestFixtures } from './utils/test-fixtures';
 import { ADDRESSES, SCENARIOS, ACTOR_NAMES } from './utils/test-constants';
 
-export function tokenLifecycleTests() {
+export function tokenLifecycleTests(config: { mapping?: boolean } = {}) {
   describe('Token Lifecycle', () => {
 
     let client: LedgerAPIClient;
@@ -18,7 +18,7 @@ export function tokenLifecycleTests() {
       // @ts-ignore
       orgId = global.orgId;
 
-      builder = new TestDataBuilder(orgId, 1, ADDRESSES.ZERO_ADDRESS, client);
+      builder = new TestDataBuilder(orgId, 1, ADDRESSES.ZERO_ADDRESS, config.mapping ? client : undefined);
       fixtures = new TestFixtures(client, builder);
     });
 

--- a/adapter-tests/src/token-lifecycle.test.ts
+++ b/adapter-tests/src/token-lifecycle.test.ts
@@ -14,7 +14,7 @@ export function tokenLifecycleTests() {
 
     beforeAll(async () => {
       // @ts-ignore
-      client = new LedgerAPIClient(global.serverAddress, global.callbackServer);
+      client = new LedgerAPIClient(global.serverAddress, global.callbackServer, global.serverBaseAddress);
       // @ts-ignore
       orgId = global.orgId;
 

--- a/adapter-tests/src/token-lifecycle.test.ts
+++ b/adapter-tests/src/token-lifecycle.test.ts
@@ -18,15 +18,15 @@ export function tokenLifecycleTests() {
       // @ts-ignore
       orgId = global.orgId;
 
-      builder = new TestDataBuilder(orgId, 1, ADDRESSES.ZERO_ADDRESS);
+      builder = new TestDataBuilder(orgId, 1, ADDRESSES.ZERO_ADDRESS, client);
       fixtures = new TestFixtures(client, builder);
     });
 
     test('should issue, transfer, and verify balances', async () => {
       // Setup: Create actors and asset
-      const issuer = builder.buildActor(ACTOR_NAMES.ISSUER);
-      const primaryBuyer = builder.buildActor('primaryBuyer');
-      const secondaryBuyer = builder.buildActor('secondaryBuyer');
+      const issuer = await builder.buildActor(ACTOR_NAMES.ISSUER);
+      const primaryBuyer = await builder.buildActor('primaryBuyer');
+      const secondaryBuyer = await builder.buildActor('secondaryBuyer');
       const asset = builder.buildFinP2PAsset();
 
       const scenario = SCENARIOS.ISSUE_TRANSFER_REDEEM;

--- a/adapter-tests/src/utils/test-builders.ts
+++ b/adapter-tests/src/utils/test-builders.ts
@@ -1,5 +1,6 @@
-import { createCrypto, generateNonce, randomResourceId, ASSET } from './utils';
+import { createCrypto, finIdToAddress, generateNonce, randomResourceId, ASSET } from './utils';
 import { LedgerAPI } from '@owneraio/finp2p-nodejs-skeleton-adapter';
+import { LedgerAPIClient } from '../api/api';
 import { eip712Signature } from '../api/mapper';
 import {
   EIP712PrimarySaleMessage,
@@ -35,18 +36,34 @@ export class TestDataBuilder {
     private orgId: string,
     private chainId: number,
     private verifyingContract: string,
+    private client?: LedgerAPIClient,
   ) {}
 
   // ========== Data Builders (creates supporting objects) ==========
 
   /**
-   * Creates a test actor with generated keys and account
-   * @example const alice = builder.buildActor('alice');
+   * Creates a test actor with generated keys and account, and registers the
+   * actor's `finId → ledgerAccountId` binding with the adapter (idempotent)
+   * when the builder is constructed with a `LedgerAPIClient`.
+   *
+   * Registering at construction time means downstream tests don't have to
+   * remember to call `TestFixtures.ensureOwnerMappingRegistered(...)` after
+   * spinning up an ad-hoc actor — every actor minted via `buildActor` is
+   * known to the adapter the moment it exists.
+   *
+   * @example const alice = await builder.buildActor('alice');
    */
-  buildActor(name: string = 'actor'): TestActor {
+  async buildActor(name: string = 'actor'): Promise<TestActor> {
     const { private: privateKeyBytes, public: publicKey } = createCrypto();
     const privateKey = privateKeyBytes.toString('hex');
     const finIdStr = publicKey.toString('hex');
+
+    if (this.client) {
+      await this.client.mapping.createOwnerMapping({
+        finId: finIdStr,
+        accountMappings: { ledgerAccountId: finIdToAddress(finIdStr) },
+      });
+    }
 
     return {
       name,

--- a/adapter-tests/src/utils/test-fixtures.ts
+++ b/adapter-tests/src/utils/test-fixtures.ts
@@ -2,7 +2,7 @@ import { LedgerAPIClient } from '../api/api';
 import { TestActor, TestDataBuilder } from './test-builders';
 import { LedgerAPI } from '@owneraio/finp2p-nodejs-skeleton-adapter';
 import { TestHelpers } from './test-assertions';
-import { generateId } from './utils';
+import { generateId, finIdToAddress } from './utils';
 
 /**
  * High-level test fixtures for common test scenarios
@@ -14,6 +14,25 @@ export class TestFixtures {
     private client: LedgerAPIClient,
     private builder: TestDataBuilder,
   ) {}
+
+  /**
+   * Register the test actor's finId → ledgerAccountId mapping with the adapter.
+   *
+   * Test actors are built with `createCrypto()`, so their finId IS their
+   * compressed secp256k1 pubkey — derive the Ethereum address from it
+   * directly via `finIdToAddress`. The derivation only belongs in the
+   * test framework; production adapters look up the binding from the
+   * AccountMappingService instead of deriving.
+   *
+   * The mapping endpoint is idempotent on `(finId, ledgerAccountId)` so
+   * it's safe to call multiple times across overlapping fixture calls.
+   */
+  async ensureOwnerMappingRegistered(actor: TestActor): Promise<void> {
+    await this.client.mapping.createOwnerMapping({
+      finId: actor.finId,
+      accountMappings: { ledgerAccountId: finIdToAddress(actor.finId) },
+    });
+  }
 
   /**
    * Sets up an asset with an initial balance for an actor
@@ -70,6 +89,11 @@ export class TestFixtures {
       asset: LedgerAPI['schemas']['asset'];
       receipt: LedgerAPI['schemas']['receipt'];
     }> {
+    // Register finId → ledgerAccountId mappings so signature verification finds
+    // a credential for buyer and issuer.
+    await this.ensureOwnerMappingRegistered(params.buyer);
+    await this.ensureOwnerMappingRegistered(params.issuer);
+
     // Create asset
     await TestHelpers.createAssetAndWait(
       this.client,
@@ -111,6 +135,9 @@ export class TestFixtures {
       balance: number;
     }> {
     const asset = this.builder.buildFiatAsset(params.fiatCode);
+
+    // Register owner's finId → ledgerAccountId mapping.
+    await this.ensureOwnerMappingRegistered(params.owner);
 
     // Create asset
     await TestHelpers.createAssetAndWait(
@@ -168,6 +195,10 @@ export class TestFixtures {
     }> {
     const operationId = params.operationId || generateId();
 
+    // Register finId → ledgerAccountId mappings for both sides.
+    await this.ensureOwnerMappingRegistered(params.source);
+    await this.ensureOwnerMappingRegistered(params.destination);
+
     const holdRequest = await this.builder.buildSignedHoldRequest({
       source: params.source,
       destination: params.destination,
@@ -203,6 +234,10 @@ export class TestFixtures {
       asset: LedgerAPI['schemas']['asset'];
       issueAmount: number;
     }> {
+    // Register finId → ledgerAccountId mappings for investor and issuer.
+    await this.ensureOwnerMappingRegistered(params.investor);
+    await this.ensureOwnerMappingRegistered(params.issuer);
+
     // Create asset
     await TestHelpers.createAssetAndWait(
       this.client,

--- a/adapter-tests/src/utils/test-fixtures.ts
+++ b/adapter-tests/src/utils/test-fixtures.ts
@@ -89,11 +89,6 @@ export class TestFixtures {
       asset: LedgerAPI['schemas']['asset'];
       receipt: LedgerAPI['schemas']['receipt'];
     }> {
-    // Register finId → ledgerAccountId mappings so signature verification finds
-    // a credential for buyer and issuer.
-    await this.ensureOwnerMappingRegistered(params.buyer);
-    await this.ensureOwnerMappingRegistered(params.issuer);
-
     // Create asset
     await TestHelpers.createAssetAndWait(
       this.client,
@@ -135,9 +130,6 @@ export class TestFixtures {
       balance: number;
     }> {
     const asset = this.builder.buildFiatAsset(params.fiatCode);
-
-    // Register owner's finId → ledgerAccountId mapping.
-    await this.ensureOwnerMappingRegistered(params.owner);
 
     // Create asset
     await TestHelpers.createAssetAndWait(
@@ -195,10 +187,6 @@ export class TestFixtures {
     }> {
     const operationId = params.operationId || generateId();
 
-    // Register finId → ledgerAccountId mappings for both sides.
-    await this.ensureOwnerMappingRegistered(params.source);
-    await this.ensureOwnerMappingRegistered(params.destination);
-
     const holdRequest = await this.builder.buildSignedHoldRequest({
       source: params.source,
       destination: params.destination,
@@ -234,10 +222,6 @@ export class TestFixtures {
       asset: LedgerAPI['schemas']['asset'];
       issueAmount: number;
     }> {
-    // Register finId → ledgerAccountId mappings for investor and issuer.
-    await this.ensureOwnerMappingRegistered(params.investor);
-    await this.ensureOwnerMappingRegistered(params.issuer);
-
     // Create asset
     await TestHelpers.createAssetAndWait(
       this.client,

--- a/adapter-tests/src/utils/utils.ts
+++ b/adapter-tests/src/utils/utils.ts
@@ -1,5 +1,6 @@
 import * as secp256k1 from 'secp256k1';
 import * as crypto from 'crypto';
+import { computeAddress } from 'ethers';
 
 export const ASSET = 102;
 
@@ -42,3 +43,12 @@ export const randomResourceId = (orgId: string, resourceType: number) => {
 };
 
 export const generateIdempotencyKey = () => crypto.randomUUID();
+
+/**
+ * Derive an Ethereum address from a finId, treating the finId hex as a
+ * compressed secp256k1 pubkey. Used only by test fixtures whose actors are
+ * constructed via `createCrypto()` and therefore have a finId that IS their
+ * pubkey. This derivation does NOT belong in production adapter code — see
+ * the AccountMappingService / `ledgerAccountId` binding for that.
+ */
+export const finIdToAddress = (finId: string): string => computeAddress(`0x${finId}`);


### PR DESCRIPTION
## Summary
Fixtures in @owneraio/adapter-tests ≤0.28.3 submit signed issue/hold/etc. without first registering the test wallet's `finId → ledgerAccountId` binding. After skeleton 0.28.18 stopped deriving the wallet address from the finId, downstream adapters fail every test at fixture setup with "Credential not found".

- New `TestFixtures.ensureOwnerMappingRegistered(actor)` — POSTs `/mapping/owners` with the actor's `finId` and derived `ledgerAccountId` (idempotent).
- Called before the first state-changing op in:
  - `setupIssuedTokens` — buyer + issuer
  - `setupFiatAssetWithBalance` — owner
  - `setupEscrowHold` — source + destination
  - `setupRedemptionScenario` — investor + issuer
- `LedgerAPIClient.mapping = new MappingLedgerAPI(host)` — was defined but not wired.
- `utils.finIdToAddress(finId)` added locally (uses ethers `computeAddress`). Derivation belongs in the test framework — test actors are built via `createCrypto()` so the finId IS the secp256k1 pubkey. Production adapters look up the binding via `AccountMappingService` instead.

Bump 0.28.2 → 0.28.4 (0.28.3 was the prior dep-only republish from the skeleton-decouple PR).

## Test plan
- [x] `npm run build` clean
- [ ] CI green
- [ ] Downstream adapter: `runAdapterTests()` no longer fails at fixture setup with "Credential not found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)