### PR TITLE
adapter-tests: split actor pre-registration from mapping-CRUD test gate (0.28.8)

### DIFF
--- a/adapter-tests/package-lock.json
+++ b/adapter-tests/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/adapter-tests",
-  "version": "0.28.7",
+  "version": "0.28.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/adapter-tests",
-      "version": "0.28.7",
+      "version": "0.28.8",
       "license": "ISC",
       "dependencies": {
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.10",

--- a/adapter-tests/package.json
+++ b/adapter-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/adapter-tests",
-  "version": "0.28.7",
+  "version": "0.28.8",
   "description": "",
   "main": "./dist/index.js",
   "types": "dist/index.d.ts",

--- a/adapter-tests/src/business-logic.test.ts
+++ b/adapter-tests/src/business-logic.test.ts
@@ -5,7 +5,7 @@ import { TestFixtures } from './utils/test-fixtures';
 import { ADDRESSES, ACTOR_NAMES } from './utils/test-constants';
 import { generateId } from './utils/utils';
 
-export function businessLogicTests(config: { mapping?: boolean } = {}) {
+export function businessLogicTests() {
   describe('Business Logic - Negative Tests', () => {
 
     let client: LedgerAPIClient;
@@ -19,7 +19,7 @@ export function businessLogicTests(config: { mapping?: boolean } = {}) {
       // @ts-ignore
       orgId = global.orgId;
 
-      builder = new TestDataBuilder(orgId, 1, ADDRESSES.ZERO_ADDRESS, config.mapping ? client : undefined);
+      builder = new TestDataBuilder(orgId, 1, ADDRESSES.ZERO_ADDRESS, client);
       fixtures = new TestFixtures(client, builder);
     });
 

--- a/adapter-tests/src/index.ts
+++ b/adapter-tests/src/index.ts
@@ -10,11 +10,21 @@ export interface AdapterTestConfig {
   mapping?: boolean;
 }
 
+/**
+ * `config.mapping` gates ONLY the mapping-CRUD test suite
+ * (`mappingOperationsTests`) — depth-asserts on the mapping API that
+ * on-chain-credential-only adapters can't satisfy.
+ *
+ * Actor pre-registration via `TestDataBuilder.buildActor` is independent
+ * of this flag: it always POSTs the actor's `finId → ledgerAccountId`
+ * to keep buildActor-style fixtures derivation-independent, and it's
+ * idempotent for adapters that map-then-derive.
+ */
 export function runAdapterTests(config?: AdapterTestConfig) {
   describe('FinP2P Adapter Test Suite', () => {
-    businessLogicTests(config);
-    tokenLifecycleTests(config);
-    insufficientBalanceTest(config);
+    businessLogicTests();
+    tokenLifecycleTests();
+    insufficientBalanceTest();
     if (config?.mapping) {
       mappingOperationsTests();
     }

--- a/adapter-tests/src/insufficient-balance.test.ts
+++ b/adapter-tests/src/insufficient-balance.test.ts
@@ -5,7 +5,7 @@ import { ADDRESSES, ACTOR_NAMES } from './utils/test-constants';
 import { generateId } from './utils/utils';
 import { TestHelpers } from './utils/test-assertions';
 
-export function insufficientBalanceTest(config: { mapping?: boolean } = {}) {
+export function insufficientBalanceTest() {
   describe('Insufficient Balance - Negative Tests', () => {
 
     let client: LedgerAPIClient;
@@ -19,7 +19,7 @@ export function insufficientBalanceTest(config: { mapping?: boolean } = {}) {
       // @ts-ignore
       orgId = global.orgId;
 
-      builder = new TestDataBuilder(orgId, 1, ADDRESSES.ZERO_ADDRESS, config.mapping ? client : undefined);
+      builder = new TestDataBuilder(orgId, 1, ADDRESSES.ZERO_ADDRESS, client);
       fixtures = new TestFixtures(client, builder);
     });
 

--- a/adapter-tests/src/token-lifecycle.test.ts
+++ b/adapter-tests/src/token-lifecycle.test.ts
@@ -4,7 +4,7 @@ import { ReceiptAssertions, TestHelpers } from './utils/test-assertions';
 import { TestFixtures } from './utils/test-fixtures';
 import { ADDRESSES, SCENARIOS, ACTOR_NAMES } from './utils/test-constants';
 
-export function tokenLifecycleTests(config: { mapping?: boolean } = {}) {
+export function tokenLifecycleTests() {
   describe('Token Lifecycle', () => {
 
     let client: LedgerAPIClient;
@@ -18,7 +18,7 @@ export function tokenLifecycleTests(config: { mapping?: boolean } = {}) {
       // @ts-ignore
       orgId = global.orgId;
 
-      builder = new TestDataBuilder(orgId, 1, ADDRESSES.ZERO_ADDRESS, config.mapping ? client : undefined);
+      builder = new TestDataBuilder(orgId, 1, ADDRESSES.ZERO_ADDRESS, client);
       fixtures = new TestFixtures(client, builder);
     });
 


### PR DESCRIPTION
## Summary
0.28.7 used a single `config.mapping` flag for two unrelated concerns:
- **pre-register actor mappings** so `buildActor`-style fixtures don't depend on `finId → address` derivation — universally desirable.
- **run mapping-API CRUD tests** that depth-assert on arbitrary `ledgerAccountId` strings, multi-field per finId, unfiltered enumeration, and soft-delete via `status: inactive` — only valid for adapters with a full mapping CRUD surface. On-chain-credential-only adapters (e.g. finp2p-contract mode) can't satisfy these.

The conflation meant such adapters had no way to get working integration tests AND skip the unsupported CRUD assertions.

Split:
- Always thread `client` into `TestDataBuilder` in the default suites — `buildActor` registration is now unconditional. Idempotent for adapters that map-then-derive, so no behavior change for them.
- `config.mapping` continues to gate only `mappingOperationsTests`.
- The three suite functions (`tokenLifecycleTests`, `businessLogicTests`, `insufficientBalanceTest`) no longer take a config arg.

Bump 0.28.7 → 0.28.8.

## Test plan
- [x] `npm run build` clean
- [ ] finp2p-contract adapter: `runAdapterTests()` succeeds end-to-end without `config.mapping`

🤖 Generated with [Claude Code](https://claude.com/claude-code)