### PR TITLE
finp2p-client: createLoanIntent — set signaturePolicy: presignedPolicy (0.28.17)

### DIFF
--- a/finp2p-client/package-lock.json
+++ b/finp2p-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.28.12",
+  "version": "0.28.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-client",
-      "version": "0.28.12",
+      "version": "0.28.17",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.12.2",

--- a/finp2p-client/package.json
+++ b/finp2p-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.28.12",
+  "version": "0.28.17",
   "description": "FinP2P API Client",
   "homepage": "https://ownera.io/",
   "main": "./dist/index.js",

--- a/finp2p-client/src/flows.ts
+++ b/finp2p-client/src/flows.ts
@@ -425,6 +425,12 @@ export interface LoanIntentParams {
   /** Epoch seconds */
   closeDate?: number;
   conditions?: LoanConditions;
+  /**
+   * Signature policy. Defaults to `{ type: 'presignedPolicy' }`. Required by
+   * finp2p-node — omitting it makes the proto conversion nil-deref and the
+   * handler crash with HTTP 502.
+   */
+  signaturePolicy?: { type: 'presignedPolicy' };
 }
 
 export async function createLoanIntent(client: FinP2PClient, params: LoanIntentParams): Promise<string> {
@@ -472,6 +478,7 @@ export async function createLoanIntent(client: FinP2PClient, params: LoanIntentP
         },
       }],
       loanInstruction,
+      signaturePolicy: params.signaturePolicy ?? { type: 'presignedPolicy' },
     },
   }));
   if (!res.id) throw new Error('Failed to create loan intent');


### PR DESCRIPTION
## Summary
`createLoanIntent` never sets `signaturePolicy` in the intent body. The OpenAPI schema declares it as `signaturePolicy?: presignedSignaturePolicy` on `loanIntent`, but finp2p-node's proto conversion nil-derefs without it — the handler panics and the client gets HTTP 502 (traefik). Currently blocks the repo flow at step 6 in env.local.eth-dtcc.

Default to `{ type: 'presignedPolicy' }` (matching what the node expects). Expose `signaturePolicy?: { type: 'presignedPolicy' }` on `LoanIntentParams` so callers can override.

Bump 0.28.12 → 0.28.17 (skipping 0.28.13–0.28.16 — already in the registry from the still-open privateOffer-variants PR #209).

## Test plan
- [x] `npm run build` clean
- [ ] CI green
- [ ] Repo flow (eth-dtcc scenario) succeeds past step 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)