### PR TITLE
finp2p-client: createLoanIntent — settlement accounts use settlementOrgId (0.28.20)

### DIFF
--- a/finp2p-client/package-lock.json
+++ b/finp2p-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.28.19",
+  "version": "0.28.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-client",
-      "version": "0.28.19",
+      "version": "0.28.20",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.12.2",

--- a/finp2p-client/package-lock.json
+++ b/finp2p-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.28.18",
+  "version": "0.28.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-client",
-      "version": "0.28.18",
+      "version": "0.28.19",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.12.2",

--- a/finp2p-client/package.json
+++ b/finp2p-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.28.19",
+  "version": "0.28.20",
   "description": "FinP2P API Client",
   "homepage": "https://ownera.io/",
   "main": "./dist/index.js",

--- a/finp2p-client/package.json
+++ b/finp2p-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.28.18",
+  "version": "0.28.19",
   "description": "FinP2P API Client",
   "homepage": "https://ownera.io/",
   "main": "./dist/index.js",

--- a/finp2p-client/src/flows.ts
+++ b/finp2p-client/src/flows.ts
@@ -994,11 +994,33 @@ export interface ExecuteLoanIntentParams {
   executorType: 'borrower' | 'lender';
   borrower: { id: string; finId: string; custodianOrgId: string };
   lender: { id: string; finId: string; custodianOrgId: string };
+
+  /** Epoch seconds — required when `conditions` is supplied. */
+  openDate?: number;
+  /** Epoch seconds — required when `conditions` is supplied. */
+  closeDate?: number;
+  /**
+   * Loan-specific conditions. Mirror what was passed to `createLoanIntent`
+   * — the node panics on a nil `loanInstruction` if the intent type
+   * requires it.
+   */
+  conditions?: LoanConditions;
 }
 
 export async function executeLoanIntent(client: FinP2PClient, params: ExecuteLoanIntentParams): Promise<string> {
   const assetOrgId = extractOrgId(params.asset.id);
   const user = params.executorType === 'borrower' ? params.borrower.id : params.lender.id;
+
+  // `loanInstruction.conditions` is required by the schema, so only include
+  // `loanInstruction` when the caller supplied `conditions` — same gating
+  // as createLoanIntent.
+  const loanInstruction = params.conditions
+    ? {
+      openDate: params.openDate!,
+      closeDate: params.closeDate!,
+      conditions: params.conditions,
+    }
+    : undefined;
 
   const res = await unwrapOperation<{ executionPlanId: string }>(client, client.executeIntent({
     user,
@@ -1036,6 +1058,7 @@ export async function executeLoanIntent(client: FinP2PClient, params: ExecuteLoa
           },
         },
       },
+      loanInstruction,
     },
   }));
   if (!res.executionPlanId) throw new Error('Failed to execute loan intent');

--- a/finp2p-client/src/flows.ts
+++ b/finp2p-client/src/flows.ts
@@ -520,15 +520,6 @@ export async function createLoanIntent(client: FinP2PClient, params: LoanIntentP
   const assetOrgId = extractOrgId(params.asset.id);
   const { start, end } = intentWindow();
 
-  const borrowerAccount = (assetRef: Finp2pAsset) => ({
-    asset: finp2pAsset(assetRef),
-    account: finIdAccount(params.borrowerFinId, assetOrgId, params.custodianOrgId),
-  });
-  const lenderAccount = (assetRef: Finp2pAsset) => ({
-    asset: finp2pAsset(assetRef),
-    account: finIdAccount(params.lenderFinId, assetOrgId, params.custodianOrgId),
-  });
-
   // `loanInstruction.conditions` is required by the schema, so only include
   // `loanInstruction` when the caller supplied `conditions`.
   const loanInstruction = params.conditions
@@ -549,15 +540,27 @@ export async function createLoanIntent(client: FinP2PClient, params: LoanIntentP
       asset: {
         assetTerm: { amount: String(params.loanAmount) },
         assetInstruction: {
-          borrowerAccount: borrowerAccount(params.asset),
-          lenderAccount: lenderAccount(params.asset),
+          borrowerAccount: {
+            asset: finp2pAsset(params.asset),
+            account: finIdAccount(params.borrowerFinId, assetOrgId, params.custodianOrgId),
+          },
+          lenderAccount: {
+            asset: finp2pAsset(params.asset),
+            account: finIdAccount(params.lenderFinId, assetOrgId, params.custodianOrgId),
+          },
         },
       },
       settlement: [{
         settlementTerm: { type: 'partialSettlement', unitValue: params.price.toFixed(2) },
         settlementInstruction: {
-          borrowerAccount: borrowerAccount(params.settlementAsset),
-          lenderAccount: lenderAccount(params.settlementAsset),
+          borrowerAccount: {
+            asset: finp2pAsset(params.settlementAsset),
+            account: finIdAccount(params.borrowerFinId, params.settlementOrgId, params.custodianOrgId),
+          },
+          lenderAccount: {
+            asset: finp2pAsset(params.settlementAsset),
+            account: finIdAccount(params.lenderFinId, params.settlementOrgId, params.custodianOrgId),
+          },
         },
       }],
       loanInstruction,


### PR DESCRIPTION
## Summary
Follow-up to the createLoanIntent / executeLoanIntent fixes in 0.28.18 and 0.28.19. The settlement-side accounts on **createLoanIntent** were built via the same factory closure as the asset-side accounts, which baked in `assetOrgId` (extracted from `params.asset.id` — the collateral side). For cross-org DvP-style loans where collateral and settlement live on different orgs, the settlement-side `account.orgId` was wrong; the settlement-org's approval workflow rejected with `validateLoanIntent: mismatch intent settlement … account: org id <collateral-org> does not match org id <settlement-org>` and the plan stayed Pending forever.

Fix: build settlement-side `borrowerAccount`/`lenderAccount` with `params.settlementOrgId` directly. The field has been there all along — just wasn't threaded through. Inlined both legs at the call site so the asset/settlement split is obvious.

**executeLoanIntent's settlement-side already uses `params.settlementOrgId` correctly**, so no change there.

Stacks on PR #220 (executeLoanIntent loanInstruction passthrough). Bump 0.28.19 → 0.28.20.

## Test plan
- [x] `npm run build` clean
- [ ] CI green
- [ ] Cross-org loan flow: create + execute + approval workflow does not reject on settlement org

🤖 Generated with [Claude Code](https://claude.com/claude-code)