### PR TITLE
finp2p-client: executeLoanIntent — pass through loanInstruction (0.28.19)

### DIFF
--- a/finp2p-client/package-lock.json
+++ b/finp2p-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.28.18",
+  "version": "0.28.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-client",
-      "version": "0.28.18",
+      "version": "0.28.19",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.12.2",

--- a/finp2p-client/package.json
+++ b/finp2p-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.28.18",
+  "version": "0.28.19",
   "description": "FinP2P API Client",
   "homepage": "https://ownera.io/",
   "main": "./dist/index.js",

--- a/finp2p-client/src/flows.ts
+++ b/finp2p-client/src/flows.ts
@@ -994,11 +994,33 @@ export interface ExecuteLoanIntentParams {
   executorType: 'borrower' | 'lender';
   borrower: { id: string; finId: string; custodianOrgId: string };
   lender: { id: string; finId: string; custodianOrgId: string };
+
+  /** Epoch seconds — required when `conditions` is supplied. */
+  openDate?: number;
+  /** Epoch seconds — required when `conditions` is supplied. */
+  closeDate?: number;
+  /**
+   * Loan-specific conditions. Mirror what was passed to `createLoanIntent`
+   * — the node panics on a nil `loanInstruction` if the intent type
+   * requires it.
+   */
+  conditions?: LoanConditions;
 }
 
 export async function executeLoanIntent(client: FinP2PClient, params: ExecuteLoanIntentParams): Promise<string> {
   const assetOrgId = extractOrgId(params.asset.id);
   const user = params.executorType === 'borrower' ? params.borrower.id : params.lender.id;
+
+  // `loanInstruction.conditions` is required by the schema, so only include
+  // `loanInstruction` when the caller supplied `conditions` — same gating
+  // as createLoanIntent.
+  const loanInstruction = params.conditions
+    ? {
+      openDate: params.openDate!,
+      closeDate: params.closeDate!,
+      conditions: params.conditions,
+    }
+    : undefined;
 
   const res = await unwrapOperation<{ executionPlanId: string }>(client, client.executeIntent({
     user,
@@ -1036,6 +1058,7 @@ export async function executeLoanIntent(client: FinP2PClient, params: ExecuteLoa
           },
         },
       },
+      loanInstruction,
     },
   }));
   if (!res.executionPlanId) throw new Error('Failed to execute loan intent');


### PR DESCRIPTION
## Summary
Follow-up to the 0.28.18 `createLoanIntent` signaturePolicy fix, same bug shape one level deeper. `ExecuteLoanIntentParams` had no `openDate` / `closeDate` / `conditions`, and the helper never emitted `loanInstruction` on the `loanIntentExecution` body. The node spec requires it; without it `LoanIntentExecution.buildTemplateDescriptorEip712` nil-derefs.

Extend `ExecuteLoanIntentParams` with the same optional triple `createLoanIntent` already takes (`openDate`, `closeDate`, `conditions`) and emit `loanInstruction` on the request body when `conditions` is supplied — identical gating to the create-side helper, so callers can't accidentally send a half-built instruction.

Bump 0.28.18 → 0.28.19.

## Test plan
- [x] `npm run build` clean
- [ ] CI green
- [ ] Repo flow exec step succeeds end-to-end (loanIntent → execute)

🤖 Generated with [Claude Code](https://claude.com/claude-code)