### PR TITLE
skeleton: bump 0.28.20 (mapping mount stays at root)

### DIFF
--- a/skeleton/package-lock.json
+++ b/skeleton/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-  "version": "0.28.17",
+  "version": "0.28.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-      "version": "0.28.17",
+      "version": "0.28.20",
       "license": "TBD",
       "dependencies": {
         "axios": "1.11.0",

--- a/skeleton/package.json
+++ b/skeleton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-  "version": "0.28.17",
+  "version": "0.28.20",
   "description": "",
   "homepage": "https://ownera.io/",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
Originally this PR moved `registerMappingRoutes` under `basePath` so mapping endpoints would land at `/api/mapping/owners`. That broke compat with the existing root mount (`/mapping/owners`) that has been in place since #148/#194 and was published as `skeleton@0.28.19`.

Reverting the route change. PR now contains only a version bump so consumers blocked on `0.28.19` can move to a known-good build.

- Mapping endpoints remain at root: `POST /mapping/owners`, `GET /mapping/owners`, `GET /mapping/fields`.
- 0.28.18 and 0.28.19 are skipped (both published from open PRs and partial); **0.28.20** is the next master-cut release.

## Test plan
- [x] `npm run build` clean
- [ ] CI green
- [ ] eth-adapter (on 0.28.19) upgrades to 0.28.20 and continues to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)