### PR TITLE
finp2p-client: fromBaseUrl, upsert bind helpers, waitForOwnerBalance (0.28.21)

### DIFF
--- a/finp2p-client/package-lock.json
+++ b/finp2p-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.28.20",
+  "version": "0.28.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-client",
-      "version": "0.28.20",
+      "version": "0.28.21",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.12.2",

--- a/finp2p-client/package.json
+++ b/finp2p-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.28.20",
+  "version": "0.28.21",
   "description": "FinP2P API Client",
   "homepage": "https://ownera.io/",
   "main": "./dist/index.js",

--- a/finp2p-client/src/client.ts
+++ b/finp2p-client/src/client.ts
@@ -16,6 +16,16 @@ export class FinP2PClient {
     this.ossClient = new OssClient(ossUrl, authTokenResolver);
   }
 
+  /**
+   * Build a client from a single router base URL. Hides the `/finapi` and
+   * `/oss/query` suffix split so callers don't have to know the SDK's internal
+   * URL convention. Trailing slashes on `baseUrl` are stripped.
+   */
+  static fromBaseUrl(baseUrl: string, authTokenResolver?: (() => string)): FinP2PClient {
+    const base = baseUrl.replace(/\/+$/, '');
+    return new FinP2PClient(`${base}/finapi`, `${base}/oss/query`, authTokenResolver);
+  }
+
   // ── Owner / Profile ──
 
   async createOwner() {
@@ -115,6 +125,29 @@ export class FinP2PClient {
     return this.finAPIClient.updateLedger(...args);
   }
 
+  /**
+   * Bind a ledger, falling back to update when the router reports a 409
+   * (the name is already bound). Returns `"created"` for the bind path,
+   * `"updated"` for the conflict-fall-through. The update path uses the
+   * `name` from the bind body and the same body shape.
+   *
+   * Assumes the server uses HTTP 409 to signal "already bound" — if that
+   * contract changes, this helper will misclassify and silently fall back.
+   */
+  async upsertLedgerBinding(
+    body: Parameters<FinAPIClient['bindLedger']>[0],
+  ): Promise<'created' | 'updated'> {
+    const result = await this.finAPIClient.bindLedger(body);
+    if ((result as any)?.response?.status === 409) {
+      await (this.finAPIClient as any).updateLedger((body as any).name, body);
+      return 'updated';
+    }
+    if ((result as any)?.error) {
+      throw new Error(`upsertLedgerBinding: ${JSON.stringify((result as any).error)}`);
+    }
+    return 'created';
+  }
+
   // ── Custody provider management ──
 
   async bindCustodyProvider(...args: Parameters<FinAPIClient['bindCustodyProvider']>) {
@@ -123,6 +156,25 @@ export class FinP2PClient {
 
   async updateCustodyProvider(...args: Parameters<FinAPIClient['updateCustodyProvider']>) {
     return this.finAPIClient.updateCustodyProvider(...args);
+  }
+
+  /**
+   * Bind a custody provider, falling back to update when the router reports
+   * a 409 (the name is already bound). See `upsertLedgerBinding` for the
+   * same caveats around the 409 contract.
+   */
+  async upsertCustodyProvider(
+    body: Parameters<FinAPIClient['bindCustodyProvider']>[0],
+  ): Promise<'created' | 'updated'> {
+    const result = await this.finAPIClient.bindCustodyProvider(body);
+    if ((result as any)?.response?.status === 409) {
+      await (this.finAPIClient as any).updateCustodyProvider((body as any).name, body);
+      return 'updated';
+    }
+    if ((result as any)?.error) {
+      throw new Error(`upsertCustodyProvider: ${JSON.stringify((result as any).error)}`);
+    }
+    return 'created';
   }
 
   // ── Approval routing ──
@@ -323,6 +375,45 @@ export class FinP2PClient {
     }
 
     throw new Error(`Execution plan ${planId} did not complete within ${maxTimes * delay}ms`);
+  }
+
+  /**
+   * Poll an owner's holding for the given asset until the balance matches
+   * `expected` (within `delta`), or `maxTimes * delay`ms elapses.
+   *
+   * `kind` selects which fields must match:
+   *   - `'synced'` (default): the on-chain-synced view (`syncedBalance`).
+   *   - `'internal'`: the local ledger view (`balance`).
+   *   - `'both'`: both views must match.
+   *
+   * Resolves `true` on first match, `false` if the polling window runs out.
+   * Useful in e2e flows where the synced view trails the ledger move.
+   */
+  async waitForOwnerBalance(
+    ownerId: string,
+    assetId: string,
+    expected: number,
+    opts: { kind?: 'internal' | 'synced' | 'both'; delta?: number; delay?: number; maxTimes?: number } = {},
+  ): Promise<boolean> {
+    const { kind = 'synced', delta = 0.01, delay = 500, maxTimes = 30 } = opts;
+    for (let i = 0; i < maxTimes; i++) {
+      try {
+        const holdings = await this.ossClient.getOwnerHoldings(ownerId);
+        const holding = holdings.find((h) => h.asset.resourceId === assetId);
+        if (holding) {
+          const close = (v: string) => Math.abs(parseFloat(v) - expected) <= delta;
+          const internal = close(holding.balance);
+          const synced = close(holding.syncedBalance);
+          if (kind === 'internal' && internal) return true;
+          if (kind === 'synced' && synced) return true;
+          if (kind === 'both' && internal && synced) return true;
+        }
+      } catch {
+        // holding may not exist yet
+      }
+      await sleep(delay);
+    }
+    return false;
   }
 
   async waitForSyncedBalance(


### PR DESCRIPTION
## Summary
Three SDK conveniences requested by the e2e team — every test suite and operator script was re-implementing the same boilerplate.

- **`FinP2PClient.fromBaseUrl(baseUrl, authResolver?)`** — static factory hiding the `/finapi` and `/oss/query` URL split. Trailing slashes stripped.
- **`upsertLedgerBinding(body)` / `upsertCustodyProvider(body)`** — try the bind; on HTTP 409 fall back to update with `body.name` as the path id. Returns `"created" | "updated"`. Encodes a server contract (409 = name conflict) — if that changes the fallback will silently misclassify; flagged in the JSDoc.
- **`waitForOwnerBalance(ownerId, assetId, expected: number, opts?)`** — numeric balance poll with tolerance. `kind: 'internal' | 'synced' | 'both'`, `delta` default 0.01, `delay` 500ms, `maxTimes` 30. Resolves `true` on first match, `false` if the window runs out.

Existing `waitForSyncedBalance(…, expectedBalance: string)` stays untouched — its exact-string-match semantics differ enough that quietly extending it would change behavior for current callers.

Asks #1 (`createInvestor`) and #4 (`upsertApprovalRouting`) are intentionally skipped — `createInvestor` duplicates the already-shipped `createOwner`; approval-routing config-merge is too risky to centralize in the SDK.

Bump 0.28.20 → 0.28.21.

## Test plan
- [x] `npm run build` clean
- [ ] CI green
- [ ] e2e team drops their local copies and confirms parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)