### PR TITLE
finp2p-client: investor network account onboarding (router 0.28)

### DIFF
--- a/finp2p-client/CLAUDE.md
+++ b/finp2p-client/CLAUDE.md
@@ -63,16 +63,31 @@ await client.getAssetProofPolicy(assetCode, assetType, paymentOrgId);
 
 ## API spec management
 
-Specs are sourced from the FinP2P router repo (`apis/` directory):
+Specs come from **two** upstream repos &mdash; a frequent source of confusion:
+
+| File(s) | Source |
+|---------|--------|
+| `application-api.base.yaml`, `common-external-components.yaml`, `operational-api.yaml` (from `operational-api.gen.yaml`), `dlt-adapter-api.yaml`, `custody-adapter-api.yaml` | `owneraio/finp2p-core` &rarr; `api/` |
+| `ownership.graphql` | `owneraio/oss` &rarr; `graphql/ownership.graphql` |
 
 ```bash
 npm run api-generate       # application API types
 npm run op-api-generate    # operational API types (with post-processing)
-npm run graphql-gen        # GraphQL types from .graphql schema files
+npm run graphql-gen        # GraphQL types from the vendored schema
 npm run generate-all       # all of the above
+npm run validate:graphql   # validate OSS queries against the schema (no output)
+npm run smoke              # wire-level checks; needs `npm run build` first
 ```
 
 The operational API post-processor (`scripts/postprocess-model-gen.ts`) handles the same circular reference and export issues as the skeleton's post-processor.
+
+**Re-sync `ownership.graphql` wholesale; never hand-edit it to match a query.** It is the only thing that constrains the OSS queries, so a hand-patched schema silently legitimises a broken selection set. `prebuild` runs `validate:graphql`, which checks every document in `src/oss/graphql/` against it and fails the build with a file:line pointer &mdash; so `npm run build` (what CI runs) catches a query/schema mismatch. `graphqlvalidate.ts` must keep the same `schema` and `documents` as `grahpqlgen.ts`.
+
+`dlt-adapter-api.yaml` and `custody-adapter-api.yaml` are reference copies only &mdash; no script generates from them, so nothing detects their drift. Re-sync them by hand when consulting them.
+
+### OSS version floor
+
+The OSS `NetworkAccount` was an object with a `wallet` field until [oss#557](https://github.com/owneraio/oss/pull/557) (2026-07-29) turned it into a `union NetworkAccount = WalletAccount | Caip10Account | CustodialAccount`. The two forms are mutually exclusive, so the queries here **require OSS at or past that commit**; against an older deployment they fail with `Cannot query field ... on type "NetworkAccount"`. If you ever need to target a pre-#557 router, revert the vendored schema and all three selections together &mdash; `owners.graphql`, `receipts.graphql`, `plans.graphql` &mdash; not just one.
 
 ## Build & publish
 

--- a/finp2p-client/CLAUDE.md
+++ b/finp2p-client/CLAUDE.md
@@ -35,6 +35,8 @@ An investor can have an on-chain **network account** onboarded per `(organizatio
 
 All four return `202 { cid }`. The ledger adapter then issues a **challenge**; poll `getOperationStatus(cid)` &mdash; while `isCompleted` is false the response carries `challenge`, and on completion it carries `{ id, networkAccount }`. Only the `signatureTemplate` variant round-trips through `submitAccountProof`; `walletConnect`, `deposit`, and `fireblocksApproval` are fulfilled out of band and the adapter reports verification directly.
 
+Read the onboarded accounts back from the OSS side with `getOwnerNetworkAccounts(ownerId, { organizationId?, assetId? })`, which returns `OssInvestorNetworkAccount[]`. The `account` union is discriminated by `kind` (an alias of `__typename`) &mdash; not `type`, because `WalletAccount` already has a field called `type`.
+
 Two things to know:
 
 - **`Idempotency-Key` is required** on all four routes &mdash; they are the only application-API routes where it is not optional. The client defaults it to `generateNonce().toString('hex')`; every method takes an optional trailing `idempotencyKey` to override.

--- a/finp2p-client/CLAUDE.md
+++ b/finp2p-client/CLAUDE.md
@@ -22,6 +22,24 @@ REST client for the FinP2P router's application and operational APIs:
 - **`op-model-gen.ts`** &mdash; Types generated from the router's `operational-api.yaml` OpenAPI spec (includes the `operationStatus` type used for callbacks)
 - **`finapi.client.ts`** &mdash; `FinAPIClient` &mdash; HTTP client using `openapi-fetch`. Key methods: `createAsset`, `shareProfile`, `getOperationStatus`, `sendCallback`, `importTransactions`, `getExecutionPlan`, `waitForOperationCompletion`
 
+### Investor network accounts (onboarding)
+
+An investor can have an on-chain **network account** onboarded per `(organization, asset)`, which operation legs may then name explicitly via the optional `networkAccount` field on the shared account schemas.
+
+| Method | Route |
+|--------|-------|
+| `createInvestorAccount` | `POST /profiles/investor/{investorId}/account/create` &mdash; adapter generates the account and holds the keys |
+| `bindInvestorAccount` | `POST /profiles/investor/{investorId}/account/bind` &mdash; caller supplies an existing account + `ownershipSignature` |
+| `submitAccountProof` | `POST /profiles/investor/{investorId}/account/proof` &mdash; fulfils a `signatureTemplate` challenge |
+| `removeInvestorAccount` | `DELETE /profiles/investor/{investorId}/account/{accountId}` |
+
+All four return `202 { cid }`. The ledger adapter then issues a **challenge**; poll `getOperationStatus(cid)` &mdash; while `isCompleted` is false the response carries `challenge`, and on completion it carries `{ id, networkAccount }`. Only the `signatureTemplate` variant round-trips through `submitAccountProof`; `walletConnect`, `deposit`, and `fireblocksApproval` are fulfilled out of band and the adapter reports verification directly.
+
+Two things to know:
+
+- **`Idempotency-Key` is required** on all four routes &mdash; they are the only application-API routes where it is not optional. The client defaults it to `generateNonce().toString('hex')`; every method takes an optional trailing `idempotencyKey` to override.
+- **`walletAccount.type` must be exactly `'walletAccount'`.** The router compares the adapter's onboarding echo byte-for-byte against the account named on an operation leg, so any other token (e.g. `'wallet'`) causes a spurious 7351 `AccountNotWhitelisted` on every operation after a successful bind.
+
 ### OSS client (`src/oss/`)
 
 GraphQL client for the router's Object Storage Service:

--- a/finp2p-client/apis/application-api.base.yaml
+++ b/finp2p-client/apis/application-api.base.yaml
@@ -86,6 +86,156 @@ paths:
               schema:
                 $ref: '#/components/schemas/operationBase'
 
+  /profiles/investor/{investorId}/account/create:
+    post:
+      tags:
+        - profiles
+      summary: Create a new wallet for an investor (LA-generated)
+      description: |
+        The LA generates a fresh wallet on the asset's network and owns the keys. Async:
+        returns `202 { cid }`; poll `GET /operations/{cid}` for the outcome. On completion
+        the payload includes the canonical wallet `{ id, account }` and the wallet is
+        mirrored into the investor resource's `data.accounts[orgId][assetId]`.
+      parameters:
+        - in: header
+          name: Idempotency-Key
+          required: true
+          schema:
+            $ref: 'common-external-components.yaml#/components/schemas/nonce'
+        - name: investorId
+          in: path
+          description: ID of the investor profile
+          required: true
+          schema:
+            $ref: 'common-external-components.yaml#/components/schemas/ownerId'
+      operationId: createInvestorAccount
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/createInvestorAccountRequest'
+        required: true
+      responses:
+        '202':
+          description: accepted operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/operationBase'
+
+  /profiles/investor/{investorId}/account/bind:
+    post:
+      tags:
+        - profiles
+      summary: Bind an existing external wallet to an investor (caller-supplied)
+      description: |
+        Caller supplies an external network account they own. `ownershipSignature` is
+        required as proof-of-ownership and is verified by the LA. Async: returns `202 { cid }`. If the
+        wallet is already bound to another investor — or to the same investor on the same
+        `(org, asset)` — completion reports `WALLET_ALREADY_BOUND` (409). A bad signature
+        reports `WALLET_BAD_SIGNATURE` (400).
+      parameters:
+        - in: header
+          name: Idempotency-Key
+          required: true
+          schema:
+            $ref: 'common-external-components.yaml#/components/schemas/nonce'
+        - name: investorId
+          in: path
+          description: ID of the investor profile
+          required: true
+          schema:
+            $ref: 'common-external-components.yaml#/components/schemas/ownerId'
+      operationId: bindInvestorAccount
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/bindInvestorAccountRequest'
+        required: true
+      responses:
+        '202':
+          description: accepted operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/operationBase'
+
+  /profiles/investor/{investorId}/account/proof:
+    post:
+      tags:
+        - profiles
+      summary: Submit a signature proof for a pending account workflow
+      description: |
+        Used only for `signatureTemplate` challenges. The client submits an `ownershipSignature`
+        over the LA-issued payload. Advances the workflow from `AWAITING_PROOF_SUBMISSION` to
+        verification; the workflow continues async (poll `GET /operations/{cid}`).
+
+        Out-of-band challenges (walletConnect / deposit / fireblocksApproval) do not use this
+        endpoint — fulfillment happens off-platform and the LA reports verification directly to
+        the asset node per the challenge's `operationResponseStrategy`.
+      parameters:
+        - in: header
+          name: Idempotency-Key
+          required: true
+          schema:
+            $ref: 'common-external-components.yaml#/components/schemas/nonce'
+        - name: investorId
+          in: path
+          description: ID of the investor profile
+          required: true
+          schema:
+            $ref: 'common-external-components.yaml#/components/schemas/ownerId'
+      operationId: submitAccountProof
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/submitAccountProofRequest'
+        required: true
+      responses:
+        '202':
+          description: proof accepted; verification continues async
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/operationBase'
+
+  /profiles/investor/{investorId}/account/{accountId}:
+    delete:
+      tags:
+        - profiles
+      summary: Unbind a wallet from an investor
+      description: |
+        Unbinds a wallet from an investor. Asynchronous: returns `202 { cid }`; the
+        local mirror row is removed only after the LA confirms completion.
+      parameters:
+        - in: header
+          name: Idempotency-Key
+          required: true
+          schema:
+            $ref: 'common-external-components.yaml#/components/schemas/nonce'
+        - name: investorId
+          in: path
+          description: ID of the investor profile
+          required: true
+          schema:
+            $ref: 'common-external-components.yaml#/components/schemas/ownerId'
+        - name: accountId
+          in: path
+          description: LA-assigned wallet identifier
+          required: true
+          schema:
+            type: string
+      operationId: removeInvestorAccount
+      responses:
+        '202':
+          description: accepted operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/operationBase'
+
   /profiles/asset:
     post:
       tags:
@@ -105,6 +255,9 @@ paths:
               required: [ name, type, denomination, ledgerAssetBinding ]
               type: object
               properties:
+                assetId:
+                  type: string
+                  description: 'unique identifier for the asset resource, will default to generated UUID if not provided'
                 metadata:
                   type: object
                   description: The asset metadata
@@ -114,6 +267,8 @@ paths:
                   type: string
                   description: The asset configuration, in serialized JSON representation (deprecated, use metadata instead)
                   deprecated: true
+                signatureTemplate:
+                  $ref: '#/components/schemas/assetSignatureTemplate'
                 verifiers:
                   type: array
                   description: A list of regulation verifiers to execute to validate a transaction
@@ -138,8 +293,6 @@ paths:
                   $ref: '#/components/schemas/assetPolicies'
                 financialIdentifier:
                   $ref: 'common-external-components.yaml#/components/schemas/financialAssetIdentifier'
-                orgSettlementAccount:
-                  $ref: 'common-external-components.yaml#/components/schemas/walletAccount'
                 allowPolicyDefaultFallback:
                   type: boolean
                   description: Flag to indicate if default policy fallback is allowed when no matching policy is found
@@ -206,6 +359,8 @@ paths:
                   deprecated: true
                   x-custom-format: "nullable"
                   nullable: true
+                signatureTemplate:
+                  $ref: '#/components/schemas/assetSignatureTemplateOpt'
                 verifiers:
                   type: array
                   description: A list of regulation verifiers to execute to validate a transaction
@@ -228,6 +383,21 @@ paths:
                   type: boolean
                   description: Flag to indicate if the asset should be automatically shared with known organizations.
                   nullable: true
+                ledgerAssetBinding:
+                  description: >
+                    One-time update per field for the ledger asset identifier.
+                    Each field can only be set once given it's blank.
+                    Once updated the field becomes immutable and any further update attempts will be rejected.
+                  type: object
+                  required: [ledgerIdentifier]
+                  properties:
+                    ledgerIdentifier:
+                      $ref: 'common-external-components.yaml#/components/schemas/ledgerAssetIdentifier'
+                financialIdentifier:
+                  description: >
+                    Promote the asset's financial classification from NONE to a real type.
+                    Allowed only when the current type is NONE.
+                  $ref: 'common-external-components.yaml#/components/schemas/financialAssetIdentifier'
         required: true
       responses:
         '200':
@@ -288,6 +458,11 @@ paths:
                 intentId:
                   type: string
                   description: 'unique identifier for the intent, will default to generated UUID if not provided'
+                metadata:
+                  $ref: 'common-external-components.yaml#/components/schemas/customMetadata'
+                  example:
+                    orderId: "OMS-2026-48291"
+                    clientRef: "INV-SMITH-0042"
 
 
         required: true
@@ -911,6 +1086,10 @@ paths:
                 executionId:
                   type: string
                   description: 'unique identifier for the execution, will default to generated UUID if not provided'
+                observers:
+                  $ref: '#/components/schemas/executionObservers'
+                metadata:
+                  $ref: 'common-external-components.yaml#/components/schemas/customMetadata'
         required: true
       responses:
         '200':
@@ -988,6 +1167,8 @@ paths:
                       $ref: 'common-external-components.yaml#/components/schemas/assetTerm'
                     instruction:
                       $ref: 'common-external-components.yaml#/components/schemas/sourceDestinationAccountAssetInstruction'
+                metadata:
+                  $ref: 'common-external-components.yaml#/components/schemas/customMetadata'
 
         required: true
       responses:
@@ -1571,6 +1752,7 @@ components:
         - $ref: '#/components/schemas/redemptionIntentUpdatePayload'
         - $ref: '#/components/schemas/privateOfferIntentUpdatePayload'
         - $ref: '#/components/schemas/requestForTransferIntentUpdatePayload'
+        - $ref: '#/components/schemas/moveIntentUpdatePayload'
       discriminator:
         propertyName: type
         mapping:
@@ -1581,6 +1763,7 @@ components:
           redemptionIntent: '#/components/schemas/redemptionIntentUpdatePayload'
           privateOfferIntent: '#/components/schemas/privateOfferIntentUpdatePayload'
           requestForTransferIntent: '#/components/schemas/requestForTransferIntentUpdatePayload'
+          moveIntent: '#/components/schemas/moveIntentUpdatePayload'
 
     primarySaleIntentUpdatePayload:
       type: object
@@ -1671,6 +1854,26 @@ components:
         assetTerm:
           $ref: 'common-external-components.yaml#/components/schemas/assetTerm'
 
+    moveIntentUpdatePayload:
+      type: object
+      required: [ type, destinationAssets ]
+      description: >-
+        Update the allowed destination assets of a Move intent. Replaces the
+        existing list; at least one destination is required. The source asset is
+        immutable. sourceToSegregatedAccount and the per-destination
+        fromSegregatedAccount pools may also be updated.
+      properties:
+        type:
+          type: string
+          enum: [ moveIntent ]
+        destinationAssets:
+          type: array
+          minItems: 1
+          items:
+            $ref: 'common-external-components.yaml#/components/schemas/moveDestination'
+        sourceToSegregatedAccount:
+          $ref: 'common-external-components.yaml#/components/schemas/finIdAccount'
+
     noSettlementOptionUpdate:
       type: object
       required: [ type ]
@@ -1715,6 +1918,15 @@ components:
 
     # Execute intent
 
+    executionObservers:
+      type: array
+      description: >
+        Optional list of organization ids that will passively observe the orchestration plan.
+        Observers receive all plan state updates but do NOT participate in plan approval or instruction execution.
+        Their acknowledgments are not required and are not counted toward any quorum.
+      items:
+        $ref: 'common-external-components.yaml#/components/schemas/orgId'
+
     intentExecution:
       type: object
       oneOf:
@@ -1725,6 +1937,7 @@ components:
         - $ref: '#/components/schemas/redemptionIntentExecution'
         - $ref: '#/components/schemas/privateOfferIntentExecution'
         - $ref: '#/components/schemas/requestForTransferIntentExecution'
+        - $ref: '#/components/schemas/moveIntentExecution'
       discriminator:
         propertyName: type
         mapping:
@@ -1735,6 +1948,7 @@ components:
           redemptionIntentExecution: '#/components/schemas/redemptionIntentExecution'
           privateOfferIntentExecution: '#/components/schemas/privateOfferIntentExecution'
           requestForTransferIntentExecution: '#/components/schemas/requestForTransferIntentExecution'
+          moveIntentExecution: '#/components/schemas/moveIntentExecution'
 
     primarySaleExecution:
       type: object
@@ -1886,6 +2100,20 @@ components:
           type: string
           enum: [ send, request ]
           description: Indicates whether the operation is to send or request money/asset.
+        asset:
+          $ref: 'common-external-components.yaml#/components/schemas/sourceDestinationIntentAsset'
+
+    moveIntentExecution:
+      type: object
+      required: [ type, nonce, asset, owner ]
+      properties:
+        type:
+          type: string
+          enum: [ moveIntentExecution ]
+        nonce:
+          $ref: 'common-external-components.yaml#/components/schemas/nonce'
+        owner:
+          $ref: 'common-external-components.yaml#/components/schemas/ownerId'
         asset:
           $ref: 'common-external-components.yaml#/components/schemas/sourceDestinationIntentAsset'
 
@@ -2062,6 +2290,12 @@ components:
               enum: [ 'workflow' ]
             metadata:
               x-go-type-skip-optional-pointer: false
+            challenge:
+              description: >-
+                Present while an investor network-account operation (bind) is parked on
+                a ledger-adapter challenge (isCompleted=false). The client fulfils it —
+                e.g. signing a signatureTemplate payload and POSTing to .../account/proof.
+              $ref: '#/components/schemas/networkAccountChallenge'
             response:
               discriminator:
                 propertyName: type
@@ -2071,6 +2305,73 @@ components:
               oneOf:
                 - $ref: 'common-external-components.yaml#/components/schemas/APIErrorsTyped'
                 - $ref: '#/components/schemas/workflowOperationResultResponse'
+
+    networkAccountChallenge:
+      description: >-
+        A ledger-adapter-issued challenge for an investor network-account bind,
+        discriminated by `type`. New variants can be added without breaking
+        existing clients.
+      type: object
+      required: [ type ]
+      oneOf:
+        - $ref: '#/components/schemas/networkAccountChallengeSignatureTemplate'
+        - $ref: '#/components/schemas/networkAccountChallengeWalletConnect'
+        - $ref: '#/components/schemas/networkAccountChallengeDeposit'
+        - $ref: '#/components/schemas/networkAccountChallengeFireblocksApproval'
+      discriminator:
+        propertyName: type
+        mapping:
+          signatureTemplate: '#/components/schemas/networkAccountChallengeSignatureTemplate'
+          walletConnect: '#/components/schemas/networkAccountChallengeWalletConnect'
+          deposit: '#/components/schemas/networkAccountChallengeDeposit'
+          fireblocksApproval: '#/components/schemas/networkAccountChallengeFireblocksApproval'
+
+    networkAccountChallengeSignatureTemplate:
+      type: object
+      required: [ type, payload ]
+      properties:
+        type:
+          type: string
+          enum: [ signatureTemplate ]
+        payload:
+          type: string
+          description: Hex-encoded payload the wallet must sign.
+
+    networkAccountChallengeWalletConnect:
+      type: object
+      required: [ type, uri ]
+      properties:
+        type:
+          type: string
+          enum: [ walletConnect ]
+        uri:
+          type: string
+          description: WalletConnect URI to approve.
+
+    networkAccountChallengeDeposit:
+      type: object
+      required: [ type, fromAddress, toAddress, amount ]
+      properties:
+        type:
+          type: string
+          enum: [ deposit ]
+        fromAddress:
+          type: string
+        toAddress:
+          type: string
+        amount:
+          type: string
+
+    networkAccountChallengeFireblocksApproval:
+      type: object
+      required: [ type, requestId ]
+      properties:
+        type:
+          type: string
+          enum: [ fireblocksApproval ]
+        requestId:
+          type: string
+          description: Fireblocks request id awaiting approval.
 
     workflowOperationResultResponse:
       allOf:
@@ -2391,7 +2692,7 @@ components:
           type: string
         operationType:
           type: string
-          enum: [ 'hold', 'issue', 'redeem', 'release', 'transfer', 'unknown' ]
+          enum: [ 'hold', 'issue', 'redeem', 'release', 'transfer', 'move', 'unknown' ]
         timestamp:
           type: integer
 
@@ -2711,7 +3012,7 @@ components:
           description: 'name of field'
         type:
           type: string
-          enum: [ 'string', 'int' ]
+          enum: [ 'string', 'int', 'bytes' ]
           description: 'type of field'
         value:
           type: string
@@ -2786,6 +3087,48 @@ components:
         bind:
           $ref: 'common-external-components.yaml#/components/schemas/ledgerAssetIdentifier'
 
+    assetSignatureTemplate:
+      type: object
+      description: |
+        Override of the signature template used for this asset's signatures.
+        Any field omitted falls back to the ledger-binding override and then
+        to the router-config defaults.
+      properties:
+        templateType:
+          type: string
+          enum: [ hashlist, eip712 ]
+        templateVersion:
+          type: integer
+          minimum: 1
+        hashFunction:
+          type: string
+          enum: [ sha3-256, blake2b, keccak-256 ]
+
+    assetSignatureTemplateOpt:
+      x-custom-format: "nullable"
+      type: object
+      nullable: true
+      description: |
+        Override of the signature template used for this asset's signatures.
+        Null clears the asset-level override; any individual field left
+        unset falls through to the ledger / router defaults.
+      properties:
+        templateType:
+          type: string
+          enum: [ hashlist, eip712 ]
+          x-custom-format: "nullable"
+          nullable: true
+        templateVersion:
+          type: integer
+          minimum: 1
+          x-custom-format: "nullable"
+          nullable: true
+        hashFunction:
+          type: string
+          enum: [ sha3-256, blake2b, keccak-256 ]
+          x-custom-format: "nullable"
+          nullable: true
+
     ledgerTokenId:
       type: object
       required: [ type, tokenId ]
@@ -2823,6 +3166,47 @@ components:
           $ref: 'common-external-components.yaml#/components/schemas/finIdAccount'
         asset:
           $ref: 'common-external-components.yaml#/components/schemas/finp2pAssetBase'
+        marker:
+          $ref: '#/components/schemas/BalanceMarker'
+
+    BalanceMarker:
+      description: marker of balance to denote the balance as of marker
+      discriminator:
+        propertyName: type
+        mapping:
+          timestamp: '#/components/schemas/BalanceMarkerTimestamp'
+          transactionBlock: '#/components/schemas/BalanceMarkerTransactionBlock'
+      oneOf:
+        - $ref: '#/components/schemas/BalanceMarkerTimestamp'
+        - $ref: '#/components/schemas/BalanceMarkerTransactionBlock'
+
+    BalanceMarkerTimestamp:
+      type: object
+      required: [ type, timestamp ]
+      properties:
+        type:
+          type: string
+          enum: [ timestamp ]
+        timestamp:
+          type: integer
+          format: int64
+          minimum: 1
+          maximum: 9999999999
+          description: epoch timestamp in seconds
+
+    BalanceMarkerTransactionBlock:
+      type: object
+      required: [ type, blockNumber, transaction ]
+      properties:
+        type:
+          type: string
+          enum: [ transactionBlock ]
+        blockNumber:
+          type: integer
+          format: int64
+          minimum: 0
+        transaction:
+          type: string
 
     # Proofs
 
@@ -2891,6 +3275,13 @@ components:
             signatureTemplate:
               type: string
               enum: [ 'hashlist', 'EIP712' ]
+            templateVersion:
+              type: integer
+              minimum: 1
+              description: |
+                Receipt-proof signature template shape version. When omitted,
+                the verifier resolves the version from the router-config /
+                ledger-binding / asset-profile chain.
 
     signatureProofPolicyOpt:
       type: object
@@ -2910,6 +3301,15 @@ components:
               type: string
               enum: [ 'hashlist', 'EIP712' ]
               x-custom-format: "nullable+signatureTemplate"
+            templateVersion:
+              type: integer
+              minimum: 1
+              x-custom-format: "nullable"
+              nullable: true
+              description: |
+                Receipt-proof signature template shape version. When omitted
+                or null, the verifier resolves the version from the
+                router-config / ledger-binding / asset-profile chain.
 
     # Documents
 
@@ -3048,7 +3448,8 @@ components:
           properties:
             code:
               type: integer
-              description: Error code from the errorcodes catalog
+              description: |
+                Error code indicating the specific failure - for more information see [API Errors](./api-error-codes-reference).
             message:
               type: string
 
@@ -3140,5 +3541,60 @@ components:
         updatedAt:
           type: string
           format: date-time
+
+    # -------- Investor accounts (Phase 1) --------
+
+    createInvestorAccountRequest:
+      type: object
+      description: |
+        Request body for `POST /profiles/investor/{investorId}/account/create`.
+        Starts the workflow with no caller-supplied wallet — the LA generates a
+        wallet on the asset's network and owns the keys.
+      required: [ organizationId, assetId ]
+      properties:
+        organizationId:
+          $ref: 'common-external-components.yaml#/components/schemas/orgId'
+        assetId:
+          type: string
+          description: ID of the asset
+
+    bindInvestorAccountRequest:
+      type: object
+      description: |
+        Request body for `POST /profiles/investor/{investorId}/account/bind`.
+        Caller supplies an external wallet plus a proof-of-ownership signature.
+        The LA still issues a challenge (typically signatureTemplate) for final verification.
+      required: [ organizationId, assetId, networkAccount, ownershipSignature ]
+      properties:
+        organizationId:
+          $ref: 'common-external-components.yaml#/components/schemas/orgId'
+        assetId:
+          type: string
+          description: ID of the asset
+        networkAccount:
+          $ref: 'common-external-components.yaml#/components/schemas/networkAccount'
+        ownershipSignature:
+          type: string
+          description: |
+            Hex-encoded proof-of-ownership signature over the network account. The signed
+            payload binds the account to the investor/org/asset so that knowing an address
+            alone is not enough to claim it. Treated as a hint; final verification is via
+            the challenge issued by the LA.
+
+    submitAccountProofRequest:
+      type: object
+      description: |
+        Request body for `POST /profiles/investor/{investorId}/account/proof`.
+        Submits the user's signature over the LA-issued `signatureTemplate` payload.
+        Advances the workflow from `AWAITING_PROOF_SUBMISSION`.
+      required: [ cid, ownershipSignature ]
+      properties:
+        cid:
+          type: string
+          description: Correlation id of the account workflow currently in `AWAITING_PROOF_SUBMISSION`.
+        ownershipSignature:
+          type: string
+          description: Hex-encoded signature over the LA-issued `signatureTemplate` payload.
+
 
 

--- a/finp2p-client/apis/common-external-components.yaml
+++ b/finp2p-client/apis/common-external-components.yaml
@@ -1,5 +1,13 @@
 components:
   schemas:
+    customMetadata:
+      type: object
+      description: >
+        Optional. A map of key:value string pairs for custom tracing, reconciliation, and business context. Opaque to the Router.
+
+      additionalProperties:
+        type: string
+        minLength: 1
     APIError:
       type: object
       required: [code, message]
@@ -152,6 +160,10 @@ components:
           enum: ['plan']
     ApiErrorClient4XX:
       type: object
+      deprecated: true
+      description: |
+        **Deprecated.** Use the standard `APIErrors` schema instead. All 4xx error
+        responses now follow the shared error format with Ownera error codes.
       required: [status, errors, type]
       properties:
         type:
@@ -191,6 +203,10 @@ components:
           enum: ['Asset metadata and config cannot be provided at the same time']
     ApiErrorServer5XX:
       type: object
+      deprecated: true
+      description: |
+        **Deprecated.** Use the standard `APIErrors` schema instead. All 5xx error
+        responses now follow the shared error format with Ownera error codes.
       required: [status, errors, type]
       properties:
         type:
@@ -217,6 +233,10 @@ components:
           type: string
           enum: ['General server error']
     ApiAnyError:
+      deprecated: true
+      description: |
+        **Deprecated.** Use the standard `APIErrors` schema instead. All error
+        responses now follow the shared error format with Ownera error codes.
       allOf:
         - oneOf:
             - $ref: '#/components/schemas/ApiErrorClient4XX'
@@ -409,7 +429,7 @@ components:
           discriminator:
             propertyName: type
             mapping:
-              random: '#/components/schemas/pollingResultsStrategy'
+              random: '#/components/schemas/randomPollingInterval'
               absolute: '#/components/schemas/absolutePollingInterval'
               relative: '#/components/schemas/relativePollingInterval'
     relativePollingInterval:
@@ -643,21 +663,71 @@ components:
       properties:
         type:
           type: string
-          pattern: .*\S.*
-          x-autoMinLength: true
+          enum: ['walletAccount']
         address:
           type: string
           description: 'address of the wallet'
           pattern: .*\S.*
           x-autoMinLength: true
     noneAccount:
-        type: object
+      type: object
+      additionalProperties: false
+    caip10Account:
+      type: object
+      required:
+        - type
+        - network
+        - address
+      properties:
+        type:
+          type: string
+          enum: ['caip10Account']
+        network:
+          type: string
+          description: 'CAIP-2 chain_id, e.g. "eip155:1", "solana:5eykt4...", "hedera:mainnet" (the same token used by the CAIP-19 asset identifier network)'
+          pattern: .*\S.*
+          x-autoMinLength: true
+        address:
+          type: string
+          description: 'CAIP-10 account_address (chain-native address)'
+          pattern: .*\S.*
+          x-autoMinLength: true
+          maxLength: 128
+    custodialAccount:
+      type: object
+      required:
+        - type
+        - provider
+        - vaultAccountId
+      properties:
+        type:
+          type: string
+          enum: ['custodialAccount']
+        provider:
+          type: string
+          description: 'Custody provider discriminator, e.g. "fireblocks"'
+          pattern: .*\S.*
+          x-autoMinLength: true
+        vaultAccountId:
+          type: string
+          description: 'Provider-internal account identifier (e.g. a Fireblocks vault account id)'
+          pattern: .*\S.*
+          x-autoMinLength: true
+        assetId:
+          type: string
+          description: 'Optional. Narrows the custodial account to a specific asset/chain.'
+          pattern: .*\S.*
+          x-autoMinLength: true
     networkAccount:
       oneOf:
         - $ref: '#/components/schemas/walletAccount'
+        - $ref: '#/components/schemas/caip10Account'
+        - $ref: '#/components/schemas/custodialAccount'
         - $ref: '#/components/schemas/noneAccount'
-
     financialAssetIdentifier:
+      description: >
+        Globally recognized code identifying the asset across networks, routers, and counterparties. Used for balance aggregation and cross-router asset recognition. Format is validated for structure only.
+
       oneOf:
         - $ref: '#/components/schemas/financialAssetIdentifierTypeISIN'
         - $ref: '#/components/schemas/financialAssetIdentifierTypeISO4217'
@@ -669,6 +739,7 @@ components:
           ISO4217: '#/components/schemas/financialAssetIdentifierTypeISO4217'
           NONE: '#/components/schemas/financialAssetIdentifierTypeNONE'
     financialAssetIdentifierTypeISIN:
+      description: Financial instruments (equities, bonds, funds, etc.). 12-character ISO 6166 code.
       type: object
       required: [assetIdentifierType, assetIdentifierValue]
       properties:
@@ -682,6 +753,7 @@ components:
           pattern: '^[A-Z]{2}[A-Z0-9]{10}$'
           x-autoMinLength: true
     financialAssetIdentifierTypeNONE:
+      description: Asset is not registered under a global identification scheme.
       type: object
       required: [assetIdentifierType]
       properties:
@@ -690,6 +762,7 @@ components:
           enum: [NONE]
           description: Classification type standards
     financialAssetIdentifierTypeISO4217:
+      description: Fiat currencies.
       type: object
       required: [assetIdentifierType, assetIdentifierValue]
       properties:
@@ -710,7 +783,7 @@ components:
           CAIP-19: '#/components/schemas/ledgerAssetIdentifierTypeCAIP-19'
     ledgerAssetIdentifierTypeCAIP-19:
       type: object
-      required: [assetIdentifierType, network, tokenId, standard]
+      required: [assetIdentifierType, tokenId]
       properties:
         assetIdentifierType:
           type: string
@@ -756,14 +829,9 @@ components:
           minLength: 1
     assetType:
       type: string
-      enum: [ Equity, Debt, Loans, Fund, RealEstate, Commodity, Fiat, Cryptocurrency, TokenizedCash, DigitalNatives, Basket, Other ]
+      enum: [Equity, Debt, Loans, Fund, RealEstate, Commodity, Fiat, Cryptocurrency, TokenizedCash, DigitalNatives, Basket, Other]
       pattern: '^[a-zA-Z0-9\- ]*$'
-      description: |
-        The type of the asset 
-        Payment asset classification:
-        - Fiat: Government-issued currencies identified by ISO 4217 codes (e.g., USD, EUR, GBP)
-        - Cryptocurrency: Blockchain-based digital currencies identified by appropriate crypto identifiers (e.g., BTC, ETH)
-        - TokenizedCash: Blockchain-based digital cash maintaining 1:1 fiat peg (stablecoins, deposit tokens, CBDCs)
+      description: "The type of the asset \nPayment asset classification:\n- Fiat: Government-issued currencies identified by ISO 4217 codes (e.g., USD, EUR, GBP)\n- Cryptocurrency: Blockchain-based digital currencies identified by appropriate crypto identifiers (e.g., BTC, ETH)\n- TokenizedCash: Blockchain-based digital cash maintaining 1:1 fiat peg (stablecoins, deposit tokens, CBDCs)\n"
       maxLength: 150
     finIdAccount:
       type: object
@@ -787,26 +855,33 @@ components:
           $ref: '#/components/schemas/finIdAccount'
         asset:
           $ref: '#/components/schemas/finp2pAsset'
+        networkAccount:
+          $ref: '#/components/schemas/networkAccount'
+          description: |
+            Optional. Investor network account to use for this leg. Must have been
+            previously bound via `POST /profiles/investor/{investorId}/account`.
+            Whitelist-validated against `investor.data.accounts[org][asset]`
+            before forwarding to the LA. Failure → error code 7351 (AccountNotWhitelistedErr, 400).
     finp2pAssetWithNoAccount:
       type: object
       description: 'describes asset information'
-      required: [ asset ]
+      required: [asset]
       properties:
         asset:
           $ref: '#/components/schemas/finp2pAsset'
     finp2pAsset:
-        type: object
-        description: 'describes asset information'
-        required: [id, ledgerIdentifier]
-        properties:
-          id:
-            $ref: '#/components/schemas/resourceId'
-          ledgerIdentifier:
-            $ref: '#/components/schemas/ledgerAssetIdentifier'
+      type: object
+      description: 'describes asset information'
+      required: [id, ledgerIdentifier]
+      properties:
+        id:
+          $ref: '#/components/schemas/resourceId'
+        ledgerIdentifier:
+          $ref: '#/components/schemas/ledgerAssetIdentifier'
     ledgerAccountAsset:
       type: object
       description: 'describes account information'
-      required: [ finp2pAccount ]
+      required: [finp2pAccount]
       properties:
         finp2pAccount:
           $ref: '#/components/schemas/finp2pAssetAccount'
@@ -821,26 +896,33 @@ components:
           $ref: '#/components/schemas/finIdAccount'
         asset:
           $ref: '#/components/schemas/finp2pAsset'
+        networkAccount:
+          $ref: '#/components/schemas/networkAccount'
+          description: |
+            Optional. Investor network account to use for this leg. Must have been
+            previously bound via `POST /profiles/investor/{investorId}/account`.
+            Whitelist-validated against `investor.data.accounts[org][asset]`
+            before forwarding to the LA. Failure → error code 7351 (AccountNotWhitelistedErr, 400).
     importTxAccount:
-        type: object
-        required:
-            - finId
-        properties:
-            finId:
-              $ref: "#/components/schemas/finId"
+      type: object
+      required:
+        - finId
+      properties:
+        finId:
+          $ref: "#/components/schemas/finId"
     importTxAssetAccount:
       type: object
       description: 'describes account information'
-      required: [ account, asset ]
+      required: [account, asset]
       properties:
         account:
-            $ref: '#/components/schemas/importTxAccount'
+          $ref: '#/components/schemas/importTxAccount'
         asset:
           $ref: '#/components/schemas/finp2pAsset'
     importTxLedgerAssetAccount:
       type: object
       description: 'describes account information'
-      required: [ finp2pAccount ]
+      required: [finp2pAccount]
       properties:
         finp2pAccount:
           $ref: '#/components/schemas/importTxAssetAccount'
@@ -924,7 +1006,7 @@ components:
     # Intent Schemas
     intentType:
       type: string
-      enum: ['primarySale', 'buyingIntent', 'sellingIntent', 'loanIntent', 'redemptionIntent', 'privateOfferIntent', 'requestForTransferIntent']
+      enum: ['primarySale', 'buyingIntent', 'sellingIntent', 'loanIntent', 'redemptionIntent', 'privateOfferIntent', 'requestForTransferIntent', 'moveIntent']
     intent:
       type: object
       oneOf:
@@ -935,6 +1017,7 @@ components:
         - $ref: '#/components/schemas/redemptionIntent'
         - $ref: '#/components/schemas/privateOfferIntent'
         - $ref: '#/components/schemas/requestForTransferIntent'
+        - $ref: '#/components/schemas/moveIntent'
       discriminator:
         propertyName: type
         mapping:
@@ -945,6 +1028,7 @@ components:
           redemptionIntent: '#/components/schemas/redemptionIntent'
           privateOfferIntent: '#/components/schemas/privateOfferIntent'
           requestForTransferIntent: '#/components/schemas/requestForTransferIntent'
+          moveIntent: '#/components/schemas/moveIntent'
     primarySale:
       type: object
       required: [type, issuer, asset, settlement]
@@ -960,7 +1044,7 @@ components:
           $ref: '#/components/schemas/sellingSettlements'
     buyingIntent:
       type: object
-      required: [type, buyer, asset]
+      required: [type, buyer, asset, settlement]
       properties:
         type:
           type: string
@@ -1007,7 +1091,7 @@ components:
               manualPolicy: '#/components/schemas/manualSignaturePolicy'
     loanIntent:
       type: object
-      required: [type, creatorType, borrower, lender, asset]
+      required: [type, creatorType, borrower, lender, asset, settlement]
       properties:
         type:
           type: string
@@ -1034,7 +1118,7 @@ components:
               presignedPolicy: '#/components/schemas/presignedSignaturePolicy'
     redemptionIntent:
       type: object
-      required: [type, issuer, asset]
+      required: [type, issuer, asset, settlement]
       properties:
         type:
           type: string
@@ -1054,11 +1138,11 @@ components:
           discriminator:
             propertyName: type
             mapping:
-              preSignedPolicy: '#/components/schemas/presignedSignaturePolicy'
+              presignedPolicy: '#/components/schemas/presignedSignaturePolicy'
               manualPolicy: '#/components/schemas/manualSignaturePolicy'
     privateOfferIntent:
       type: object
-      required: [type, buyer, seller, asset]
+      required: [type, buyer, seller, asset, settlement]
       properties:
         type:
           type: string
@@ -1080,6 +1164,54 @@ components:
             mapping:
               presignedPolicy: '#/components/schemas/presignedSignaturePolicy'
               manualPolicy: '#/components/schemas/manualSignaturePolicy'
+    moveIntent:
+      type: object
+      # A Move intent carries no issuer — it is an org-level migration declared by
+      # the source asset's own organization (creation is restricted to that org).
+      required: [type, asset]
+      properties:
+        type:
+          type: string
+          enum: [moveIntent]
+        asset:
+          $ref: '#/components/schemas/moveAsset'
+        signaturePolicy:
+          oneOf:
+            - $ref: '#/components/schemas/presignedSignaturePolicy'
+            - $ref: '#/components/schemas/manualSignaturePolicy'
+          discriminator:
+            propertyName: type
+            mapping:
+              presignedPolicy: '#/components/schemas/presignedSignaturePolicy'
+              manualPolicy: '#/components/schemas/manualSignaturePolicy'
+    moveDestination:
+      type: object
+      description: 'a Move destination asset. Superset of finp2pAsset (same required id + ledgerIdentifier), plus an optional pre-funded pool the Transfer drains into the destination for the hold-transfer-* variants.'
+      required: [id, ledgerIdentifier]
+      properties:
+        id:
+          $ref: '#/components/schemas/resourceId'
+        ledgerIdentifier:
+          $ref: '#/components/schemas/ledgerAssetIdentifier'
+        fromSegregatedAccount:
+          $ref: '#/components/schemas/finIdAccount'
+        fromSegregatedAccountOwner:
+          description: 'owner of the pre-funded pool account — the Transfer seller (debited party) for receipts and regulation. Required when fromSegregatedAccount is set.'
+          $ref: '#/components/schemas/resourceId'
+    moveAsset:
+      type: object
+      description: 'asset-level migration path declared by the source asset''s organization; source + one-or-more destination assets (no quantity). Optional sourceToSegregatedAccount receives held source tokens on release (instead of burning); each destination may carry a pre-funded fromSegregatedAccount pool for the hold-transfer-* variants. The executor picks one destination at execution.'
+      required: [sourceAsset, destinationAssets]
+      properties:
+        sourceAsset:
+          $ref: '#/components/schemas/finp2pAsset'
+        destinationAssets:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/moveDestination'
+        sourceToSegregatedAccount:
+          $ref: '#/components/schemas/finIdAccount'
     requestForTransferIntent:
       type: object
       required: [type, sender, receiver, asset]
@@ -1129,7 +1261,7 @@ components:
           $ref: '#/components/schemas/destinationAccountAssetInstruction'
     issuingAsset:
       type: object
-      required: [ assetInstruction, assetTerm ]
+      required: [assetInstruction, assetTerm]
       properties:
         assetTerm:
           $ref: '#/components/schemas/assetTerm'
@@ -1137,7 +1269,7 @@ components:
           $ref: '#/components/schemas/sourceOnlyAssetDestinationAccountLedgerAssetInstruction'
     redemptionAsset:
       type: object
-      required: [ assetInstruction, assetTerm ]
+      required: [assetInstruction, assetTerm]
       properties:
         assetTerm:
           $ref: '#/components/schemas/assetTerm'
@@ -1153,7 +1285,7 @@ components:
           $ref: '#/components/schemas/borrowerLenderAccountAssetInstruction'
     loanExecuteAsset:
       type: object
-      required: [ assetInstruction, assetTerm ]
+      required: [assetInstruction, assetTerm]
       properties:
         assetTerm:
           $ref: '#/components/schemas/assetTerm'
@@ -1188,7 +1320,7 @@ components:
         $ref: '#/components/schemas/sellingSettlementBase'
     sellingSettlementBase:
       type: object
-      required: [settlementTerm, settlementInstruction]
+      required: [settlementTerm]
       properties:
         settlementTerm:
           $ref: '#/components/schemas/settlementTerm'
@@ -1201,7 +1333,7 @@ components:
         $ref: '#/components/schemas/buyingSettlementBase'
     buyingSettlementBase:
       type: object
-      required: [settlementInstruction, settlementTerm]
+      required: [settlementTerm]
       properties:
         settlementTerm:
           $ref: '#/components/schemas/settlementTerm'
@@ -1214,7 +1346,7 @@ components:
         $ref: '#/components/schemas/loanIntentSettlementBase'
     loanIntentSettlementBase:
       type: object
-      required: [settlementInstruction, settlementTerm]
+      required: [settlementTerm]
       properties:
         settlementTerm:
           $ref: '#/components/schemas/settlementTerm'
@@ -1234,29 +1366,29 @@ components:
         - $ref: '#/components/schemas/fullSettlementOption'
     partialSettlementOption:
       type: 'object'
-      required: [ 'type', 'unitValue' ]
+      required: ['type', 'unitValue']
       properties:
         type:
           type: 'string'
-          enum: [ 'partialSettlement' ]
+          enum: ['partialSettlement']
         unitValue:
           $ref: '#/components/schemas/unitValue'
     fullSettlementOption:
       type: 'object'
-      required: [ 'type', 'amount' ]
+      required: ['type', 'amount']
       properties:
         type:
           type: 'string'
-          enum: [ 'fullSettlement' ]
+          enum: ['fullSettlement']
         amount:
           $ref: '#/components/schemas/amount'
     noSettlementOption:
       type: 'object'
-      required: [ 'type' ]
+      required: ['type']
       properties:
         type:
           type: 'string'
-          enum: [ 'noSettlement' ]
+          enum: ['noSettlement']
     assetTerm:
       type: object
       required: [amount]
@@ -1285,7 +1417,7 @@ components:
           $ref: '#/components/schemas/finp2pAssetAccount'
     sourceDestinationAccountLedgerAssetInstruction:
       type: object
-      required: [ sourceAccount, destinationAccount ]
+      required: [sourceAccount, destinationAccount]
       properties:
         sourceAccount:
           $ref: '#/components/schemas/finp2pAssetAccount'
@@ -1293,7 +1425,7 @@ components:
           $ref: '#/components/schemas/finp2pAssetAccount'
     sourceOnlyAssetDestinationAccountLedgerAssetInstruction:
       type: object
-      required: [ sourceAccount, destinationAccount ]
+      required: [sourceAccount, destinationAccount]
       properties:
         sourceAccount:
           $ref: '#/components/schemas/finp2pAssetWithNoAccount'
@@ -1307,7 +1439,7 @@ components:
           $ref: '#/components/schemas/finp2pAssetAccountOptional'
     optionalDestinationAccountAssetInstruction:
       type: object
-      required: [ destinationAccount ]
+      required: [destinationAccount]
       properties:
         destinationAccount:
           $ref: '#/components/schemas/finp2pAssetAccountOptional'

--- a/finp2p-client/apis/custody-adapter-api.yaml
+++ b/finp2p-client/apis/custody-adapter-api.yaml
@@ -26,6 +26,7 @@ paths:
           schema:
             type: string
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -36,7 +37,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'common-external-components.yaml#/components/schemas/PlanApprovalResponse'
+                $ref: 'common-external-components.yaml#/components/schemas/ExecutionPlanApprovalOperation'
         '202':
           description: Operation is pending
           content:
@@ -105,6 +106,7 @@ paths:
       description: Request adapter approval or rejection to a proposal in an execution plan
       operationId: executionPlanProposal
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -116,12 +118,6 @@ paths:
             application/json:
               schema:
                 $ref: 'common-external-components.yaml#/components/schemas/ApproveExecutionPlanResponse'
-        '400':
-          description: Invalid Input
-          content: {}
-        '500':
-          description: System error
-          content: {}
   /plan/proposal/status:
     post:
       tags:
@@ -130,6 +126,7 @@ paths:
       description: notify the adapter on proposal status
       operationId: executionPlanProposalStatus
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -140,12 +137,6 @@ paths:
           content: {}
         '204':
           description: successful operation
-          content: {}
-        '400':
-          description: Invalid Input
-          content: {}
-        '500':
-          description: System error
           content: {}
   /accounts:
     post:
@@ -625,7 +616,7 @@ components:
           x-autoMinLength: true
         type:
           type: string
-          enum: ["string", "int"]
+          enum: ["string", "int", "bytes"]
           description: 'type of field'
         value:
           type: string

--- a/finp2p-client/apis/dlt-adapter-api.yaml
+++ b/finp2p-client/apis/dlt-adapter-api.yaml
@@ -41,12 +41,6 @@ paths:
             application/json:
               schema:
                 $ref: 'common-external-components.yaml#/components/schemas/ApproveExecutionPlanResponse'
-        '400':
-          description: Invalid Input
-          content: {}
-        '500':
-          description: System error
-          content: {}
   /plan/proposal:
     post:
       tags:
@@ -66,12 +60,6 @@ paths:
             application/json:
               schema:
                 $ref: 'common-external-components.yaml#/components/schemas/ApproveExecutionPlanResponse'
-        '400':
-          description: Invalid Input
-          content: {}
-        '500':
-          description: System error
-          content: {}
   /plan/proposal/status:
     post:
       tags:
@@ -90,12 +78,6 @@ paths:
           content: {}
         '204':
           description: successful operation
-          content: {}
-        '400':
-          description: Invalid Input
-          content: {}
-        '500':
-          description: System error
           content: {}
   /payments/depositInstruction:
     post:
@@ -123,12 +105,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DepositInstructionResponse'
-        '400':
-          description: Invalid Input
-          content: {}
-        '500':
-          description: System error
-          content: {}
   /payments/payout:
     post:
       tags:
@@ -155,12 +131,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PayoutResponse'
-        '400':
-          description: Invalid Input
-          content: {}
-        '500':
-          description: System error
-          content: {}
   /assets/getBalance:
     post:
       deprecated: true
@@ -181,12 +151,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetAssetBalanceResponse'
-        '404':
-          description: Owner not found
-          content: {}
-        '500':
-          description: System error
-          content: {}
   /assets/create:
     post:
       tags:
@@ -213,12 +177,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CreateAssetResponse'
-        '400':
-          description: Invalid Input
-          content: {}
-        '500':
-          description: System error
-          content: {}
   /assets/issue:
     post:
       tags:
@@ -245,12 +203,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/IssueAssetsResponse'
-        '400':
-          description: Invalid Input
-          content: {}
-        '500':
-          description: System error
-          content: {}
   /assets/redeem:
     post:
       tags:
@@ -277,12 +229,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RedeemAssetsResponse'
-        '400':
-          description: Invalid Input
-          content: {}
-        '500':
-          description: System error
-          content: {}
+  /assets/move:
+    post:
+      tags:
+        - transactions
+      summary: Asset Token Move
+      description: Move existing asset token to another ledger
+      operationId: moveAssets
+      parameters:
+        - in: header
+          name: Idempotency-Key
+          description: hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds)
+          schema:
+            type: string
+          required: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MoveAssetsRequest'
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MoveAssetsResponse'
   /assets/transfer:
     post:
       tags:
@@ -309,12 +281,123 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TransferAssetResponse'
-        '400':
-          description: Invalid Input
-          content: {}
-        '500':
-          description: System error
-          content: {}
+  /accounts/create:
+    post:
+      tags:
+        - management
+      summary: Create or bind an investor account on this LA (Phase 1)
+      description: |
+        Single LA-side endpoint covering both flows:
+
+        - **Create new** — `bindInfo` is absent. The LA generates a fresh wallet on the
+          asset's network.
+        - **Bind existing** — `bindInfo` carries the caller-supplied `networkAccount`
+          and `ownershipSignature` (proof-of-ownership hint).
+
+        The LA issues a **challenge** (signatureTemplate / walletConnect / deposit /
+        fireblocksApproval / …) which the user must fulfill. Two response shapes:
+
+        - `207 Multi-Status` — challenge ready immediately; body has `challenge` and
+          `operationResponseStrategy`.
+        - `202 Accepted` — LA needs more time; body has `cid` and
+          `operationResponseStrategy`. Asset node polls or awaits callback per strategy;
+          the challenge arrives via `GET /operations/status/{cid}`.
+
+        The `ledger.accounts.wallets` jsonb column is updated **only after challenge verification**.
+      operationId: createAccount
+      parameters:
+        - in: header
+          name: Idempotency-Key
+          description: hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds)
+          schema:
+            type: string
+          required: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateAccountRequest'
+        required: true
+      responses:
+        '202':
+          description: Challenge will be issued asynchronously; poll `/operations/status/{cid}`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountOperationAccepted'
+        '207':
+          description: Challenge issued immediately as part of the response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountOperationChallenge'
+  /accounts/{cid}/proof:
+    post:
+      tags:
+        - management
+      summary: Submit signature proof for a signatureTemplate challenge (Phase 1)
+      description: |
+        Used only when the challenge `type` is `signatureTemplate`. The asset node forwards
+        the client's signature; the LA verifies it against the challenge payload. Verification
+        outcome is reported via the workflow's normal response strategy.
+      operationId: submitAccountProof
+      parameters:
+        - in: header
+          name: Idempotency-Key
+          description: hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds)
+          schema:
+            type: string
+          required: true
+        - name: cid
+          in: path
+          required: true
+          description: Correlation id of the account workflow.
+          schema:
+            type: string
+            x-allowEmpty: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubmitAccountProofRequest'
+        required: true
+      responses:
+        '200':
+          description: Proof accepted; verification continues per response strategy.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountOperationAccepted'
+  /accounts/{accountId}:
+    delete:
+      tags:
+        - management
+      summary: Unbind an investor account (Phase 1)
+      description: |
+        Removes the account entry from the `ledger.accounts.wallets` jsonb column. Async; cid in response.
+      operationId: removeAccount
+      parameters:
+        - in: header
+          name: Idempotency-Key
+          description: hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds)
+          schema:
+            type: string
+          required: true
+        - name: accountId
+          in: path
+          required: true
+          description: LA-assigned account identifier.
+          schema:
+            type: string
+            pattern: .*\S.*
+            x-autoMinLength: true
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountOperationAccepted'
   /assets/receipts/{transactionId}:
     get:
       tags:
@@ -338,12 +421,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetReceiptResponse'
-        '404':
-          description: Transaction not found
-          content: {}
-        '500':
-          description: System error
-          content: {}
   /assets/hold:
     post:
       tags:
@@ -370,12 +447,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HoldOperationResponse'
-        '400':
-          description: Invalid Input
-          content: {}
-        '500':
-          description: System error
-          content: {}
   /assets/release:
     post:
       tags:
@@ -402,12 +473,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ReleaseOperationResponse'
-        '400':
-          description: Invalid Input
-          content: {}
-        '500':
-          description: System error
-          content: {}
   /assets/rollback:
     post:
       tags:
@@ -434,12 +499,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RollbackOperationResponse'
-        '400':
-          description: Invalid Input
-          content: {}
-        '500':
-          description: System error
-          content: {}
   /operations/status/{cid}:
     get:
       tags:
@@ -462,12 +521,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetOperationStatusResponse'
-        '404':
-          description: Transaction not found
-          content: {}
-        '500':
-          description: System error
-          content: {}
   /asset/balance:
     post:
       tags:
@@ -488,12 +541,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AssetBalanceInfoResponse'
-        '404':
-          description: Owner not found
-          content: {}
-        '500':
-          description: System error
-          content: {}
   /health:
     get:
       summary: Health check
@@ -641,8 +688,7 @@ components:
         settlementRef:
           type: string
           description: 'Reference to the corresponding settlement operation'
-          pattern: .*\S.*
-          x-autoMinLength: true
+          x-allowEmpty: true
         signature:
           $ref: '#/components/schemas/signature'
         executionContext:
@@ -676,8 +722,7 @@ components:
         settlementRef:
           type: string
           description: 'Reference to the corresponding payment operation'
-          pattern: .*\S.*
-          x-autoMinLength: true
+          x-allowEmpty: true
         signature:
           $ref: '#/components/schemas/signature'
         executionContext:
@@ -709,13 +754,44 @@ components:
         settlementRef:
           type: string
           description: 'Reference to the corresponding payment operation'
+          x-allowEmpty: true
+        signature:
+          $ref: '#/components/schemas/signature'
+        executionContext:
+          $ref: '#/components/schemas/executionContext'
+    TransferAssetResponse:
+      allOf:
+        - $ref: '#/components/schemas/receiptOperation'
+    MoveAssetsRequest:
+      type: object
+      required:
+        - nonce
+        - source
+        - destination
+        - quantity
+        - signature
+      properties:
+        nonce:
+          $ref: 'common-external-components.yaml#/components/schemas/nonce'
+        operationId:
+          type: string
+          x-go-type-skip-optional-pointer: true
+          pattern: .*\S.*
+          x-autoMinLength: true
+        source:
+          $ref: '#/components/schemas/account'
+        destination:
+          $ref: '#/components/schemas/account'
+        quantity:
+          type: string
+          description: 'How many units of the asset tokens'
           pattern: .*\S.*
           x-autoMinLength: true
         signature:
           $ref: '#/components/schemas/signature'
         executionContext:
           $ref: '#/components/schemas/executionContext'
-    TransferAssetResponse:
+    MoveAssetsResponse:
       allOf:
         - $ref: '#/components/schemas/receiptOperation'
     GetReceiptResponse:
@@ -849,7 +925,7 @@ components:
           required: [ledgerIdentifier]
           properties:
             ledgerIdentifier:
-               $ref: 'common-external-components.yaml#/components/schemas/ledgerAssetIdentifier'
+              $ref: 'common-external-components.yaml#/components/schemas/ledgerAssetIdentifier'
         - $ref: 'common-external-components.yaml#/components/schemas/finp2pAssetBase'
     payoutAsset:
       $ref: 'common-external-components.yaml#/components/schemas/finp2pAsset'
@@ -863,7 +939,6 @@ components:
           description: 'withdrawal description'
           pattern: .*\S.*
           x-autoMinLength: true
-
     account:
       type: object
       required:
@@ -877,14 +952,20 @@ components:
         ledgerAccount:
           oneOf:
             - $ref: '#/components/schemas/walletLedgerAccount'
+            - $ref: '#/components/schemas/caip10LedgerAccount'
+            - $ref: '#/components/schemas/custodialLedgerAccount'
           discriminator:
             propertyName: type
             mapping:
               walletAccount: '#/components/schemas/walletLedgerAccount'
-
+              caip10Account: '#/components/schemas/caip10LedgerAccount'
+              custodialAccount: '#/components/schemas/custodialLedgerAccount'
     walletLedgerAccount:
       $ref: 'common-external-components.yaml#/components/schemas/walletAccount'
-
+    caip10LedgerAccount:
+      $ref: 'common-external-components.yaml#/components/schemas/caip10Account'
+    custodialLedgerAccount:
+      $ref: 'common-external-components.yaml#/components/schemas/custodialAccount'
     depositPayoutAccount:
       type: object
       required:
@@ -933,6 +1014,181 @@ components:
               $ref: '#/components/schemas/receiptOperationErrorInformation'
             response:
               $ref: '#/components/schemas/receipt'
+    # -------- Investor accounts (Phase 1) --------
+    CreateAccountRequest:
+      type: object
+      description: |
+        Body for `POST /accounts/create`. Single LA-side endpoint covering both create-new
+        and bind-existing flows.
+
+        - **Create new** — omit `bindInfo`. The LA generates a wallet on the asset's network.
+        - **Bind existing** — populate `bindInfo` with the caller-supplied wallet and a
+          proof-of-ownership signature hint. The LA still issues a challenge for final verification.
+
+        The response is either `207` (challenge ready) or `202` (challenge pending) — see the
+        endpoint definition.
+      required: [organizationId, assetId, finId]
+      properties:
+        organizationId:
+          type: string
+          pattern: .*\S.*
+          x-autoMinLength: true
+        assetId:
+          type: string
+          pattern: .*\S.*
+          x-autoMinLength: true
+        finId:
+          $ref: "common-external-components.yaml#/components/schemas/finId"
+          description: |
+            The investor this account is being onboarded for, identified by their canonical
+            finId (hex-encoded compressed secp256k1 public key — the same identity that appears
+            on this investor's ledger operation legs). Resolved by the asset node from the
+            investor profile; lets the ledger adapter couple the resulting network account to
+            the investor so it can enforce wallet↔finId ownership on later operations. Required:
+            an investor without a resolvable finId cannot onboard a network account.
+        bindInfo:
+          $ref: '#/components/schemas/BindInfo'
+    accountOwnershipSignature:
+      type: object
+      description: |
+        Proof-of-ownership signature for network-account onboarding — a raw signature over
+        the ledger adapter's challenge payload. Unlike a transaction `signature` it carries no
+        template or hash function: there is nothing to template, only the challenge bytes to sign.
+      required: [signature]
+      properties:
+        signature:
+          type: string
+          description: hex representation of the ownership signature
+          x-allowEmpty: true
+    BindInfo:
+      type: object
+      description: |
+        Bind-info block. When present in `CreateAccountRequest`, signals the bind-existing flow.
+      required: [networkAccount, ownershipSignature]
+      properties:
+        networkAccount:
+          $ref: 'common-external-components.yaml#/components/schemas/networkAccount'
+        ownershipSignature:
+          $ref: '#/components/schemas/accountOwnershipSignature'
+          description: |
+            Proof-of-ownership hint over the network account. The LA may verify this upfront,
+            but the authoritative ownership proof is the challenge-fulfillment step.
+    SubmitAccountProofRequest:
+      type: object
+      description: |
+        Body for `POST /accounts/{cid}/proof`. Used only for `signatureTemplate` challenges.
+      required: [ownershipSignature]
+      properties:
+        ownershipSignature:
+          $ref: '#/components/schemas/accountOwnershipSignature'
+          description: Signature over the LA's `signatureTemplate` challenge payload.
+    AccountOperationAccepted:
+      description: |
+        Returned for `202` and for `200` from `proof` / `delete`. When `isCompleted` is
+        false, the result is not yet available and `cid` lets the asset node poll
+        `/operations/status/{cid}` or receive a callback per `operationResponseStrategy`.
+        When the adapter completes the operation synchronously, `isCompleted` is true and
+        exactly one of `response` (the account it created) or `error` is present.
+      allOf:
+        - $ref: 'common-external-components.yaml#/components/schemas/OperationBase'
+        - type: object
+          properties:
+            operationMetadata:
+              $ref: 'common-external-components.yaml#/components/schemas/OperationMetadata'
+            response:
+              $ref: '#/components/schemas/networkAccountRecord'
+            error:
+              $ref: '#/components/schemas/networkAccountOperationErrorInformation'
+            expiresInSeconds:
+              type: integer
+              format: int64
+              description: |
+                Onboarding deadline the ledger adapter grants for this create/bind, in
+                seconds from now. The asset node arms the workflow's whole-process timeout
+                from this value (set once, at acceptance). Omitted/zero => no auto-expiry.
+    AccountOperationChallenge:
+      description: |
+        Returned for `207` from `POST /accounts/create`. Structurally a superset of
+        AccountOperationAccepted (the router decodes both create responses into this
+        one type), adding the LA-issued challenge.
+      allOf:
+        - $ref: '#/components/schemas/AccountOperationAccepted'
+        - type: object
+          required: [challenge]
+          properties:
+            challenge:
+              $ref: '#/components/schemas/AccountChallenge'
+    AccountChallenge:
+      description: |
+        LA-issued challenge that the user must fulfill. Discriminated by `type`. New variants
+        can be added without breaking existing clients.
+      type: object
+      required: [type]
+      oneOf:
+        - $ref: '#/components/schemas/AccountChallengeWalletConnect'
+        - $ref: '#/components/schemas/AccountChallengeSignatureTemplate'
+        - $ref: '#/components/schemas/AccountChallengeDeposit'
+        - $ref: '#/components/schemas/AccountChallengeFireblocksApproval'
+      discriminator:
+        propertyName: type
+        mapping:
+          walletConnect: '#/components/schemas/AccountChallengeWalletConnect'
+          signatureTemplate: '#/components/schemas/AccountChallengeSignatureTemplate'
+          deposit: '#/components/schemas/AccountChallengeDeposit'
+          fireblocksApproval: '#/components/schemas/AccountChallengeFireblocksApproval'
+    AccountChallengeWalletConnect:
+      type: object
+      required: [type, uri]
+      properties:
+        type: {type: string, enum: [walletConnect]}
+        uri:
+          type: string
+          description: WalletConnect URI or QR-encodable payload.
+          pattern: .*\S.*
+          x-autoMinLength: true
+    AccountChallengeSignatureTemplate:
+      type: object
+      required: [type, payload]
+      properties:
+        type: {type: string, enum: [signatureTemplate]}
+        payload:
+          type: string
+          description: |
+            Hex-encoded data the client must sign with the wallet's private key and submit via
+            `POST /accounts/{cid}/proof`.
+          pattern: .*\S.*
+          x-autoMinLength: true
+    AccountChallengeDeposit:
+      type: object
+      required: [type, fromAddress, toAddress, amount]
+      properties:
+        type: {type: string, enum: [deposit]}
+        fromAddress: {type: string, description: Address claimed by the user., pattern: .*\S.*, x-autoMinLength: true}
+        toAddress: {type: string, description: Destination address the LA watches., pattern: .*\S.*, x-autoMinLength: true}
+        amount: {type: string, description: Required deposit amount (string for precision)., pattern: .*\S.*, x-autoMinLength: true}
+    AccountChallengeFireblocksApproval:
+      type: object
+      required: [type, fireblocksRequestId]
+      properties:
+        type: {type: string, enum: [fireblocksApproval]}
+        fireblocksRequestId:
+          type: string
+          description: Fireblocks-side request id; user approves in the Fireblocks app.
+          pattern: .*\S.*
+          x-autoMinLength: true
+    networkAccountRecord:
+      description: |
+        Canonical account record returned on workflow completion via `GET /operations/status/{cid}`.
+      type: object
+      required: [id, networkAccount]
+      properties:
+        id:
+          type: string
+          description: LA-assigned account identifier.
+          pattern: .*\S.*
+          x-autoMinLength: true
+        networkAccount:
+          $ref: 'common-external-components.yaml#/components/schemas/networkAccount'
     createAssetOperation:
       allOf:
         - $ref: 'common-external-components.yaml#/components/schemas/OperationBase'
@@ -964,10 +1220,14 @@ components:
         code:
           type: integer
           format: uint32
+          description: 1 for failure in regApps validation, 4 failure in signature verification
         message:
           type: string
-          pattern: .*\S.*
-          x-autoMinLength: true
+          x-allowEmpty: true
+        regulationErrorDetails:
+          type: array
+          items:
+            $ref: 'common-external-components.yaml#/components/schemas/RegulationError'
     createAssetOperationErrorInformation:
       type: object
       properties:
@@ -1021,6 +1281,7 @@ components:
         - $ref: '#/components/schemas/operationStatusDeposit'
         - $ref: '#/components/schemas/operationStatusReceipt'
         - $ref: '#/components/schemas/operationStatusApproval'
+        - $ref: '#/components/schemas/operationStatusAccount'
       discriminator:
         propertyName: type
         mapping:
@@ -1028,6 +1289,7 @@ components:
           deposit: '#/components/schemas/operationStatusDeposit'
           receipt: '#/components/schemas/operationStatusReceipt'
           approval: '#/components/schemas/operationStatusApproval'
+          account: '#/components/schemas/operationStatusAccount'
     operationStatusCreateAsset:
       type: object
       required:
@@ -1072,6 +1334,55 @@ components:
           enum: [approval]
         operation:
           $ref: 'common-external-components.yaml#/components/schemas/ExecutionPlanApprovalOperation'
+    operationStatusAccount:
+      type: object
+      required:
+        - type
+        - operation
+      properties:
+        type:
+          type: string
+          enum: [account]
+        operation:
+          $ref: '#/components/schemas/networkAccountOperation'
+    networkAccountOperation:
+      description: |
+        Status of an investor network-account create/bind/unbind operation, polled via
+        `GET /operations/status/{cid}`. While a challenge is outstanding, `challenge` is
+        present; on completion `response` carries the canonical `{ id, wallet }`; on failure
+        `error` carries the LA-level code/message.
+      allOf:
+        - $ref: 'common-external-components.yaml#/components/schemas/OperationBase'
+        - type: object
+          properties:
+            challenge:
+              $ref: '#/components/schemas/AccountChallenge'
+            response:
+              $ref: '#/components/schemas/networkAccountRecord'
+            error:
+              $ref: '#/components/schemas/networkAccountOperationErrorInformation'
+            expiresInSeconds:
+              type: integer
+              format: int64
+              description: |
+                Onboarding deadline the ledger adapter grants, in seconds from now, when it
+                supplies (or revises) one on this status — e.g. alongside a challenge delivered
+                via callback in proxy mode, where the adapter's own deadline could not ride the
+                proxy's immediate acceptance. The asset node re-arms the workflow deadline from
+                a non-zero value. Omitted/zero => previously armed deadline stands.
+    networkAccountOperationErrorInformation:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: uint32
+        message:
+          type: string
+          pattern: .*\S.*
+          x-autoMinLength: true
     signature:
       type: object
       required: [signature, template, hashFunc]
@@ -1080,8 +1391,7 @@ components:
         signature:
           type: string
           description: 'hex representation of the signature'
-          pattern: .*\S.*
-          x-autoMinLength: true
+          x-allowEmpty: true
         template:
           $ref: '#/components/schemas/signatureTemplate'
         hashFunc:
@@ -1112,6 +1422,9 @@ components:
           type: string
           description: 'hex representation of the combined hash groups hash value'
           x-allowEmpty: true
+        templateVersion:
+          type: integer
+          description: 'Template shape version. When omitted, the verifier resolves the version from the signature proof context.'
     hashGroup:
       type: object
       required:
@@ -1220,6 +1533,9 @@ components:
           type: string
           description: 'hex representation of template hash'
           x-allowEmpty: true
+        templateVersion:
+          type: integer
+          description: 'Template shape version. When omitted, the verifier resolves the version from the signature proof context.'
     EIP712TypeString:
       type: string
       pattern: '^(?:$|0([^x].*)?|[^0].*)$' # matches string that doesn't start with hexadecimal prefix
@@ -1331,13 +1647,13 @@ components:
           x-autoMinLength: true
     operationType:
       type: string
-      enum: ['issue', 'transfer', 'hold', 'release', 'redeem']
+      enum: ['issue', 'transfer', 'hold', 'release', 'redeem', 'move']
     ledgerAssetInfo:
       type: object
       required: [ledgerIdentifier]
       properties:
         ledgerIdentifier:
-           $ref: 'common-external-components.yaml#/components/schemas/ledgerAssetIdentifier'
+          $ref: 'common-external-components.yaml#/components/schemas/ledgerAssetIdentifier'
         ledgerReference:
           oneOf:
             - $ref: '#/components/schemas/contractDetails'

--- a/finp2p-client/apis/operational-api.yaml
+++ b/finp2p-client/apis/operational-api.yaml
@@ -571,18 +571,17 @@ paths:
                 errors:
                   - code: 2003
                     message: 'Gateway timeout'
-  /execution/proposals:
+  /execution/approvalsConfig:
     put:
       tags:
         - 'execution'
-      summary: 'Override approvals config'
-      description: 'Override approvals config'
-      operationId: 'Override approvals config'
+      summary: 'Set approvals config'
+      description: 'Sets the approvals configuration for the router. Defines which approvers are required for each router category (tokenization, payments, investor, custodian).'
+      operationId: 'setApprovalsConfig'
       requestBody:
         content:
           application/json:
             example:
-              ownerId: 'bank-x:101:511c1d7f-4ed8-410d-887c-a10e3e499a01'
               tokenization:
                 http-endpoint-1:
                   config_type: 'http'
@@ -633,8 +632,8 @@ paths:
       tags:
         - 'execution'
       summary: 'Update approvals config'
-      description: 'Update approvals config'
-      operationId: 'update approvals config'
+      description: 'Updates the approvals configuration for the router. Allows partial updates to approvers per router category (tokenization, payments, investor, custodian).'
+      operationId: 'updateApprovalsConfig'
       requestBody:
         content:
           application/json:
@@ -642,7 +641,112 @@ paths:
               update-example-1:
                 summary: 'disable http-endpoint-1, change proposals of ledger-approver-1 and delete payments config'
                 value:
-                  ownerId: 'bank-x:101:511c1d7f-4ed8-410d-887c-a10e3e499a01'
+                  tokenization:
+                    http-endpoint-1:
+                      config_type: 'http'
+                      disabled: true
+                    ledger-approver-1:
+                      config_type: 'ledger'
+                      proposals:
+                        - 'cancel'
+                  payments: null
+            schema:
+              $ref: '#/components/schemas/approvalConfigUpdate'
+      responses:
+        '200':
+          description: 'Configuration updated successfully'
+        '400':
+          description: 'Bad Request'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 1002
+                    message: 'Invalid request format'
+        '500':
+          description: 'Internal Server Error'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 2202
+                    message: 'Internal service failure'
+  /execution/proposals:
+    put:
+      deprecated: true
+      tags:
+        - 'execution'
+      summary: 'Set approvals config'
+      description: 'Deprecated. Use /execution/approvalsConfig. Sets the approvals configuration for the router. Defines which approvers are required for each router category (tokenization, payments, investor, custodian).'
+      operationId: 'setProposalsConfig'
+      requestBody:
+        content:
+          application/json:
+            example:
+              tokenization:
+                http-endpoint-1:
+                  config_type: 'http'
+                  endpoint: 'http://approver-service.internal/approvals'
+                  timeout: '45s'
+                  proposals:
+                    - 'reset'
+                    - 'cancel'
+                    - 'instruction'
+                ledger-approver-1:
+                  config_type: 'ledger'
+                  name: 'ledger-approver-1'
+                  proposals:
+                    - 'reset'
+                    - 'instruction'
+              payments:
+                ledger-approver-2:
+                  config_type: 'ledger'
+                  name: 'payments-ledger-approver'
+                  proposals:
+                    - 'instruction'
+            schema:
+              $ref: '#/components/schemas/approvalConfig'
+      responses:
+        '201':
+          description: 'Created the new configuration successfully'
+        '400':
+          description: 'Bad Request'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 1002
+                    message: 'Invalid request format'
+        '500':
+          description: 'Internal Server Error'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 2202
+                    message: 'Internal service failure'
+    patch:
+      deprecated: true
+      tags:
+        - 'execution'
+      summary: 'Update approvals config'
+      description: 'Deprecated. Use /execution/approvalsConfig. Updates the approvals configuration for the router. Allows partial updates to approvers per router category (tokenization, payments, investor, custodian).'
+      operationId: 'updateProposalsConfig'
+      requestBody:
+        content:
+          application/json:
+            examples:
+              update-example-1:
+                summary: 'disable http-endpoint-1, change proposals of ledger-approver-1 and delete payments config'
+                value:
                   tokenization:
                     http-endpoint-1:
                       config_type: 'http'
@@ -1186,11 +1290,19 @@ paths:
         - name: 'assetMatchingType'
           in: 'query'
           description: 'asset matching type'
-          required: true
+          required: false
           schema:
             type: 'string'
-            pattern: .*\S.*
-            x-autoMinLength: true
+            minLength: 1
+            maxLength: 255
+        - name: 'ledgerName'
+          in: 'query'
+          description: 'filter policies whose ledgerNames allow-list contains this ledger (or have no ledger constraint)'
+          required: false
+          schema:
+            type: 'string'
+            minLength: 1
+            maxLength: 255
       responses:
         '200':
           description: 'found some policies'
@@ -1603,7 +1715,7 @@ paths:
           application/json:
             schema:
               type: 'object'
-              required: ['name', 'endpoint']
+              required: ['name', 'endpoint', 'requestTimeout', 'backoff', 'singleRequestTimeout']
               properties:
                 name:
                   type: 'string'
@@ -1619,6 +1731,8 @@ paths:
                   $ref: '#/components/schemas/adapterAuthOptions'
                 idempotency:
                   $ref: '#/components/schemas/adapterIdempotencyOptions'
+                retryStrategy:
+                  $ref: '#/components/schemas/adapterRetryStrategy'
                 displayName:
                   type: 'string'
                   description: 'display name'
@@ -1626,28 +1740,42 @@ paths:
                   x-autoMinLength: true
                 requestTimeout:
                   type: 'string'
-                  pattern: '^-?(?:\d+(?:\.\d+)?h)?(?:\d+(?:\.\d+)?m)?(?:\d+(?:\.\d+)?s)?(?:\d+(?:\.\d+)?ms)?(?:\d+(?:\.\d+)?(us|µs))?(?:\d+(?:\.\d+)?ns)?$'
+                  pattern: '^[1-9]\d*(?:\.\d+)?(h|m|s|ms|us|µs|ns)(\d+(?:\.\d+)?(h|m|s|ms|us|µs|ns))*$'
                   description: 'request timeout (e.g. 300s)'
-                  default: '300s'
                   minLength: 1
-                  x-autoMinLength: true
                 backoff:
                   type: 'string'
-                  pattern: '^-?(?:\d+(?:\.\d+)?h)?(?:\d+(?:\.\d+)?m)?(?:\d+(?:\.\d+)?s)?(?:\d+(?:\.\d+)?ms)?(?:\d+(?:\.\d+)?(us|µs))?(?:\d+(?:\.\d+)?ns)?$'
+                  pattern: '^[1-9]\d*(?:\.\d+)?(h|m|s|ms|us|µs|ns)(\d+(?:\.\d+)?(h|m|s|ms|us|µs|ns))*$'
                   description: 'backoff (e.g. 60s)'
-                  default: '60s'
                   minLength: 1
-                  x-autoMinLength: true
                 singleRequestTimeout:
                   type: 'string'
-                  pattern: '^-?(?:\d+(?:\.\d+)?h)?(?:\d+(?:\.\d+)?m)?(?:\d+(?:\.\d+)?s)?(?:\d+(?:\.\d+)?ms)?(?:\d+(?:\.\d+)?(us|µs))?(?:\d+(?:\.\d+)?ns)?$'
+                  pattern: '^[1-9]\d*(?:\.\d+)?(h|m|s|ms|us|µs|ns)(\d+(?:\.\d+)?(h|m|s|ms|us|µs|ns))*$'
                   description: 'single request timeout (e.g. 90s)'
-                  default: '90s'
                   minLength: 1
-                  x-autoMinLength: true
       responses:
         '200':
           description: 'successful operation'
+        '400':
+          description: 'Bad Request'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 1002
+                    message: 'Invalid request format'
+        '500':
+          description: 'Internal Server Error'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 2202
+                    message: 'Internal service failure'
   /custody/{name}/update:
     patch:
       tags:
@@ -1694,33 +1822,52 @@ paths:
                     - $ref: '#/components/schemas/adapterIdempotencyOptionsOpt'
                   nullable: true
                   x-custom-format: 'nullable+idempotencyOptions'
+                retryStrategy:
+                  oneOf:
+                    - $ref: '#/components/schemas/adapterRetryStrategy'
+                  nullable: true
+                  x-custom-format: 'nullable+retryStrategy'
                 requestTimeout:
                   type: 'string'
                   description: 'request timeout (e.g. 300s)'
                   x-custom-format: 'nullable'
                   nullable: true
-                  pattern: '^-?(?:\d+(?:\.\d+)?h)?(?:\d+(?:\.\d+)?m)?(?:\d+(?:\.\d+)?s)?(?:\d+(?:\.\d+)?ms)?(?:\d+(?:\.\d+)?(us|µs))?(?:\d+(?:\.\d+)?ns)?$'
-                  minLength: 1
-                  x-autoMinLength: true
+                  pattern: '^[1-9]\d*(?:\.\d+)?(h|m|s|ms|us|µs|ns)(\d+(?:\.\d+)?(h|m|s|ms|us|µs|ns))*$'
                 backoff:
                   type: 'string'
                   description: 'backoff (e.g. 60s)'
                   x-custom-format: 'nullable'
                   nullable: true
-                  pattern: '^-?(?:\d+(?:\.\d+)?h)?(?:\d+(?:\.\d+)?m)?(?:\d+(?:\.\d+)?s)?(?:\d+(?:\.\d+)?ms)?(?:\d+(?:\.\d+)?(us|µs))?(?:\d+(?:\.\d+)?ns)?$'
-                  minLength: 1
-                  x-autoMinLength: true
+                  pattern: '^[1-9]\d*(?:\.\d+)?(h|m|s|ms|us|µs|ns)(\d+(?:\.\d+)?(h|m|s|ms|us|µs|ns))*$'
                 singleRequestTimeout:
                   type: 'string'
                   description: 'single request timeout (e.g. 90s)'
                   x-custom-format: 'nullable'
-                  pattern: '^-?(?:\d+(?:\.\d+)?h)?(?:\d+(?:\.\d+)?m)?(?:\d+(?:\.\d+)?s)?(?:\d+(?:\.\d+)?ms)?(?:\d+(?:\.\d+)?(us|µs))?(?:\d+(?:\.\d+)?ns)?$'
+                  pattern: '^[1-9]\d*(?:\.\d+)?(h|m|s|ms|us|µs|ns)(\d+(?:\.\d+)?(h|m|s|ms|us|µs|ns))*$'
                   nullable: true
-                  minLength: 1
-                  x-autoMinLength: true
       responses:
         '200':
           description: 'successful operation'
+        '400':
+          description: 'Bad Request'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 1002
+                    message: 'Invalid request format'
+        '500':
+          description: 'Internal Server Error'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 2202
+                    message: 'Internal service failure'
   /ledger/{name}/update:
     patch:
       tags:
@@ -1755,25 +1902,19 @@ paths:
                   description: 'The maximum time allowed for the entire request operation to complete, including all retry attempts. After this duration, the request will fail with a timeout error'
                   x-custom-format: 'nullable'
                   nullable: true
-                  pattern: '^-?(?:\d+(?:\.\d+)?h)?(?:\d+(?:\.\d+)?m)?(?:\d+(?:\.\d+)?s)?(?:\d+(?:\.\d+)?ms)?(?:\d+(?:\.\d+)?(us|µs))?(?:\d+(?:\.\d+)?ns)?$'
-                  minLength: 1
-                  x-autoMinLength: true
+                  pattern: '^[1-9]\d*(?:\.\d+)?(h|m|s|ms|us|µs|ns)(\d+(?:\.\d+)?(h|m|s|ms|us|µs|ns))*$'
                 backoff:
                   type: 'string'
                   description: 'The waiting period between consecutive retry attempts when a request fails. This delay helps prevent overwhelming the ledger adapter during temporary failures'
                   x-custom-format: 'nullable'
                   nullable: true
-                  pattern: '^-?(?:\d+(?:\.\d+)?h)?(?:\d+(?:\.\d+)?m)?(?:\d+(?:\.\d+)?s)?(?:\d+(?:\.\d+)?ms)?(?:\d+(?:\.\d+)?(us|µs))?(?:\d+(?:\.\d+)?ns)?$'
-                  minLength: 1
-                  x-autoMinLength: true
+                  pattern: '^[1-9]\d*(?:\.\d+)?(h|m|s|ms|us|µs|ns)(\d+(?:\.\d+)?(h|m|s|ms|us|µs|ns))*$'
                 singleRequestTimeout:
                   type: 'string'
                   description: 'The maximum time allowed for each individual request attempt. If a single attempt exceeds this duration, it will be retried according to the backoff configuration'
                   x-custom-format: 'nullable'
-                  pattern: '^-?(?:\d+(?:\.\d+)?h)?(?:\d+(?:\.\d+)?m)?(?:\d+(?:\.\d+)?s)?(?:\d+(?:\.\d+)?ms)?(?:\d+(?:\.\d+)?(us|µs))?(?:\d+(?:\.\d+)?ns)?$'
+                  pattern: '^[1-9]\d*(?:\.\d+)?(h|m|s|ms|us|µs|ns)(\d+(?:\.\d+)?(h|m|s|ms|us|µs|ns))*$'
                   nullable: true
-                  minLength: 1
-                  x-autoMinLength: true
                 auth:
                   oneOf:
                     - $ref: '#/components/schemas/adapterAuthOptionsOpt'
@@ -1784,6 +1925,11 @@ paths:
                     - $ref: '#/components/schemas/adapterIdempotencyOptionsOpt'
                   nullable: true
                   x-custom-format: 'nullable+idempotencyOptions'
+                retryStrategy:
+                  oneOf:
+                    - $ref: '#/components/schemas/adapterRetryStrategy'
+                  nullable: true
+                  x-custom-format: 'nullable+retryStrategy'
                 displayName:
                   type: 'string'
                   description: 'A human-readable name for the ledger that appears in user interfaces'
@@ -1832,7 +1978,7 @@ paths:
           application/json:
             schema:
               type: 'object'
-              required: ['name', 'endpoint']
+              required: ['name', 'endpoint', 'requestTimeout', 'backoff', 'singleRequestTimeout']
               properties:
                 name:
                   type: 'string'
@@ -1848,6 +1994,8 @@ paths:
                   $ref: '#/components/schemas/adapterAuthOptions'
                 idempotency:
                   $ref: '#/components/schemas/adapterIdempotencyOptions'
+                retryStrategy:
+                  $ref: '#/components/schemas/adapterRetryStrategy'
                 displayName:
                   type: 'string'
                   description: 'A human-readable name for the ledger that appears in user interfaces'
@@ -1855,25 +2003,19 @@ paths:
                   x-autoMinLength: true
                 requestTimeout:
                   type: 'string'
-                  pattern: '^-?(?:\d+(?:\.\d+)?h)?(?:\d+(?:\.\d+)?m)?(?:\d+(?:\.\d+)?s)?(?:\d+(?:\.\d+)?ms)?(?:\d+(?:\.\d+)?(us|µs))?(?:\d+(?:\.\d+)?ns)?$'
+                  pattern: '^[1-9]\d*(?:\.\d+)?(h|m|s|ms|us|µs|ns)(\d+(?:\.\d+)?(h|m|s|ms|us|µs|ns))*$'
                   description: 'The maximum time allowed for the entire request operation to complete, including all retry attempts. After this duration, the request will fail with a timeout error'
-                  default: '300s'
                   minLength: 1
-                  x-autoMinLength: true
                 backoff:
                   type: 'string'
-                  pattern: '^-?(?:\d+(?:\.\d+)?h)?(?:\d+(?:\.\d+)?m)?(?:\d+(?:\.\d+)?s)?(?:\d+(?:\.\d+)?ms)?(?:\d+(?:\.\d+)?(us|µs))?(?:\d+(?:\.\d+)?ns)?$'
+                  pattern: '^[1-9]\d*(?:\.\d+)?(h|m|s|ms|us|µs|ns)(\d+(?:\.\d+)?(h|m|s|ms|us|µs|ns))*$'
                   description: 'The waiting period between consecutive retry attempts when a request fails. This delay helps prevent overwhelming the ledger adapter during temporary failures'
-                  default: '60s'
                   minLength: 1
-                  x-autoMinLength: true
                 singleRequestTimeout:
                   type: 'string'
-                  pattern: '^-?(?:\d+(?:\.\d+)?h)?(?:\d+(?:\.\d+)?m)?(?:\d+(?:\.\d+)?s)?(?:\d+(?:\.\d+)?ms)?(?:\d+(?:\.\d+)?(us|µs))?(?:\d+(?:\.\d+)?ns)?$'
+                  pattern: '^[1-9]\d*(?:\.\d+)?(h|m|s|ms|us|µs|ns)(\d+(?:\.\d+)?(h|m|s|ms|us|µs|ns))*$'
                   description: 'The maximum time allowed for each individual request attempt. If a single attempt exceeds this duration, it will be retried according to the backoff configuration'
-                  default: '90s'
                   minLength: 1
-                  x-autoMinLength: true
                 balanceSyncAllowed:
                   type: 'boolean'
                   description: 'Indicates whether balance synchronization is enabled for this ledger'
@@ -1937,18 +2079,14 @@ paths:
                   x-autoMinLength: true
                 requestTimeout:
                   type: 'string'
-                  pattern: '^-?(?:\d+(?:\.\d+)?h)?(?:\d+(?:\.\d+)?m)?(?:\d+(?:\.\d+)?s)?(?:\d+(?:\.\d+)?ms)?(?:\d+(?:\.\d+)?(us|µs))?(?:\d+(?:\.\d+)?ns)?$'
+                  pattern: '^[1-9]\d*(?:\.\d+)?(h|m|s|ms|us|µs|ns)(\d+(?:\.\d+)?(h|m|s|ms|us|µs|ns))*$'
                   description: 'The maximum time allowed for each request to the data provider adapter'
                   default: '30s'
-                  minLength: 1
-                  x-autoMinLength: true
                 backoff:
                   type: 'string'
-                  pattern: '^-?(?:\d+(?:\.\d+)?h)?(?:\d+(?:\.\d+)?m)?(?:\d+(?:\.\d+)?s)?(?:\d+(?:\.\d+)?ms)?(?:\d+(?:\.\d+)?(us|µs))?(?:\d+(?:\.\d+)?ns)?$'
+                  pattern: '^[1-9]\d*(?:\.\d+)?(h|m|s|ms|us|µs|ns)(\d+(?:\.\d+)?(h|m|s|ms|us|µs|ns))*$'
                   description: 'The waiting period between consecutive retry attempts when a request fails'
                   default: '5m'
-                  minLength: 1
-                  x-autoMinLength: true
       responses:
         '200':
           description: 'successful operation'
@@ -1956,6 +2094,26 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/dataProviderResponse'
+        '400':
+          description: 'Bad Request'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 1002
+                    message: 'Invalid request format'
+        '500':
+          description: 'Internal Server Error'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 2202
+                    message: 'Internal service failure'
   /dataprovider/{name}/update:
     patch:
       tags:
@@ -2007,17 +2165,13 @@ paths:
                   description: 'The maximum time allowed for each request to the data provider adapter'
                   x-custom-format: 'nullable'
                   nullable: true
-                  pattern: '^-?(?:\d+(?:\.\d+)?h)?(?:\d+(?:\.\d+)?m)?(?:\d+(?:\.\d+)?s)?(?:\d+(?:\.\d+)?ms)?(?:\d+(?:\.\d+)?(us|µs))?(?:\d+(?:\.\d+)?ns)?$'
-                  minLength: 1
-                  x-autoMinLength: true
+                  pattern: '^[1-9]\d*(?:\.\d+)?(h|m|s|ms|us|µs|ns)(\d+(?:\.\d+)?(h|m|s|ms|us|µs|ns))*$'
                 backoff:
                   type: 'string'
                   description: 'The waiting period between consecutive retry attempts when a request fails'
                   x-custom-format: 'nullable'
                   nullable: true
-                  pattern: '^-?(?:\d+(?:\.\d+)?h)?(?:\d+(?:\.\d+)?m)?(?:\d+(?:\.\d+)?s)?(?:\d+(?:\.\d+)?ms)?(?:\d+(?:\.\d+)?(us|µs))?(?:\d+(?:\.\d+)?ns)?$'
-                  minLength: 1
-                  x-autoMinLength: true
+                  pattern: '^[1-9]\d*(?:\.\d+)?(h|m|s|ms|us|µs|ns)(\d+(?:\.\d+)?(h|m|s|ms|us|µs|ns))*$'
       responses:
         '200':
           description: 'successful operation'
@@ -2025,8 +2179,200 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/dataProviderResponse'
+        '400':
+          description: 'Bad Request'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 1002
+                    message: 'Invalid request format'
+        '500':
+          description: 'Internal Server Error'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 2202
+                    message: 'Internal service failure'
+  /capabilities:
+    get:
+      tags:
+        - 'capabilities'
+      summary: 'Get node capabilities'
+      description: 'Returns this node''s effective protocol capabilities, derived from its configured trading policies plus a code-level baseline. Served from a cache (rebuilt on a cold cache); read-only.'
+      operationId: 'getNodeCapabilities'
+      responses:
+        '200':
+          description: 'successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/nodeCapabilities'
+        '400':
+          description: 'Bad Request'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 6102
+                    message: 'Data mapping error'
+        '500':
+          description: 'Internal Server Error'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 2000
+                    message: 'General server error'
+        '502':
+          description: 'Bad Gateway'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 2300
+                    message: 'An internal communication error'
+        '503':
+          description: 'Service Unavailable'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 2002
+                    message: 'Service unavailable'
+        '504':
+          description: 'Gateway Timeout'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 2003
+                    message: 'Gateway timeout'
 components:
   schemas:
+    nodeCapabilities:
+      type: 'object'
+      description: 'The set of protocol features this node supports. Static capability ids are the protocol enum names (e.g. SERVICE_NODE, INTENT_BUYING); per-intent capabilities (incl. signing) are carried under intentCapabilities.'
+      properties:
+        protocolVersion:
+          type: 'integer'
+          format: 'int64'
+          description: 'The protocol version this node currently speaks.'
+        minProtocolVersion:
+          type: 'integer'
+          format: 'int64'
+          description: 'The oldest protocol version this node can interoperate with.'
+        services:
+          type: 'array'
+          description: 'Supported P2P service capability ids.'
+          items:
+            type: 'string'
+            pattern: .*\S.*
+            x-autoMinLength: true
+        execution:
+          type: 'array'
+          description: 'Supported execution-plan capability ids.'
+          items:
+            type: 'string'
+            pattern: .*\S.*
+            x-autoMinLength: true
+        operations:
+          type: 'array'
+          description: 'Supported async operation capability ids.'
+          items:
+            type: 'string'
+            pattern: .*\S.*
+            x-autoMinLength: true
+        custodySigning:
+          $ref: '#/components/schemas/signatureCapability'
+        intentCapabilities:
+          type: 'array'
+          description: 'Policy-derived per-intent capabilities.'
+          items:
+            $ref: '#/components/schemas/intentCapability'
+    intentCapability:
+      type: 'object'
+      description: 'A supported intent and the per-intent capabilities the node handles for it.'
+      properties:
+        id:
+          type: 'string'
+          description: 'Intent capability id (e.g. INTENT_BUYING).'
+          pattern: .*\S.*
+          x-autoMinLength: true
+        features:
+          type: 'array'
+          description: 'Per-intent feature ids (e.g. INTENT_FEATURE_SETTLEMENT_FULL); empty means the base intent with no optional features.'
+          items:
+            type: 'string'
+            pattern: .*\S.*
+            x-autoMinLength: true
+        instructions:
+          type: 'array'
+          description: 'Instruction capability ids used by this intent''s policies.'
+          items:
+            type: 'string'
+            pattern: .*\S.*
+            x-autoMinLength: true
+        signing:
+          $ref: '#/components/schemas/signatureCapabilities'
+    signatureCapabilities:
+      type: 'object'
+      description: 'Signing capabilities grouped by signing kind.'
+      properties:
+        investor:
+          $ref: '#/components/schemas/signatureCapability'
+        receiptProof:
+          $ref: '#/components/schemas/signatureCapability'
+    signatureCapability:
+      type: 'object'
+      description: 'The signing menu for one kind.'
+      properties:
+        algorithms:
+          type: 'array'
+          description: 'Public-key algorithm enum names.'
+          items:
+            type: 'string'
+            enum: ['ECDSA_SECP256K1']
+        templates:
+          type: 'array'
+          description: 'Supported signature templates.'
+          items:
+            $ref: '#/components/schemas/templateSupport'
+    templateSupport:
+      type: 'object'
+      description: 'One signature template with its supported versions and hash functions.'
+      properties:
+        type:
+          type: 'string'
+          description: 'Template type (HashList | EIP712).'
+          enum: ['HashList', 'EIP712']
+        versions:
+          type: 'array'
+          description: 'Supported template versions (back-compat).'
+          items:
+            type: 'integer'
+            format: 'int64'
+        hashFunctions:
+          type: 'array'
+          description: 'Hash function enum names valid for this template.'
+          items:
+            type: 'string'
+            enum: ['SHA_3_256', 'BLAKE2B', 'KECCAK_256']
     dataProviderResponse:
       type: 'object'
       properties:
@@ -2304,7 +2650,10 @@ components:
         timeout:
           type: 'string'
           format: 'duration'
-          pattern: '^\d+(\.\d{1,9})?s$'
+          description: |
+            Approver timeout in Go duration format (e.g. `90s`, `1m30s`, `1h`). Values are normalized on write, so the value read back may differ from what was written (e.g. `90s` may be returned as `1m30s`).
+          minLength: 1
+          pattern: '^(\d+h)?(\d+m)?(\d+(\.\d{1,9})?s)?$'
         proposals:
           $ref: '#/components/schemas/proposalsApprovalConfig'
     httpEndpointRoleApprovalConfigUpdate:
@@ -2378,6 +2727,22 @@ components:
             type: 'string'
             pattern: '^([1-5][0-9]{2})$'
           nullable: true
+    adapterRetryStrategy:
+      type: 'object'
+      description: 'Per-binding retry policy for the external adapter''s WORKFLOW-layer handling of transient (technical) errors. When omitted, the service falls back to the global retry defaults (prior behavior). transientErrorsMaxRetries and transientErrorsUnlimitedRetries are mutually exclusive; set at most one.'
+      properties:
+        transientErrorsMaxRetries:
+          type: 'integer'
+          minimum: 0
+          description: 'Number of times the workflow re-drives the handler after a transient error before hanging. Omit to use the global default (flow_handler_retries_on_technical_error). Ignored when transientErrorsUnlimitedRetries is true.'
+        transientErrorsUnlimitedRetries:
+          type: 'boolean'
+          default: false
+          description: 'Retry transient errors indefinitely, overriding transientErrorsMaxRetries and all stop-limits. Business errors are unaffected and still terminate the workflow.'
+        alertAfter:
+          type: 'integer'
+          minimum: 1
+          description: 'Cumulative technical-retry count at which the saturation alert fires, followed by dampened periodic re-alerts. Omit to use the engine default.'
     adapterAuthOptions:
       type: 'array'
       description: 'List of authentication mechanisms supported by this ledger'
@@ -2656,7 +3021,7 @@ components:
           $ref: '#/components/schemas/transactionDetails'
         operationType:
           type: 'string'
-          enum: ['issue', 'transfer', 'hold', 'release', 'redeem']
+          enum: ['issue', 'transfer', 'hold', 'release', 'redeem', 'move']
         proof:
           $ref: '#/components/schemas/proofPolicy'
     transactionDetails:
@@ -2731,6 +3096,8 @@ components:
             $ref: '#/components/schemas/executionParticipant'
         contract:
           $ref: '#/components/schemas/contract'
+        metadata:
+          $ref: 'common-external-components.yaml#/components/schemas/customMetadata'
     contract:
       type: 'object'
       properties:
@@ -3080,6 +3447,13 @@ components:
         type:
           type: 'string'
           enum: ['hashList']
+        templateVersion:
+          type: 'integer'
+          minimum: 1
+          description: |
+            This version identifies the HashList template specification revision.
+            When omitted, the verifier resolves the version from the
+            router/ledger/asset-profile resolver chain.
         hashGroups:
           type: 'array'
           items:
@@ -3179,6 +3553,15 @@ components:
         type:
           type: 'string'
           enum: ['EIP712']
+        templateVersion:
+          type: 'integer'
+          minimum: 1
+          description: |
+            Template shape version. When omitted, the verifier resolves the
+            version from the router/ledger/asset-profile resolver chain.
+            Not to be confused with EIP712Domain.version (the EIP-712
+            contract domain version). See pkg/signature/specs/eip712/ for
+            versioned specs.
         domain:
           $ref: '#/components/schemas/EIP712Domain'
         message:
@@ -3241,7 +3624,7 @@ components:
           $ref: 'common-external-components.yaml#/components/schemas/receiptAssetDetails'
         operationType:
           type: 'string'
-          enum: ['hold', 'issue', 'redeem', 'release', 'transfer', 'unknown']
+          enum: ['hold', 'issue', 'redeem', 'release', 'transfer', 'move', 'unknown']
         operationRef:
           type: 'string'
           pattern: .*\S.*
@@ -3371,6 +3754,12 @@ components:
           type: 'array'
           items:
             $ref: '#/components/schemas/settlementStrategyType'
+        signingCapabilities:
+          $ref: '#/components/schemas/signatureCapabilities'
+        requiredProtocolVersion:
+          type: 'integer'
+          format: 'uint32'
+          description: 'minimum FinP2P protocol version required to execute this policy''s instruction graph; absent or 0 = protocol baseline (version 1)'
     createPolicyRequest:
       type: 'object'
       required: ['policyId', 'description', 'priority', 'intent', 'instructions']
@@ -3409,6 +3798,12 @@ components:
           type: 'array'
           items:
             $ref: '#/components/schemas/settlementStrategyType'
+        signingCapabilities:
+          $ref: '#/components/schemas/signatureCapabilities'
+        requiredProtocolVersion:
+          type: 'integer'
+          format: 'uint32'
+          description: 'minimum FinP2P protocol version required to execute this policy''s instruction graph; absent or 0 = protocol baseline (version 1)'
     updatePolicyRequest:
       type: 'object'
       required: ['policyId', 'description', 'priority', 'intent', 'instructions', 'version', 'assetMatchingCriteria']
@@ -3426,7 +3821,7 @@ components:
           description: 'priority of the policy'
         intent:
           type: 'string'
-          enum: ['primarySale', 'buyingIntent', 'sellingIntent', 'loanIntent', 'redemptionIntent', 'privateOfferIntent', 'requestForTransferIntent']
+          enum: ['primarySale', 'buyingIntent', 'sellingIntent', 'loanIntent', 'redemptionIntent', 'privateOfferIntent', 'requestForTransferIntent', 'moveIntent']
         description:
           type: 'string'
           maxLength: 255
@@ -3452,6 +3847,12 @@ components:
           type: 'array'
           items:
             $ref: '#/components/schemas/settlementStrategyType'
+        signingCapabilities:
+          $ref: '#/components/schemas/signatureCapabilities'
+        requiredProtocolVersion:
+          type: 'integer'
+          format: 'uint32'
+          description: 'minimum FinP2P protocol version required to execute this policy''s instruction graph; absent or 0 = protocol baseline (version 1)'
     settlementStrategyType:
       type: 'string'
       enum: ['NOSETTLEMENT', 'PARTIAL', 'FULL']
@@ -3498,6 +3899,18 @@ components:
             type: 'string'
             maxLength: 255
             minLength: 2
+        ledgerNames:
+          description: |
+            Optional allow-list of ledger names. When non-empty, the policy
+            attaches only to assets whose ledger binding name matches one of
+            the listed values (case-insensitive). Empty or omitted = no
+            constraint on the asset's ledger binding.
+          nullable: false
+          type: 'array'
+          items:
+            type: 'string'
+            maxLength: 255
+            minLength: 1
         ledgerAssetIdentifiers:
           type: 'array'
           items:
@@ -3561,7 +3974,7 @@ components:
       properties:
         instruction:
           type: 'string'
-          enum: ['Hold', 'Transfer', 'Release', 'Await', 'Issue', 'RevertHold', 'Redeem']
+          enum: ['Hold', 'Transfer', 'Release', 'Await', 'Issue', 'RevertHold', 'Redeem', 'Move']
         sequence:
           type: 'integer'
           format: 'uint32'

--- a/finp2p-client/apis/ownership.graphql
+++ b/finp2p-client/apis/ownership.graphql
@@ -42,6 +42,8 @@ enum IntentTypes {
     LOAN
     PRIVATE_OFFER
     REQUEST_FOR_TRANSFER
+    MOVE
+    REDEMPTION
 }
 
 
@@ -385,6 +387,9 @@ type User implements Profile  {
 
     accounts(filter: [Filter!]): [FinP2PAccount!]
 
+    "Investor network accounts (LA-managed wallets) bound to a specific organization and asset."
+    networkAccounts(filter: [Filter!]): [InvestorNetworkAccount!]
+
     "User's associated messages"
     #    inbox(filter : [Filter!]): [IncomingMessage!]!
     inbox(filter : [Filter!]): Messages!
@@ -509,7 +514,13 @@ type Custodian {
 type TokenBalance {
     userId: String!
     assetId: String!
-    quantity: String!
+    quantity: String! ## calculated balance based on asset's receipt
+    availableQuantity: String! ## calculated available balance based on asset's receipt
+    heldQuantity: String! ## calculated held balance based on asset's receipt
+    syncedQuantity: String! ## balance synced from ledger
+    syncedAvailableQuantity: String! ## available balance synced from ledger
+    syncedHeldQuantity: String! ## held balance synced from ledger
+    syncedQuantityTimestamp: Int! ## epoch seconds timestamp of last balance synchronization
     transactionsDetails: [TransactionDetails!]
 }
 
@@ -574,6 +585,8 @@ type Signature {
     signature: String!
     hashFunction: String!
     templateType: templateType!
+    "Template shape version. Defaults to 1 when the producer is on a pre-versioning finp2p-core release."
+    templateVersion: Int!
 }
 
 enum templateType {
@@ -610,6 +623,7 @@ enum OperationType {
     Release
     Hold
     Redeem
+    Move
 }
 
 type TradeDetails {
@@ -652,6 +666,11 @@ type Certificate {
 }
 
 
+type KeyValuePair {
+    key: String!
+    value: String!
+}
+
 "Represent an Asset's Transaction Intent occasion in which the Asset's tokens are issued."
 type Intent {
     id: String!
@@ -674,11 +693,17 @@ type Intent {
     "Intent data"
     intent: IntentDetails
 
+    "Custom key-value metadata for tracing and reconciliation"
+    customMetadata: [KeyValuePair!]
+
     "Profile metadata, contains ACL information of the profile."
     metadata: ProfileMetadata!
 
     "intent resource version"
     version: String!
+
+    "Reason the intent was rejected, prefixed with the rejecting organization (owner side only)."
+    rejectReason: String
 }
 
 
@@ -730,10 +755,22 @@ type LedgerAccountAsset {
     networkAccount: NetworkAccount
 }
 
-"Network account - represents external network accounts like wallets"
-type NetworkAccount {
-    "Wallet account if present"
-    wallet: WalletAccount
+"Network account — exactly one variant, mirroring the proto NetworkAccount oneof."
+union NetworkAccount = WalletAccount | Caip10Account | CustodialAccount
+
+"An investor's LA-managed network account bound to a specific organization and asset."
+type InvestorNetworkAccount {
+    "Organization that manages this network account."
+    organizationId: String!
+
+    "Asset the network account is bound to."
+    assetId: String!
+
+    "LA-assigned account identifier."
+    id: String!
+
+    "The bound network identity — a union of variants (wallet today; caip10/custodial when projected). Exactly one variant is set."
+    account: NetworkAccount
 }
 
 "Wallet account for blockchain wallets"
@@ -743,6 +780,27 @@ type WalletAccount {
 
     "Wallet address"
     address: String!
+}
+
+"CAIP-10 chain-agnostic on-chain account"
+type Caip10Account {
+    "CAIP-2 chain_id, e.g. eip155:1 (the same token used by the CAIP-19 asset identifier network)"
+    network: String!
+
+    "CAIP-10 account address (chain-native address)"
+    address: String!
+}
+
+"Custodial account reference (e.g. a Fireblocks vault account) that is not a single on-chain address"
+type CustodialAccount {
+    "Custody provider discriminator, e.g. fireblocks"
+    provider: String!
+
+    "Provider-internal account identifier (e.g. a Fireblocks vault account id)"
+    vaultAccountId: String!
+
+    "Optional. Narrows the custodial account to a specific asset/chain."
+    assetId: String
 }
 
 "FinP2P asset with resource ID and ledger identifier"
@@ -757,9 +815,9 @@ type FinP2PAsset {
 "CAIP-19 format ledger identifier"
 type Caip19Identifier {
     "CAIP-2 network identifier (e.g., eip155:1, solana:mainnet)"
-    network: String!
+    network: String
     "Token standard (e.g., erc20, erc721)"
-    standard: String!
+    standard: String
     "Token ID or contract address"
     tokenId: String!
 }
@@ -859,6 +917,12 @@ type ExecutionPlan {
     "list of plan approvals"
     approvals: [PlanApproval]!
 
+    "Plan-level workflows: workflows scoped to the plan itself (e.g. plan_approval, and plan-scoped signature_request) — NOT the per-instruction workflows, which are under instructions.workflows. Fully populated (state, health, availableActions, references, metadata), same as the top-level `workflows` query."
+    workflows: [Workflow!]!
+
+    "All workflows related to this plan (plan-level and per-instruction) — the top-level `workflows` query pre-scoped to the plan, with the same filter/pagination/ordering. Use pageInfo.totalCount for the count and a filter (e.g. health_status EQ UNHEALTHY) for the problematic subset. Defaults to creationTimestamp ASC."
+    relatedWorkflows(filter: [Filter!], paginate: PaginateInput = {}, orderBy: WorkflowOrder): Workflows!
+
     "plan creation (timestamp in sec)"
     creationTimestamp: Int!
 
@@ -867,6 +931,9 @@ type ExecutionPlan {
 
     "version of the execution plan"
     version: Int!
+
+    "Custom key-value metadata for tracing and reconciliation"
+    customMetadata: [KeyValuePair!]
 }
 
 type ExecutionPlanContract {
@@ -888,7 +955,7 @@ enum InvestorRole {
 }
 
 union ExecutionPlanContractDetails = IssuanceContractDetails | BuyingContractDetails | SellingContractDetails | LoanContractDetails
-    | TransferContractDetails | RedemptionContractDetails | PrivateOfferContractDetails | RequestForTransferContractDetails
+    | TransferContractDetails | RedemptionContractDetails | PrivateOfferContractDetails | RequestForTransferContractDetails | MoveContractDetails
 
 type IssuanceContractDetails {
     asset: AssetOrder!
@@ -912,6 +979,10 @@ type LoanContractDetails {
 }
 
 type TransferContractDetails {
+    asset: AssetOrder!
+}
+
+type MoveContractDetails {
     asset: AssetOrder!
 }
 
@@ -979,7 +1050,7 @@ type InstructionApproval {
     reason: String!
 }
 
-union InstructionDetails = IssueInstruction | TransferInstruction | HoldInstruction | ReleaseInstruction | RevertHoldInstruction | AwaitInstruction | RedeemInstruction
+union InstructionDetails = IssueInstruction | TransferInstruction | HoldInstruction | ReleaseInstruction | RevertHoldInstruction | AwaitInstruction | RedeemInstruction | MoveInstruction
 
 union InstructionCompletionState = UnknownState | ErrorState | SuccessState
 
@@ -1085,6 +1156,17 @@ type RedeemInstruction {
     amount: String!
 }
 
+type MoveInstruction {
+    "source account information"
+    source: LedgerAccountAsset!
+
+    "destination account information"
+    destination: LedgerAccountAsset!
+
+    "asset's move amount"
+    amount: String!
+}
+
 type ExecutionPlanInstructions {
     nodes: [ExecutionPlanInstruction!]
 }
@@ -1138,7 +1220,7 @@ enum ActionType {
 }
 
 
-union IntentDetails = PrimarySale | BuyingIntent | SellingIntent | LoanIntent | RedemptionIntent | PrivateOfferIntent | RequestForTransferIntent
+union IntentDetails = PrimarySale | BuyingIntent | SellingIntent | LoanIntent | RedemptionIntent | PrivateOfferIntent | RequestForTransferIntent | MoveIntent
 
 type PrimarySale  {
     "Issuer id"
@@ -1153,7 +1235,7 @@ type PrimarySale  {
     "Settlement term"
     settlementTerm: SettlementTerm
 
-    sellingSettlementInstruction: SellingSettlementInstruction!
+    sellingSettlementInstruction: SellingSettlementInstruction
 }
 
 type RedemptionIntent  {
@@ -1205,6 +1287,10 @@ type PresignedRequestForTransferIntentSignaturePolicy{
     _ignore: Boolean
 }
 
+type PresignedMoveIntentSignaturePolicy{
+    _ignore: Boolean
+}
+
 type PresignedPrivateOfferIntentSignaturePolicy{
     _ignore: Boolean
 }
@@ -1215,6 +1301,7 @@ union LoanSignaturePolicy = PresignedLoanIntentSignaturePolicy
 union RedemptionSignaturePolicy = PresignedRedemptionIntentSignaturePolicy | ManualIntentSignaturePolicy
 union PrivateOfferSignaturePolicy = PresignedPrivateOfferIntentSignaturePolicy | ManualIntentSignaturePolicy
 union RequestForTransferSignaturePolicy = PresignedRequestForTransferIntentSignaturePolicy | ManualIntentSignaturePolicy
+union MoveSignaturePolicy = PresignedMoveIntentSignaturePolicy | ManualIntentSignaturePolicy
 
 type BuyingIntent{
     "resource id of the buyer"
@@ -1232,7 +1319,7 @@ type BuyingIntent{
     "Signature policy type"
     signaturePolicyType: SignaturePolicyType!
     signaturePolicy: BuyingSignaturePolicy!
-    settlementInstruction: BuyingSettlementInstruction!
+    settlementInstruction: BuyingSettlementInstruction
 }
 
 type SellingIntent{
@@ -1251,7 +1338,7 @@ type SellingIntent{
     "Signature policy type"
     signaturePolicyType: SignaturePolicyType!
     signaturePolicy: SellingSignaturePolicy!
-    sellingSettlementInstruction: SellingSettlementInstruction!
+    sellingSettlementInstruction: SellingSettlementInstruction
 }
 
 type PrivateOfferIntent{
@@ -1273,7 +1360,7 @@ type PrivateOfferIntent{
     "Signature policy type"
     signaturePolicyType: SignaturePolicyType!
     signaturePolicy: PrivateOfferSignaturePolicy!
-    sellingSettlementInstruction: SellingSettlementInstruction!
+    sellingSettlementInstruction: SellingSettlementInstruction
 }
 
 type RequestForTransferIntent{
@@ -1307,6 +1394,33 @@ type RequestForTransferRequestInstruction {
     receiverAccount: FinP2PAssetAccount
 }
 
+"A Move destination asset. Superset of FinP2PAsset (same resourceId + ledgerIdentifier), plus an optional pre-funded pool the Transfer drains into the destination for the hold-transfer-* variants."
+type MoveDestination{
+    "Resource ID of the destination FinP2P asset"
+    resourceId: String!
+
+    "Ledger identifier for the destination asset"
+    ledgerIdentifier: LedgerIdentifier
+
+    "Optional pre-funded pool account drained into this destination by the hold-transfer-* variants (null otherwise)"
+    fromSegregatedAccount: FinP2PAccount
+}
+
+type MoveIntent{
+    "Source asset of the migration path (resourceId + ledgerIdentifier; accounts are supplied per-owner at execution)"
+    sourceAsset: FinP2PAsset
+
+    "Allowed destination assets of the migration path (the executor picks one at execution)"
+    destinationAssets: [MoveDestination!]
+
+    "Optional segregated account that receives released source tokens for the hold-*-release variants (instead of burning via Redeem)"
+    sourceToSegregatedAccount: FinP2PAccount
+
+    "Signature policy type"
+    signaturePolicyType: SignaturePolicyType!
+    signaturePolicy: MoveSignaturePolicy!
+}
+
 type LoanIntent{
     "resource id of the borrower"
     borrower: String!
@@ -1325,7 +1439,7 @@ type LoanIntent{
     settlementTerm: SettlementTerm
 
     "Signature policy type"
-    loanSettlementInstruction: LoanSettlementInstruction!
+    loanSettlementInstruction: LoanSettlementInstruction
     loanInstruction: LoanInstruction!
     signaturePolicyType: SignaturePolicyType!
     signaturePolicy: LoanSignaturePolicy!
@@ -1626,11 +1740,23 @@ type Subscription {
     userHoldingAdded: User!
     userHoldingChanged(fieldNames: [HoldingFields!]!): User!
     assetDataChanged(identifierType: AssetDataIdentifierType, identifierValue: String, dataTypes: [DataType!]): AssetDataItem!
+
+    "Fires when a new intent is committed. Filters AND together; if a filter is omitted it matches everything. ownerOrgIds matches the org ids OSS derives for the intent. For Move this is the source asset's org; for two-sided intents like RequestForTransfer and Loan it may include both sides."
+    intentAdded(intentTypes: [IntentTypes!], assetIds: [String!], ownerOrgIds: [String!]): Intent!
+
+    "Fires when an intent field listed in fieldNames changes. Same filter semantics as intentAdded."
+    intentChanged(fieldNames: [IntentField!]!, intentTypes: [IntentTypes!], assetIds: [String!], ownerOrgIds: [String!]): Intent!
 }
 
 "Fields to subscribe on"
 enum PlanField {
     Status
+}
+
+"Fields to subscribe on"
+enum IntentField {
+    Status
+    RemainingQuantity
 }
 
 "Fields to subscribe on"
@@ -1754,6 +1880,7 @@ enum SignatureTemplate {
 type SignatureProofPolicy {
     verifyingKey: String!
     signatureTemplate: SignatureTemplate!
+    templateVersion: Int!
 }
 
 type NoProofPolicy {
@@ -1764,7 +1891,7 @@ enum FinancialIdentifierType {
     UNSPECIFIED
     ISIN
     ISO4217
-    CUSTOM
+    NONE
 }
 
 type FinancialIdentifier {
@@ -1787,6 +1914,9 @@ type WorkflowMetadata {
 
     currentStateRetry: Int!
 
+    "Non-resetting retry aggregate across all states (never-give-up visibility, core #1251)"
+    cumulativeRetries: Int!
+
     traceId: String!
 
     correlationIds: [String!]
@@ -1805,7 +1935,10 @@ type Workflow {
     "Name of the workflow"
     name: String!
 
-    "Current transition id of the workflow"
+    "Current state of the workflow (always populated; the state machine's current node, e.g. the initial state before any transition is applied)"
+    state: String!
+
+    "Id of the last applied transition (empty until the first transition; use `state` for the workflow's current position)"
     transitionId: String!
 
     "Current status of the workflow"
@@ -1834,6 +1967,9 @@ type Workflow {
 
     "Workflow creation timestamp"
     creationTimestamp: Int!
+
+    "Workflow last-modified timestamp (epoch millis)"
+    lastModified: Int!
 }
 
 "Health status of a workflow"
@@ -1860,6 +1996,8 @@ enum WorkflowHealthStatus {
     STALE
     STUCK
     UNHEALTHY
+    "Actively retrying but still working (durable signal, core #1251) — not an error state"
+    RETRYING
 }
 
 "Additional health assessment metadata"
@@ -1904,6 +2042,8 @@ enum WorkflowOrderField {
     REFERENCE_ID
     HEALTH_STATUS
     CORRELATION_ID
+    CREATION_TIMESTAMP
+    LAST_MODIFIED
 }
 
 input WorkflowOrder {

--- a/finp2p-client/apis/ownership.graphql
+++ b/finp2p-client/apis/ownership.graphql
@@ -106,9 +106,6 @@ type Asset implements Profile  {
 
     "whether the asset is auto-shared"
     autoShare: Boolean!
-
-    "omnibus account for the asset, if applicable"
-    orgSettlementAccount: NetworkAccount
 }
 
 type LedgerAssetInfo {

--- a/finp2p-client/grahpqlgen.ts
+++ b/finp2p-client/grahpqlgen.ts
@@ -4,6 +4,7 @@ import type { CodegenConfig } from '@graphql-codegen/cli';
 const config: CodegenConfig = {
   overwrite: true,
   schema: "./apis/ownership.graphql",
+  documents: "./src/oss/graphql/*.graphql",
   generates: {
     "src/oss/graphql.d.ts": {
       plugins: ["typescript"]

--- a/finp2p-client/graphqlvalidate.ts
+++ b/finp2p-client/graphqlvalidate.ts
@@ -1,0 +1,29 @@
+/**
+ * Validation-only codegen config.
+ *
+ * `graphql-codegen` validates every document in `documents` against `schema`
+ * and exits non-zero on a mismatch (e.g. selecting a field on a union type).
+ * That check is the only guard the OSS queries have — nothing else in the build
+ * compares them to the schema, and a stale vendored schema is precisely how a
+ * broken selection set stays invisible until a real server rejects it.
+ *
+ * This config exists so the check can run without rewriting the committed
+ * `graphql.d.ts`: output goes to a throwaway path under node_modules/.cache,
+ * so `npm run validate:graphql` is side-effect free and safe in CI.
+ *
+ * Keep `schema` and `documents` identical to grahpqlgen.ts.
+ */
+import type { CodegenConfig } from '@graphql-codegen/cli';
+
+const config: CodegenConfig = {
+  overwrite: true,
+  schema: './apis/ownership.graphql',
+  documents: './src/oss/graphql/*.graphql',
+  generates: {
+    'node_modules/.cache/graphql-validate/schema.d.ts': {
+      plugins: ['typescript'],
+    },
+  },
+};
+
+export default config;

--- a/finp2p-client/package-lock.json
+++ b/finp2p-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.28.22",
+  "version": "0.28.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-client",
-      "version": "0.28.22",
+      "version": "0.28.24",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.12.2",

--- a/finp2p-client/package-lock.json
+++ b/finp2p-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.28.24",
+  "version": "0.28.23",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-client",
-      "version": "0.28.24",
+      "version": "0.28.23",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.12.2",

--- a/finp2p-client/package.json
+++ b/finp2p-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.28.22",
+  "version": "0.28.24",
   "description": "FinP2P API Client",
   "homepage": "https://ownera.io/",
   "main": "./dist/index.js",

--- a/finp2p-client/package.json
+++ b/finp2p-client/package.json
@@ -9,7 +9,9 @@
     "dist/**/*"
   ],
   "scripts": {
-    "prebuild": "eslint ./src --ext .ts --fix",
+    "validate:graphql": "graphql-codegen --config graphqlvalidate.ts",
+    "smoke": "node scripts/smoke-investor-accounts.js",
+    "prebuild": "npm run validate:graphql && eslint ./src --ext .ts --fix",
     "build": "tsc",
     "postbuild": "cpx 'src/oss/graphql/*.graphql' dist/oss/graphql/",
     "api-generate": "npx openapi-typescript ./apis/application-api.base.yaml -o src/finapi/model-gen.ts",

--- a/finp2p-client/package.json
+++ b/finp2p-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-client",
-  "version": "0.28.24",
+  "version": "0.28.23",
   "description": "FinP2P API Client",
   "homepage": "https://ownera.io/",
   "main": "./dist/index.js",

--- a/finp2p-client/scripts/smoke-investor-accounts.js
+++ b/finp2p-client/scripts/smoke-investor-accounts.js
@@ -1,0 +1,173 @@
+/**
+ * Wire-level smoke test for the investor network-account onboarding surface.
+ *
+ * This package has no test harness, and the onboarding methods are thin
+ * wrappers whose interesting behaviour is what actually goes on the wire —
+ * request path, the required Idempotency-Key header, and how the OSS
+ * NetworkAccount union is discriminated. Typechecking cannot catch a wrong
+ * path or a missing header, so assert them against throwaway local servers.
+ *
+ *   node scripts/smoke-investor-accounts.js     (run `npm run build` first)
+ *
+ * Exits non-zero on the first failed assertion.
+ */
+const http = require('http');
+const path = require('path');
+const assert = require('node:assert/strict');
+
+const dist = path.join(__dirname, '..', 'dist');
+const { FinAPIClient } = require(path.join(dist, 'finapi'));
+const { OssClient } = require(path.join(dist, 'oss'));
+
+const INVESTOR = 'bank-x:101:511c1d7f-4ed8-410d-887c-a10e3e499a01';
+
+/** Start a server that records requests and replies with `reply`. Resolves to { port, seen, close }. */
+function recordingServer(reply) {
+  const seen = [];
+  const server = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (c) => { body += c; });
+    req.on('end', () => {
+      seen.push({
+        method: req.method,
+        url: req.url,
+        idempotencyKey: req.headers['idempotency-key'],
+        body: body ? JSON.parse(body) : null,
+      });
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(reply));
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, () => resolve({
+      port: server.address().port,
+      seen,
+      close: () => server.close(),
+    }));
+  });
+}
+
+async function checkRestSurface() {
+  const srv = await recordingServer({ cid: 'cid-123', isCompleted: false });
+  const client = new FinAPIClient(`http://127.0.0.1:${srv.port}`);
+
+  await client.createInvestorAccount(INVESTOR, { organizationId: 'bank-x', assetId: 'asset-1' });
+  await client.bindInvestorAccount(INVESTOR, {
+    organizationId: 'bank-x',
+    assetId: 'asset-1',
+    networkAccount: { type: 'caip10Account', network: 'eip155:1', address: '0xabc' },
+    ownershipSignature: 'deadbeef',
+  });
+  await client.submitAccountProof(INVESTOR, { cid: 'cid-123', ownershipSignature: 'cafe' });
+  await client.removeInvestorAccount(INVESTOR, 'acct-7', 'explicit-key-abc');
+  srv.close();
+
+  const [create, bind, proof, remove] = srv.seen;
+  const encoded = encodeURIComponent(INVESTOR);
+
+  assert.equal(srv.seen.length, 4, 'expected four requests');
+
+  assert.equal(create.method, 'POST');
+  assert.equal(create.url, `/profiles/investor/${encoded}/account/create`);
+  assert.deepEqual(create.body, { organizationId: 'bank-x', assetId: 'asset-1' });
+
+  assert.equal(bind.method, 'POST');
+  assert.equal(bind.url, `/profiles/investor/${encoded}/account/bind`);
+  assert.equal(bind.body.networkAccount.type, 'caip10Account');
+  assert.equal(bind.body.ownershipSignature, 'deadbeef');
+
+  assert.equal(proof.method, 'POST');
+  assert.equal(proof.url, `/profiles/investor/${encoded}/account/proof`);
+  assert.deepEqual(proof.body, { cid: 'cid-123', ownershipSignature: 'cafe' });
+
+  assert.equal(remove.method, 'DELETE');
+  assert.equal(remove.url, `/profiles/investor/${encoded}/account/acct-7`);
+
+  // Idempotency-Key is required on all four routes.
+  const keys = srv.seen.map((s) => s.idempotencyKey);
+  assert.ok(keys.every(Boolean), 'every request must carry Idempotency-Key');
+  const auto = keys.slice(0, 3);
+  assert.ok(auto.every((k) => /^[0-9a-f]{64}$/.test(k)), 'auto keys must be 32-byte hex');
+  assert.equal(new Set(auto).size, 3, 'auto keys must differ per call');
+  assert.equal(keys[3], 'explicit-key-abc', 'explicit key must be honored');
+
+  console.log('  ok  REST: 4 routes, bodies, required Idempotency-Key, explicit override');
+}
+
+async function checkOssReadBack() {
+  const accounts = [
+    {
+      organizationId: 'bank-x', assetId: 'asset-1', id: 'acct-1',
+      account: { kind: 'WalletAccount', type: 'walletAccount', address: '0xaaa' },
+    },
+    {
+      organizationId: 'bank-x', assetId: 'asset-2', id: 'acct-2',
+      account: { kind: 'Caip10Account', network: 'eip155:1', address: '0xbbb' },
+    },
+    {
+      organizationId: 'bank-y', assetId: 'asset-1', id: 'acct-3',
+      account: { kind: 'CustodialAccount', provider: 'fireblocks', vaultAccountId: 'v7', assetId: null },
+    },
+  ];
+  const srv = await recordingServer({
+    data: {
+      users: {
+        nodes: [{
+          id: INVESTOR, name: 'Inv', finIds: ['abc'], organizationId: 'bank-x',
+          metadata: { acl: [] }, networkAccounts: accounts,
+        }],
+      },
+    },
+  });
+  const client = new OssClient(`http://127.0.0.1:${srv.port}`);
+
+  const all = await client.getOwnerNetworkAccounts(INVESTOR);
+  const byAsset = await client.getOwnerNetworkAccounts(INVESTOR, { assetId: 'asset-1' });
+  const scoped = await client.getOwnerNetworkAccounts(INVESTOR, { organizationId: 'bank-x', assetId: 'asset-1' });
+  srv.close();
+
+  const vars = srv.seen[0].body.variables;
+  assert.equal(vars.includeNetworkAccounts, true, 'must opt into networkAccounts');
+  assert.equal(vars.includeCerts, false);
+  assert.equal(vars.includeHoldings, false);
+
+  // The union must be selected via inline fragments, never as an object field.
+  const query = srv.seen[0].body.query;
+  assert.ok(/networkAccounts/.test(query), 'query must select networkAccounts');
+  assert.ok(/\.\.\. on WalletAccount/.test(query), 'must use an inline fragment on WalletAccount');
+  assert.ok(!/networkAccount\s*{\s*wallet/.test(query), 'must not select `wallet` on the union');
+
+  assert.deepEqual(all.map((a) => a.id), ['acct-1', 'acct-2', 'acct-3']);
+  assert.deepEqual(
+    all.map((a) => a.account.kind),
+    ['WalletAccount', 'Caip10Account', 'CustodialAccount'],
+    'all three union variants must round-trip',
+  );
+  assert.deepEqual(byAsset.map((a) => a.id), ['acct-1', 'acct-3'], 'assetId scope');
+  assert.deepEqual(scoped.map((a) => a.id), ['acct-1'], 'organizationId + assetId scope');
+
+  console.log('  ok  OSS: query variables, union discrimination, scope filtering');
+}
+
+async function checkOssNotFound() {
+  const srv = await recordingServer({ data: { users: { nodes: [] } } });
+  const client = new OssClient(`http://127.0.0.1:${srv.port}`);
+  await assert.rejects(
+    () => client.getOwnerNetworkAccounts('missing'),
+    (e) => e.constructor.name === 'ItemNotFoundError',
+    'unknown owner must raise ItemNotFoundError',
+  );
+  srv.close();
+  console.log('  ok  OSS: unknown owner raises ItemNotFoundError');
+}
+
+(async () => {
+  console.log('investor network-account smoke test');
+  await checkRestSurface();
+  await checkOssReadBack();
+  await checkOssNotFound();
+  console.log('all assertions passed');
+})().catch((e) => {
+  console.error('FAILED:', e.message);
+  process.exit(1);
+});

--- a/finp2p-client/src/client.ts
+++ b/finp2p-client/src/client.ts
@@ -52,6 +52,24 @@ export class FinP2PClient {
     return this.finAPIClient.createOwnerAccount(...args);
   }
 
+  // ── Investor network accounts (onboarding) ──
+
+  async createInvestorAccount(...args: Parameters<FinAPIClient['createInvestorAccount']>) {
+    return this.finAPIClient.createInvestorAccount(...args);
+  }
+
+  async bindInvestorAccount(...args: Parameters<FinAPIClient['bindInvestorAccount']>) {
+    return this.finAPIClient.bindInvestorAccount(...args);
+  }
+
+  async submitAccountProof(...args: Parameters<FinAPIClient['submitAccountProof']>) {
+    return this.finAPIClient.submitAccountProof(...args);
+  }
+
+  async removeInvestorAccount(...args: Parameters<FinAPIClient['removeInvestorAccount']>) {
+    return this.finAPIClient.removeInvestorAccount(...args);
+  }
+
   // ── Intent creation / execution ──
 
   async createIntent(...args: Parameters<FinAPIClient['createIntent']>) {

--- a/finp2p-client/src/client.ts
+++ b/finp2p-client/src/client.ts
@@ -70,6 +70,11 @@ export class FinP2PClient {
     return this.finAPIClient.removeInvestorAccount(...args);
   }
 
+  /** Read back an investor's onboarded network accounts from the OSS read model. */
+  async getOwnerNetworkAccounts(...args: Parameters<OssClient['getOwnerNetworkAccounts']>) {
+    return this.ossClient.getOwnerNetworkAccounts(...args);
+  }
+
   // ── Intent creation / execution ──
 
   async createIntent(...args: Parameters<FinAPIClient['createIntent']>) {

--- a/finp2p-client/src/finapi/finapi.client.ts
+++ b/finp2p-client/src/finapi/finapi.client.ts
@@ -81,6 +81,12 @@ export type NetworkAccountChallenge = FinAPIComponents['schemas']['networkAccoun
  * they are the only application-API routes where it is not optional. The value
  * is a hex-encoded 32-byte nonce: 24 random bytes plus an 8-byte big-endian
  * epoch-seconds suffix, which is what `generateNonce()` produces.
+ *
+ * A fresh key is minted per call, which is the right default for independent
+ * requests but provides no deduplication on retry: a caller that retries a
+ * timed-out request without passing its own key gets a new key, and the router
+ * treats it as a new operation. If you own the retry loop, generate one key and
+ * thread the same value through every attempt.
  */
 function idempotencyHeader(idempotencyKey?: string) {
   return { 'Idempotency-Key': idempotencyKey ?? generateNonce().toString('hex') };

--- a/finp2p-client/src/finapi/finapi.client.ts
+++ b/finp2p-client/src/finapi/finapi.client.ts
@@ -1,7 +1,7 @@
 import createClient, { Client, Middleware } from 'openapi-fetch';
 import { components as FinAPIComponents, paths as FinAPIPaths } from './model-gen';
 import { components as OpComponents, paths as OpPaths } from './op-model-gen';
-import { normalizeBaseUrl, sleep } from './utils';
+import { generateNonce, normalizeBaseUrl, sleep } from './utils';
 
 // Helper: extract the request body type for a given path + method from openapi-fetch paths
 type RequestBody<P extends keyof FinAPIPaths, M extends keyof FinAPIPaths[P]> =
@@ -15,9 +15,10 @@ type OpRequestBody<P extends keyof OpPaths, M extends keyof OpPaths[P]> =
  * every spec field is available without hand-maintained signatures.
  *
  * Required: name, type, denomination, ledgerAssetBinding.
- * Optional: symbol, issuerId, intentTypes, assetPolicies, config (deprecated),
- *           metadata, verifiers, financialIdentifier, orgSettlementAccount,
- *           allowPolicyDefaultFallback, decimalPlaces, autoShare.
+ * Optional: assetId, symbol, issuerId, intentTypes, assetPolicies,
+ *           config (deprecated), metadata, verifiers, financialIdentifier,
+ *           signatureTemplate, allowPolicyDefaultFallback, decimalPlaces,
+ *           autoShare.
  */
 export type CreateAssetOptions = RequestBody<'/profiles/asset', 'post'>;
 
@@ -28,11 +29,62 @@ export type CreateAssetOptions = RequestBody<'/profiles/asset', 'post'>;
  * name, symbol, assetPolicies, allowPolicyDefaultFallback, autoShare.
  *
  * Immutable post-creation (not in this body): type, issuerId, denomination,
- * ledgerAssetBinding, financialIdentifier, intentTypes, orgSettlementAccount,
- * decimalPlaces. Intent allow-list changes have their own dedicated routes
- * under `/profiles/asset/{id}/intent[/...]`.
+ * financialIdentifier, intentTypes, decimalPlaces. `ledgerAssetBinding` and
+ * `financialIdentifier` accept one-time promotions only. Intent allow-list
+ * changes have their own dedicated routes under
+ * `/profiles/asset/{id}/intent[/...]`.
  */
 export type PatchAssetOptions = RequestBody<'/profiles/asset/{id}', 'patch'>;
+
+// ── Investor network accounts ──
+
+/** Body of `POST /profiles/investor/{investorId}/account/create` — `{ organizationId, assetId }`. */
+export type CreateInvestorAccountBody = RequestBody<'/profiles/investor/{investorId}/account/create', 'post'>;
+
+/**
+ * Body of `POST /profiles/investor/{investorId}/account/bind` —
+ * `{ organizationId, assetId, networkAccount, ownershipSignature }`.
+ *
+ * Note `ownershipSignature` is a bare hex string here. The adapter-facing spec
+ * wraps it in an object (`accountOwnershipSignature { signature }`), so the two
+ * sides are deliberately not the same type.
+ */
+export type BindInvestorAccountBody = RequestBody<'/profiles/investor/{investorId}/account/bind', 'post'>;
+
+/** Body of `POST /profiles/investor/{investorId}/account/proof` — `{ cid, ownershipSignature }`. */
+export type SubmitAccountProofBody = RequestBody<'/profiles/investor/{investorId}/account/proof', 'post'>;
+
+/**
+ * An investor network account: `walletAccount`, `caip10Account`,
+ * `custodialAccount`, or `noneAccount`, discriminated by `type`.
+ *
+ * The `walletAccount` discriminator must be exactly `'walletAccount'` — the
+ * router compares the adapter's onboarding echo byte-for-byte against the
+ * account named on an operation leg, so any other token (e.g. `'wallet'`)
+ * produces a spurious 7351 `AccountNotWhitelisted` on every operation after a
+ * successful bind.
+ */
+export type NetworkAccount = FinAPIComponents['schemas']['networkAccount'];
+
+/**
+ * Challenge issued by the ledger adapter while a network-account operation is
+ * parked. Present on `operationResponse` whenever `isCompleted` is false.
+ *
+ * Only `signatureTemplate` is fulfilled through `submitAccountProof`; the
+ * `walletConnect`, `deposit`, and `fireblocksApproval` variants are fulfilled
+ * out of band and the adapter reports verification directly to the asset node.
+ */
+export type NetworkAccountChallenge = FinAPIComponents['schemas']['networkAccountChallenge'];
+
+/**
+ * `Idempotency-Key` is **required** on all four investor-account endpoints —
+ * they are the only application-API routes where it is not optional. The value
+ * is a hex-encoded 32-byte nonce: 24 random bytes plus an 8-byte big-endian
+ * epoch-seconds suffix, which is what `generateNonce()` produces.
+ */
+function idempotencyHeader(idempotencyKey?: string) {
+  return { 'Idempotency-Key': idempotencyKey ?? generateNonce().toString('hex') };
+}
 
 export class FinAPIClient {
 
@@ -114,6 +166,67 @@ export class FinAPIClient {
     return this.apiClient.POST('/profiles/owner/{ownerId}/account', {
       params: { path: { ownerId } },
       body,
+    });
+  }
+
+  // ── Investor network accounts (onboarding) ──
+
+  /**
+   * Onboard a new adapter-generated network account for an investor. The ledger
+   * adapter creates the wallet on the asset's network and holds the keys.
+   *
+   * Returns `202 { cid }`; the adapter then issues a challenge. Poll
+   * `getOperationStatus(cid)` — while `isCompleted` is false the response
+   * carries `challenge`, and on completion it carries the canonical
+   * `{ id, networkAccount }` record.
+   */
+  async createInvestorAccount(investorId: string, body: CreateInvestorAccountBody, idempotencyKey?: string) {
+    return this.apiClient.POST('/profiles/investor/{investorId}/account/create', {
+      params: { path: { investorId }, header: idempotencyHeader(idempotencyKey) },
+      body,
+    });
+  }
+
+  /**
+   * Bind an investor's existing external network account. `ownershipSignature`
+   * is a proof-of-ownership hint over the account; the authoritative proof is
+   * fulfilling the challenge the adapter issues afterwards.
+   *
+   * Returns `202 { cid }`. Completion reports `WALLET_ALREADY_BOUND` (409) if
+   * the account is already bound — including to this same investor on the same
+   * `(org, asset)` pair — or `WALLET_BAD_SIGNATURE` (400) on a bad signature.
+   */
+  async bindInvestorAccount(investorId: string, body: BindInvestorAccountBody, idempotencyKey?: string) {
+    return this.apiClient.POST('/profiles/investor/{investorId}/account/bind', {
+      params: { path: { investorId }, header: idempotencyHeader(idempotencyKey) },
+      body,
+    });
+  }
+
+  /**
+   * Submit the investor's signature over a `signatureTemplate` challenge
+   * payload, advancing the workflow out of `AWAITING_PROOF_SUBMISSION`.
+   *
+   * Only for the `signatureTemplate` challenge variant — the out-of-band
+   * variants must not be routed here.
+   */
+  async submitAccountProof(investorId: string, body: SubmitAccountProofBody, idempotencyKey?: string) {
+    return this.apiClient.POST('/profiles/investor/{investorId}/account/proof', {
+      params: { path: { investorId }, header: idempotencyHeader(idempotencyKey) },
+      body,
+    });
+  }
+
+  /**
+   * Unbind a network account from an investor. Returns `202 { cid }`; the
+   * router's local mirror row is removed only once the adapter confirms.
+   *
+   * `accountId` is the adapter-assigned identifier from the onboarding
+   * completion payload, not the account address.
+   */
+  async removeInvestorAccount(investorId: string, accountId: string, idempotencyKey?: string) {
+    return this.apiClient.DELETE('/profiles/investor/{investorId}/account/{accountId}', {
+      params: { path: { investorId, accountId }, header: idempotencyHeader(idempotencyKey) },
     });
   }
 

--- a/finp2p-client/src/finapi/model-gen.ts
+++ b/finp2p-client/src/finapi/model-gen.ts
@@ -44,6 +44,100 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/profiles/investor/{investorId}/account/create': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+         * Create a new wallet for an investor (LA-generated)
+         * @description The LA generates a fresh wallet on the asset's network and owns the keys. Async:
+         *     returns `202 { cid }`; poll `GET /operations/{cid}` for the outcome. On completion
+         *     the payload includes the canonical wallet `{ id, account }` and the wallet is
+         *     mirrored into the investor resource's `data.accounts[orgId][assetId]`.
+         */
+    post: operations['createInvestorAccount'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/profiles/investor/{investorId}/account/bind': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+         * Bind an existing external wallet to an investor (caller-supplied)
+         * @description Caller supplies an external network account they own. `ownershipSignature` is
+         *     required as proof-of-ownership and is verified by the LA. Async: returns `202 { cid }`. If the
+         *     wallet is already bound to another investor — or to the same investor on the same
+         *     `(org, asset)` — completion reports `WALLET_ALREADY_BOUND` (409). A bad signature
+         *     reports `WALLET_BAD_SIGNATURE` (400).
+         */
+    post: operations['bindInvestorAccount'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/profiles/investor/{investorId}/account/proof': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+         * Submit a signature proof for a pending account workflow
+         * @description Used only for `signatureTemplate` challenges. The client submits an `ownershipSignature`
+         *     over the LA-issued payload. Advances the workflow from `AWAITING_PROOF_SUBMISSION` to
+         *     verification; the workflow continues async (poll `GET /operations/{cid}`).
+         *
+         *     Out-of-band challenges (walletConnect / deposit / fireblocksApproval) do not use this
+         *     endpoint — fulfillment happens off-platform and the LA reports verification directly to
+         *     the asset node per the challenge's `operationResponseStrategy`.
+         */
+    post: operations['submitAccountProof'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/profiles/investor/{investorId}/account/{accountId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    /**
+         * Unbind a wallet from an investor
+         * @description Unbinds a wallet from an investor. Asynchronous: returns `202 { cid }`; the
+         *     local mirror row is removed only after the LA confirms completion.
+         */
+    delete: operations['removeInvestorAccount'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/profiles/asset': {
     parameters: {
       query?: never;
@@ -689,7 +783,7 @@ export interface components {
     executionPlanId: string;
     /** @description Allowed intent types to be applied on an asset */
     intentTypes: components['schemas']['intentType'][];
-    updateIntent: components['schemas']['primarySaleIntentUpdatePayload'] | components['schemas']['buyingIntentUpdatePayload'] | components['schemas']['sellingIntentUpdatePayload'] | components['schemas']['loanIntentUpdatePayload'] | components['schemas']['redemptionIntentUpdatePayload'] | components['schemas']['privateOfferIntentUpdatePayload'] | components['schemas']['requestForTransferIntentUpdatePayload'];
+    updateIntent: components['schemas']['primarySaleIntentUpdatePayload'] | components['schemas']['buyingIntentUpdatePayload'] | components['schemas']['sellingIntentUpdatePayload'] | components['schemas']['loanIntentUpdatePayload'] | components['schemas']['redemptionIntentUpdatePayload'] | components['schemas']['privateOfferIntentUpdatePayload'] | components['schemas']['requestForTransferIntentUpdatePayload'] | components['schemas']['moveIntentUpdatePayload'];
     /** @description allowed fields to be updated on given intent type */
     primarySaleIntentUpdatePayload: {
       /**
@@ -759,6 +853,16 @@ export interface components {
       type: 'requestForTransferIntent';
       assetTerm?: components['schemas']['assetTerm'];
     };
+    /** @description Update the allowed destination assets of a Move intent. Replaces the existing list; at least one destination is required. The source asset is immutable. sourceToSegregatedAccount and the per-destination fromSegregatedAccount pools may also be updated. */
+    moveIntentUpdatePayload: {
+      /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+      type: 'moveIntent';
+      destinationAssets: components['schemas']['moveDestination'][];
+      sourceToSegregatedAccount?: components['schemas']['finIdAccount'];
+    };
     noSettlementOptionUpdate: {
       /**
              * @description discriminator enum property added by openapi-typescript
@@ -783,7 +887,9 @@ export interface components {
       amount: components['schemas']['amount'];
     };
     settlementTermUpdate: components['schemas']['noSettlementOptionUpdate'] | components['schemas']['partialSettlementOptionUpdate'] | components['schemas']['fullSettlementOptionUpdate'];
-    intentExecution: components['schemas']['primarySaleExecution'] | components['schemas']['buyingIntentExecution'] | components['schemas']['sellingIntentExecution'] | components['schemas']['loanIntentExecution'] | components['schemas']['redemptionIntentExecution'] | components['schemas']['privateOfferIntentExecution'] | components['schemas']['requestForTransferIntentExecution'];
+    /** @description Optional list of organization ids that will passively observe the orchestration plan. Observers receive all plan state updates but do NOT participate in plan approval or instruction execution. Their acknowledgments are not required and are not counted toward any quorum. */
+    executionObservers: components['schemas']['orgId'][];
+    intentExecution: components['schemas']['primarySaleExecution'] | components['schemas']['buyingIntentExecution'] | components['schemas']['sellingIntentExecution'] | components['schemas']['loanIntentExecution'] | components['schemas']['redemptionIntentExecution'] | components['schemas']['privateOfferIntentExecution'] | components['schemas']['requestForTransferIntentExecution'] | components['schemas']['moveIntentExecution'];
     primarySaleExecution: {
       /**
              * @description discriminator enum property added by openapi-typescript
@@ -885,6 +991,16 @@ export interface components {
       action: 'send' | 'request';
       asset: components['schemas']['sourceDestinationIntentAsset'];
     };
+    moveIntentExecution: {
+      /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+      type: 'moveIntentExecution';
+      nonce: components['schemas']['nonce'];
+      owner: components['schemas']['ownerId'];
+      asset: components['schemas']['sourceDestinationIntentAsset'];
+    };
     /**
          * @description Type of response, immediate / synchronous response or asynchronous
          * @enum {string}
@@ -971,6 +1087,8 @@ export interface components {
       /** @enum {string} */
       type: 'workflow';
       metadata?: unknown;
+      /** @description Present while an investor network-account operation (bind) is parked on a ledger-adapter challenge (isCompleted=false). The client fulfils it — e.g. signing a signatureTemplate payload and POSTing to .../account/proof. */
+      challenge?: components['schemas']['networkAccountChallenge'];
       response?: components['schemas']['APIErrorsTyped'] | components['schemas']['workflowOperationResultResponse'];
     } & {
       /**
@@ -978,6 +1096,45 @@ export interface components {
              * @enum {string}
              */
       type: 'workflow';
+    };
+    /** @description A ledger-adapter-issued challenge for an investor network-account bind, discriminated by `type`. New variants can be added without breaking existing clients. */
+    networkAccountChallenge: components['schemas']['networkAccountChallengeSignatureTemplate'] | components['schemas']['networkAccountChallengeWalletConnect'] | components['schemas']['networkAccountChallengeDeposit'] | components['schemas']['networkAccountChallengeFireblocksApproval'];
+    networkAccountChallengeSignatureTemplate: {
+      /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+      type: 'signatureTemplate';
+      /** @description Hex-encoded payload the wallet must sign. */
+      payload: string;
+    };
+    networkAccountChallengeWalletConnect: {
+      /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+      type: 'walletConnect';
+      /** @description WalletConnect URI to approve. */
+      uri: string;
+    };
+    networkAccountChallengeDeposit: {
+      /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+      type: 'deposit';
+      fromAddress: string;
+      toAddress: string;
+      amount: string;
+    };
+    networkAccountChallengeFireblocksApproval: {
+      /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+      type: 'fireblocksApproval';
+      /** @description Fireblocks request id awaiting approval. */
+      requestId: string;
     };
     workflowOperationResultResponse: {
       /** @enum {string} */
@@ -1178,7 +1335,7 @@ export interface components {
       assetDetails?: components['schemas']['receiptAssetDetails'];
       operationRef?: string;
       /** @enum {string} */
-      operationType: 'hold' | 'issue' | 'redeem' | 'release' | 'transfer' | 'unknown';
+      operationType: 'hold' | 'issue' | 'redeem' | 'release' | 'transfer' | 'move' | 'unknown';
       timestamp: number;
     };
     /**
@@ -1454,7 +1611,7 @@ export interface components {
              * @description type of field
              * @enum {string}
              */
-      type?: 'string' | 'int';
+      type?: 'string' | 'int' | 'bytes';
       /** @description hex representation of the field value */
       value?: string;
     };
@@ -1490,6 +1647,30 @@ export interface components {
       ledger: string;
       bind?: components['schemas']['ledgerAssetIdentifier'];
     };
+    /**
+         * @description Override of the signature template used for this asset's signatures.
+         *     Any field omitted falls back to the ledger-binding override and then
+         *     to the router-config defaults.
+         */
+    assetSignatureTemplate: {
+      /** @enum {string} */
+      templateType?: 'hashlist' | 'eip712';
+      templateVersion?: number;
+      /** @enum {string} */
+      hashFunction?: 'sha3-256' | 'blake2b' | 'keccak-256';
+    };
+    /**
+         * @description Override of the signature template used for this asset's signatures.
+         *     Null clears the asset-level override; any individual field left
+         *     unset falls through to the ledger / router defaults.
+         */
+    assetSignatureTemplateOpt: {
+      /** @enum {string|null} */
+      templateType?: 'hashlist' | 'eip712' | null;
+      templateVersion?: number | null;
+      /** @enum {string|null} */
+      hashFunction?: 'sha3-256' | 'blake2b' | 'keccak-256' | null;
+    } | null;
     ledgerTokenId: {
       /**
              * @description the type of the identifier
@@ -1507,6 +1688,31 @@ export interface components {
     AccountBalanceSyncRequest: {
       account: components['schemas']['finIdAccount'];
       asset: components['schemas']['finp2pAssetBase'];
+      marker?: components['schemas']['BalanceMarker'];
+    };
+    /** @description marker of balance to denote the balance as of marker */
+    BalanceMarker: components['schemas']['BalanceMarkerTimestamp'] | components['schemas']['BalanceMarkerTransactionBlock'];
+    BalanceMarkerTimestamp: {
+      /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+      type: 'timestamp';
+      /**
+             * Format: int64
+             * @description epoch timestamp in seconds
+             */
+      timestamp: number;
+    };
+    BalanceMarkerTransactionBlock: {
+      /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+      type: 'transactionBlock';
+      /** Format: int64 */
+      blockNumber: number;
+      transaction: string;
     };
     assetPolicies: {
       proof?: components['schemas']['proofPolicy'];
@@ -1539,6 +1745,12 @@ export interface components {
         publicKey?: string;
         /** @enum {string} */
         signatureTemplate?: 'hashlist' | 'EIP712';
+        /**
+                 * @description Receipt-proof signature template shape version. When omitted,
+                 *     the verifier resolves the version from the router-config /
+                 *     ledger-binding / asset-profile chain.
+                 */
+        templateVersion?: number;
       };
     };
     signatureProofPolicyOpt: {
@@ -1555,6 +1767,12 @@ export interface components {
         publicKey?: string;
         /** @enum {string} */
         signatureTemplate?: 'hashlist' | 'EIP712';
+        /**
+                 * @description Receipt-proof signature template shape version. When omitted
+                 *     or null, the verifier resolves the version from the
+                 *     router-config / ledger-binding / asset-profile chain.
+                 */
+        templateVersion?: number | null;
       };
     };
     documentsList: {
@@ -1631,7 +1849,7 @@ export interface components {
       status: 'accepted' | 'rejected';
       /** @description Present only when status is "rejected" */
       error?: {
-        /** @description Error code from the errorcodes catalog */
+        /** @description Error code indicating the specific failure - for more information see [API Errors](./api-error-codes-reference). */
         code?: number;
         message?: string;
       };
@@ -1683,6 +1901,45 @@ export interface components {
       updatedAt?: string;
     };
     /**
+         * @description Request body for `POST /profiles/investor/{investorId}/account/create`.
+         *     Starts the workflow with no caller-supplied wallet — the LA generates a
+         *     wallet on the asset's network and owns the keys.
+         */
+    createInvestorAccountRequest: {
+      organizationId: components['schemas']['orgId'];
+      /** @description ID of the asset */
+      assetId: string;
+    };
+    /**
+         * @description Request body for `POST /profiles/investor/{investorId}/account/bind`.
+         *     Caller supplies an external wallet plus a proof-of-ownership signature.
+         *     The LA still issues a challenge (typically signatureTemplate) for final verification.
+         */
+    bindInvestorAccountRequest: {
+      organizationId: components['schemas']['orgId'];
+      /** @description ID of the asset */
+      assetId: string;
+      networkAccount: components['schemas']['networkAccount'];
+      /**
+             * @description Hex-encoded proof-of-ownership signature over the network account. The signed
+             *     payload binds the account to the investor/org/asset so that knowing an address
+             *     alone is not enough to claim it. Treated as a hint; final verification is via
+             *     the challenge issued by the LA.
+             */
+      ownershipSignature: string;
+    };
+    /**
+         * @description Request body for `POST /profiles/investor/{investorId}/account/proof`.
+         *     Submits the user's signature over the LA-issued `signatureTemplate` payload.
+         *     Advances the workflow from `AWAITING_PROOF_SUBMISSION`.
+         */
+    submitAccountProofRequest: {
+      /** @description Correlation id of the account workflow currently in `AWAITING_PROOF_SUBMISSION`. */
+      cid: string;
+      /** @description Hex-encoded signature over the LA-issued `signatureTemplate` payload. */
+      ownershipSignature: string;
+    };
+    /**
          * @description 32 bytes buffer (24 randomly generated bytes by the client + 8 bytes epoch timestamp seconds) encoded to hex:
          *
          *       const nonce = Buffer.alloc(32);
@@ -1710,8 +1967,34 @@ export interface components {
          * @description Existing owner hex representation of a secp256k1 public key 33 bytes compressed
          */
     finId: string;
+    walletAccount: {
+      /** @enum {string} */
+      type: 'walletAccount';
+      /** @description address of the wallet */
+      address: string;
+    };
+    caip10Account: {
+      /** @enum {string} */
+      type: 'caip10Account';
+      /** @description CAIP-2 chain_id, e.g. "eip155:1", "solana:5eykt4...", "hedera:mainnet" (the same token used by the CAIP-19 asset identifier network) */
+      network: string;
+      /** @description CAIP-10 account_address (chain-native address) */
+      address: string;
+    };
+    custodialAccount: {
+      /** @enum {string} */
+      type: 'custodialAccount';
+      /** @description Custody provider discriminator, e.g. "fireblocks" */
+      provider: string;
+      /** @description Provider-internal account identifier (e.g. a Fireblocks vault account id) */
+      vaultAccountId: string;
+      /** @description Optional. Narrows the custodial account to a specific asset/chain. */
+      assetId?: string;
+    };
+    noneAccount: Record<string, never>;
+    networkAccount: components['schemas']['walletAccount'] | components['schemas']['caip10Account'] | components['schemas']['custodialAccount'] | components['schemas']['noneAccount'];
     /** @enum {string} */
-    intentType: 'primarySale' | 'buyingIntent' | 'sellingIntent' | 'loanIntent' | 'redemptionIntent' | 'privateOfferIntent' | 'requestForTransferIntent';
+    intentType: 'primarySale' | 'buyingIntent' | 'sellingIntent' | 'loanIntent' | 'redemptionIntent' | 'privateOfferIntent' | 'requestForTransferIntent' | 'moveIntent';
     /** @description Allowed intent types to be applied on an asset */
     intentTypesAllowEmpty: components['schemas']['intentType'][];
     /**
@@ -1739,11 +2022,12 @@ export interface components {
              * @enum {string}
              */
       assetIdentifierType: 'CAIP-19';
-      network: string;
+      network?: string;
       tokenId: string;
-      standard: string;
+      standard?: string;
     };
     ledgerAssetIdentifier: components['schemas']['ledgerAssetIdentifierTypeCAIP-19'];
+    /** @description Financial instruments (equities, bonds, funds, etc.). 12-character ISO 6166 code. */
     financialAssetIdentifierTypeISIN: {
       /**
              * @description Classification type standards (enum property replaced by openapi-typescript)
@@ -1753,6 +2037,7 @@ export interface components {
       /** @description The classification standard used to identify the asset */
       assetIdentifierValue: string;
     };
+    /** @description Fiat currencies. */
     financialAssetIdentifierTypeISO4217: {
       /**
              * @description Classification type standards (enum property replaced by openapi-typescript)
@@ -1762,6 +2047,7 @@ export interface components {
       /** @description The classification standard used to identify the asset */
       assetIdentifierValue: string;
     };
+    /** @description Asset is not registered under a global identification scheme. */
     financialAssetIdentifierTypeNONE: {
       /**
              * @description Classification type standards (enum property replaced by openapi-typescript)
@@ -1769,12 +2055,8 @@ export interface components {
              */
       assetIdentifierType: 'NONE';
     };
+    /** @description Globally recognized code identifying the asset across networks, routers, and counterparties. Used for balance aggregation and cross-router asset recognition. Format is validated for structure only. */
     financialAssetIdentifier: components['schemas']['financialAssetIdentifierTypeISIN'] | components['schemas']['financialAssetIdentifierTypeISO4217'] | components['schemas']['financialAssetIdentifierTypeNONE'];
-    walletAccount: {
-      type: string;
-      /** @description address of the wallet */
-      address: string;
-    };
     /** @description the total number of units */
     amount: string;
     assetTerm: {
@@ -1802,6 +2084,13 @@ export interface components {
     finp2pAssetAccount: {
       account: components['schemas']['finIdAccount'];
       asset: components['schemas']['finp2pAsset'];
+      /**
+             * @description Optional. Investor network account to use for this leg. Must have been
+             *     previously bound via `POST /profiles/investor/{investorId}/account`.
+             *     Whitelist-validated against `investor.data.accounts[org][asset]`
+             *     before forwarding to the LA. Failure → error code 7351 (AccountNotWhitelistedErr, 400).
+             */
+      networkAccount?: components['schemas']['networkAccount'];
     };
     sourceAccountAssetInstruction: {
       sourceAccount: components['schemas']['finp2pAssetAccount'];
@@ -1841,7 +2130,7 @@ export interface components {
     };
     sellingSettlementBase: {
       settlementTerm: components['schemas']['settlementTerm'];
-      settlementInstruction: components['schemas']['destinationAccountAssetInstruction'];
+      settlementInstruction?: components['schemas']['destinationAccountAssetInstruction'];
     };
     sellingSettlements: components['schemas']['sellingSettlementBase'][];
     primarySale: {
@@ -1860,7 +2149,7 @@ export interface components {
     };
     buyingSettlementBase: {
       settlementTerm: components['schemas']['settlementTerm'];
-      settlementInstruction: components['schemas']['sourceAccountAssetInstruction'];
+      settlementInstruction?: components['schemas']['sourceAccountAssetInstruction'];
     };
     presignedSignaturePolicy: {
       /**
@@ -1886,7 +2175,7 @@ export interface components {
       /** @description resource id of the buyer */
       buyer: string;
       asset: components['schemas']['buyingAsset'];
-      settlement?: components['schemas']['buyingSettlementBase'];
+      settlement: components['schemas']['buyingSettlementBase'];
       signaturePolicy?: components['schemas']['presignedSignaturePolicy'] | components['schemas']['manualSignaturePolicy'];
     };
     sellingIntent: {
@@ -1910,7 +2199,7 @@ export interface components {
     };
     loanIntentSettlementBase: {
       settlementTerm: components['schemas']['settlementTerm'];
-      settlementInstruction: components['schemas']['borrowerLenderAccountAssetInstruction'];
+      settlementInstruction?: components['schemas']['borrowerLenderAccountAssetInstruction'];
     };
     loanIntentSettlements: components['schemas']['loanIntentSettlementBase'][];
     repaymentTerm: {
@@ -1965,7 +2254,7 @@ export interface components {
       borrower: components['schemas']['ownerId'];
       lender: components['schemas']['ownerId'];
       asset: components['schemas']['loanIntentAsset'];
-      settlement?: components['schemas']['loanIntentSettlements'];
+      settlement: components['schemas']['loanIntentSettlements'];
       loanInstruction?: components['schemas']['loanInstruction'];
       signaturePolicy?: components['schemas']['presignedSignaturePolicy'];
     };
@@ -1973,6 +2262,13 @@ export interface components {
     finp2pAssetAccountOptional: {
       account?: components['schemas']['finIdAccount'];
       asset: components['schemas']['finp2pAsset'];
+      /**
+             * @description Optional. Investor network account to use for this leg. Must have been
+             *     previously bound via `POST /profiles/investor/{investorId}/account`.
+             *     Whitelist-validated against `investor.data.accounts[org][asset]`
+             *     before forwarding to the LA. Failure → error code 7351 (AccountNotWhitelistedErr, 400).
+             */
+      networkAccount?: components['schemas']['networkAccount'];
     };
     optionalDestinationAccountAssetInstruction: {
       destinationAccount: components['schemas']['finp2pAssetAccountOptional'];
@@ -1997,7 +2293,7 @@ export interface components {
       type: 'redemptionIntent';
       issuer: components['schemas']['ownerId'];
       asset: components['schemas']['redemptionAsset'];
-      settlement?: components['schemas']['buyingSettlements'];
+      settlement: components['schemas']['buyingSettlements'];
       conditions?: components['schemas']['redemptionIntentConditions'];
       signaturePolicy?: components['schemas']['presignedSignaturePolicy'] | components['schemas']['manualSignaturePolicy'];
     };
@@ -2017,7 +2313,7 @@ export interface components {
       buyer: components['schemas']['ownerId'];
       seller: components['schemas']['ownerId'];
       asset: components['schemas']['privateOfferIntentAsset'];
-      settlement?: components['schemas']['sellingSettlements'];
+      settlement: components['schemas']['sellingSettlements'];
       signaturePolicy?: components['schemas']['presignedSignaturePolicy'] | components['schemas']['manualSignaturePolicy'];
     };
     requestForTransferSendAssetInstruction: {
@@ -2052,7 +2348,34 @@ export interface components {
       asset: components['schemas']['requestForTransferIntentAsset'];
       signaturePolicy?: components['schemas']['presignedSignaturePolicy'] | components['schemas']['manualSignaturePolicy'];
     };
-    intent: components['schemas']['primarySale'] | components['schemas']['buyingIntent'] | components['schemas']['sellingIntent'] | components['schemas']['loanIntent'] | components['schemas']['redemptionIntent'] | components['schemas']['privateOfferIntent'] | components['schemas']['requestForTransferIntent'];
+    /** @description a Move destination asset. Superset of finp2pAsset (same required id + ledgerIdentifier), plus an optional pre-funded pool the Transfer drains into the destination for the hold-transfer-* variants. */
+    moveDestination: {
+      id: components['schemas']['resourceId'];
+      ledgerIdentifier: components['schemas']['ledgerAssetIdentifier'];
+      fromSegregatedAccount?: components['schemas']['finIdAccount'];
+      /** @description owner of the pre-funded pool account — the Transfer seller (debited party) for receipts and regulation. Required when fromSegregatedAccount is set. */
+      fromSegregatedAccountOwner?: components['schemas']['resourceId'];
+    };
+    /** @description asset-level migration path declared by the source asset's organization; source + one-or-more destination assets (no quantity). Optional sourceToSegregatedAccount receives held source tokens on release (instead of burning); each destination may carry a pre-funded fromSegregatedAccount pool for the hold-transfer-* variants. The executor picks one destination at execution. */
+    moveAsset: {
+      sourceAsset: components['schemas']['finp2pAsset'];
+      destinationAssets: components['schemas']['moveDestination'][];
+      sourceToSegregatedAccount?: components['schemas']['finIdAccount'];
+    };
+    moveIntent: {
+      /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+      type: 'moveIntent';
+      asset: components['schemas']['moveAsset'];
+      signaturePolicy?: components['schemas']['presignedSignaturePolicy'] | components['schemas']['manualSignaturePolicy'];
+    };
+    intent: components['schemas']['primarySale'] | components['schemas']['buyingIntent'] | components['schemas']['sellingIntent'] | components['schemas']['loanIntent'] | components['schemas']['redemptionIntent'] | components['schemas']['privateOfferIntent'] | components['schemas']['requestForTransferIntent'] | components['schemas']['moveIntent'];
+    /** @description Optional. A map of key:value string pairs for custom tracing, reconciliation, and business context. Opaque to the Router. */
+    customMetadata: {
+      [key: string]: string;
+    };
     APIError: {
       /** @description Error code indicating the specific failure - for more information see [API Errors](./api-error-codes-reference). */
       code: number;
@@ -2303,6 +2626,120 @@ export interface operations {
       };
     };
   };
+  createInvestorAccount: {
+    parameters: {
+      query?: never;
+      header: {
+        'Idempotency-Key': components['schemas']['nonce'];
+      };
+      path: {
+        /** @description ID of the investor profile */
+        investorId: components['schemas']['ownerId'];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['createInvestorAccountRequest'];
+      };
+    };
+    responses: {
+      /** @description accepted operation */
+      202: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['operationBase'];
+        };
+      };
+    };
+  };
+  bindInvestorAccount: {
+    parameters: {
+      query?: never;
+      header: {
+        'Idempotency-Key': components['schemas']['nonce'];
+      };
+      path: {
+        /** @description ID of the investor profile */
+        investorId: components['schemas']['ownerId'];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['bindInvestorAccountRequest'];
+      };
+    };
+    responses: {
+      /** @description accepted operation */
+      202: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['operationBase'];
+        };
+      };
+    };
+  };
+  submitAccountProof: {
+    parameters: {
+      query?: never;
+      header: {
+        'Idempotency-Key': components['schemas']['nonce'];
+      };
+      path: {
+        /** @description ID of the investor profile */
+        investorId: components['schemas']['ownerId'];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['submitAccountProofRequest'];
+      };
+    };
+    responses: {
+      /** @description proof accepted; verification continues async */
+      202: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['operationBase'];
+        };
+      };
+    };
+  };
+  removeInvestorAccount: {
+    parameters: {
+      query?: never;
+      header: {
+        'Idempotency-Key': components['schemas']['nonce'];
+      };
+      path: {
+        /** @description ID of the investor profile */
+        investorId: components['schemas']['ownerId'];
+        /** @description LA-assigned wallet identifier */
+        accountId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description accepted operation */
+      202: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['operationBase'];
+        };
+      };
+    };
+  };
   createAssetProfile: {
     parameters: {
       query?: never;
@@ -2315,6 +2752,8 @@ export interface operations {
     requestBody: {
       content: {
         'application/json': {
+          /** @description unique identifier for the asset resource, will default to generated UUID if not provided */
+          assetId?: string;
           /** @description The asset metadata */
           metadata?: {
             [key: string]: unknown;
@@ -2324,6 +2763,7 @@ export interface operations {
                      * @description The asset configuration, in serialized JSON representation (deprecated, use metadata instead)
                      */
           config?: string;
+          signatureTemplate?: components['schemas']['assetSignatureTemplate'];
           /** @description A list of regulation verifiers to execute to validate a transaction */
           verifiers?: components['schemas']['assetVerifier'][];
           intentTypes?: components['schemas']['intentTypesAllowEmpty'];
@@ -2335,7 +2775,6 @@ export interface operations {
           ledgerAssetBinding: components['schemas']['ledgerAssetBinding'];
           assetPolicies?: components['schemas']['assetPolicies'];
           financialIdentifier?: components['schemas']['financialAssetIdentifier'];
-          orgSettlementAccount?: components['schemas']['walletAccount'];
           /**
                      * @description Flag to indicate if default policy fallback is allowed when no matching policy is found
                      * @default true
@@ -2399,6 +2838,7 @@ export interface operations {
                      * @description The asset configuration, in serilized JSON representation (deprecated, use metadata instead)
                      */
           config?: string | null;
+          signatureTemplate?: components['schemas']['assetSignatureTemplateOpt'];
           /** @description A list of regulation verifiers to execute to validate a transaction */
           verifiers?: components['schemas']['assetVerifier'][] | null;
           name?: components['schemas']['nameOpt'];
@@ -2408,6 +2848,12 @@ export interface operations {
           allowPolicyDefaultFallback?: boolean | null;
           /** @description Flag to indicate if the asset should be automatically shared with known organizations. */
           autoShare?: boolean | null;
+          /** @description One-time update per field for the ledger asset identifier. Each field can only be set once given it's blank. Once updated the field becomes immutable and any further update attempts will be rejected. */
+          ledgerAssetBinding?: {
+            ledgerIdentifier: components['schemas']['ledgerAssetIdentifier'];
+          };
+          /** @description Promote the asset's financial classification from NONE to a real type. Allowed only when the current type is NONE. */
+          financialIdentifier?: components['schemas']['financialAssetIdentifier'];
         };
       };
     };
@@ -2460,6 +2906,13 @@ export interface operations {
           intent: components['schemas']['intent'];
           /** @description unique identifier for the intent, will default to generated UUID if not provided */
           intentId?: string;
+          /**
+                     * @example {
+                     *       "orderId": "OMS-2026-48291",
+                     *       "clientRef": "INV-SMITH-0042"
+                     *     }
+                     */
+          metadata?: components['schemas']['customMetadata'];
         };
       };
     };
@@ -2967,6 +3420,8 @@ export interface operations {
           intent: components['schemas']['intentExecution'];
           /** @description unique identifier for the execution, will default to generated UUID if not provided */
           executionId?: string;
+          observers?: components['schemas']['executionObservers'];
+          metadata?: components['schemas']['customMetadata'];
         };
       };
     };
@@ -3038,6 +3493,7 @@ export interface operations {
             term: components['schemas']['assetTerm'];
             instruction: components['schemas']['sourceDestinationAccountAssetInstruction'];
           };
+          metadata?: components['schemas']['customMetadata'];
         };
       };
     };

--- a/finp2p-client/src/finapi/op-model-gen.ts
+++ b/finp2p-client/src/finapi/op-model-gen.ts
@@ -108,6 +108,30 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/execution/approvalsConfig': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    /**
+         * Set approvals config
+         * @description Sets the approvals configuration for the router. Defines which approvers are required for each router category (tokenization, payments, investor, custodian).
+         */
+    put: operations['setApprovalsConfig'];
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /**
+         * Update approvals config
+         * @description Updates the approvals configuration for the router. Allows partial updates to approvers per router category (tokenization, payments, investor, custodian).
+         */
+    patch: operations['updateApprovalsConfig'];
+    trace?: never;
+  };
   '/execution/proposals': {
     parameters: {
       query?: never;
@@ -117,19 +141,21 @@ export interface paths {
     };
     get?: never;
     /**
-         * Override approvals config
-         * @description Override approvals config
+         * Set approvals config
+         * @deprecated
+         * @description Deprecated. Use /execution/approvalsConfig. Sets the approvals configuration for the router. Defines which approvers are required for each router category (tokenization, payments, investor, custodian).
          */
-    put: operations['Override approvals config'];
+    put: operations['setProposalsConfig'];
     post?: never;
     delete?: never;
     options?: never;
     head?: never;
     /**
          * Update approvals config
-         * @description Update approvals config
+         * @deprecated
+         * @description Deprecated. Use /execution/approvalsConfig. Updates the approvals configuration for the router. Allows partial updates to approvers per router category (tokenization, payments, investor, custodian).
          */
-    patch: operations['update approvals config'];
+    patch: operations['updateProposalsConfig'];
     trace?: never;
   };
   '/discovery/pinning_config': {
@@ -436,10 +462,86 @@ export interface paths {
     patch: operations['update data provider binding'];
     trace?: never;
   };
+  '/capabilities': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+         * Get node capabilities
+         * @description Returns this node's effective protocol capabilities, derived from its configured trading policies plus a code-level baseline. Served from a cache (rebuilt on a cold cache); read-only.
+         */
+    get: operations['getNodeCapabilities'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
   schemas: {
+    /** @description The set of protocol features this node supports. Static capability ids are the protocol enum names (e.g. SERVICE_NODE, INTENT_BUYING); per-intent capabilities (incl. signing) are carried under intentCapabilities. */
+    nodeCapabilities: {
+      /**
+             * Format: int64
+             * @description The protocol version this node currently speaks.
+             */
+      protocolVersion?: number;
+      /**
+             * Format: int64
+             * @description The oldest protocol version this node can interoperate with.
+             */
+      minProtocolVersion?: number;
+      /** @description Supported P2P service capability ids. */
+      services?: string[];
+      /** @description Supported execution-plan capability ids. */
+      execution?: string[];
+      /** @description Supported async operation capability ids. */
+      operations?: string[];
+      custodySigning?: components['schemas']['signatureCapability'];
+      /** @description Policy-derived per-intent capabilities. */
+      intentCapabilities?: components['schemas']['intentCapability'][];
+    };
+    /** @description A supported intent and the per-intent capabilities the node handles for it. */
+    intentCapability: {
+      /** @description Intent capability id (e.g. INTENT_BUYING). */
+      id?: string;
+      /** @description Per-intent feature ids (e.g. INTENT_FEATURE_SETTLEMENT_FULL); empty means the base intent with no optional features. */
+      features?: string[];
+      /** @description Instruction capability ids used by this intent's policies. */
+      instructions?: string[];
+      signing?: components['schemas']['signatureCapabilities'];
+    };
+    /** @description Signing capabilities grouped by signing kind. */
+    signatureCapabilities: {
+      investor?: components['schemas']['signatureCapability'];
+      receiptProof?: components['schemas']['signatureCapability'];
+    };
+    /** @description The signing menu for one kind. */
+    signatureCapability: {
+      /** @description Public-key algorithm enum names. */
+      algorithms?: 'ECDSA_SECP256K1'[];
+      /** @description Supported signature templates. */
+      templates?: components['schemas']['templateSupport'][];
+    };
+    /** @description One signature template with its supported versions and hash functions. */
+    templateSupport: {
+      /**
+             * @description Template type (HashList | EIP712).
+             * @enum {string}
+             */
+      type?: 'HashList' | 'EIP712';
+      /** @description Supported template versions (back-compat). */
+      versions?: number[];
+      /** @description Hash function enum names valid for this template. */
+      hashFunctions?: ('SHA_3_256' | 'BLAKE2B' | 'KECCAK_256')[];
+    };
     dataProviderResponse: {
       /**
              * Format: uuid
@@ -536,7 +638,10 @@ export interface components {
       disabled: boolean;
       /** Format: address */
       endpoint: string;
-      /** Format: duration */
+      /**
+             * Format: duration
+             * @description Approver timeout in Go duration format (e.g. `90s`, `1m30s`, `1h`). Values are normalized on write, so the value read back may differ from what was written (e.g. `90s` may be returned as `1m30s`).
+             */
       timeout?: string;
       proposals?: components['schemas']['proposalsApprovalConfig'];
     };
@@ -583,6 +688,18 @@ export interface components {
              *     ]
              */
       transientFailureCodes: string[] | null;
+    };
+    /** @description Per-binding retry policy for the external adapter's WORKFLOW-layer handling of transient (technical) errors. When omitted, the service falls back to the global retry defaults (prior behavior). transientErrorsMaxRetries and transientErrorsUnlimitedRetries are mutually exclusive; set at most one. */
+    adapterRetryStrategy: {
+      /** @description Number of times the workflow re-drives the handler after a transient error before hanging. Omit to use the global default (flow_handler_retries_on_technical_error). Ignored when transientErrorsUnlimitedRetries is true. */
+      transientErrorsMaxRetries?: number;
+      /**
+             * @description Retry transient errors indefinitely, overriding transientErrorsMaxRetries and all stop-limits. Business errors are unaffected and still terminate the workflow.
+             * @default false
+             */
+      transientErrorsUnlimitedRetries: boolean;
+      /** @description Cumulative technical-retry count at which the saturation alert fires, followed by dampened periodic re-alerts. Omit to use the engine default. */
+      alertAfter?: number;
     };
     /** @description List of authentication mechanisms supported by this ledger */
     adapterAuthOptions: (components['schemas']['adapterOAuthOptions'] | components['schemas']['adapterMtlsOptions'] | components['schemas']['adapterApiKeyOptions'])[];
@@ -735,7 +852,7 @@ export interface components {
       destination?: components['schemas']['importTxLedgerAssetAccount'];
       transactionDetails: components['schemas']['transactionDetails'];
       /** @enum {string} */
-      operationType?: 'issue' | 'transfer' | 'hold' | 'release' | 'redeem';
+      operationType?: 'issue' | 'transfer' | 'hold' | 'release' | 'redeem' | 'move';
       proof?: components['schemas']['proofPolicy'];
     };
     /** @description Additional input and output details for UTXO supporting DLTs */
@@ -781,6 +898,7 @@ export interface components {
       instructions: components['schemas']['executionInstruction'][];
       participants: components['schemas']['executionParticipant'][];
       contract: components['schemas']['contract'];
+      metadata?: components['schemas']['customMetadata'];
     };
     contract: {
       investors?: components['schemas']['investor'][];
@@ -987,6 +1105,12 @@ export interface components {
              * @enum {string}
              */
       type: 'hashList';
+      /**
+             * @description This version identifies the HashList template specification revision.
+             *     When omitted, the verifier resolves the version from the
+             *     router/ledger/asset-profile resolver chain.
+             */
+      templateVersion?: number;
       hashGroups: components['schemas']['hashGroup'][];
       /** @description hex representation of the combined hash groups hash value */
       hash: string;
@@ -1040,6 +1164,14 @@ export interface components {
              * @enum {string}
              */
       type: 'EIP712';
+      /**
+             * @description Template shape version. When omitted, the verifier resolves the
+             *     version from the router/ledger/asset-profile resolver chain.
+             *     Not to be confused with EIP712Domain.version (the EIP-712
+             *     contract domain version). See pkg/signature/specs/eip712/ for
+             *     versioned specs.
+             */
+      templateVersion?: number;
       domain: components['schemas']['EIP712Domain'];
       message: {
         [key: string]: components['schemas']['EIP712TypedValue'];
@@ -1069,7 +1201,7 @@ export interface components {
       tradeDetails?: components['schemas']['receiptTradeDetails'];
       details: components['schemas']['receiptAssetDetails'];
       /** @enum {string} */
-      operationType?: 'hold' | 'issue' | 'redeem' | 'release' | 'transfer' | 'unknown';
+      operationType?: 'hold' | 'issue' | 'redeem' | 'release' | 'transfer' | 'move' | 'unknown';
       operationRef?: string;
       timestamp: number;
       proof?: components['schemas']['proofPolicy'];
@@ -1154,6 +1286,12 @@ export interface components {
       assetMatchingCriteria?: components['schemas']['assetMatchingCriteria'];
       constraints?: components['schemas']['constraints'];
       settlementStrategy?: components['schemas']['settlementStrategyType'][];
+      signingCapabilities?: components['schemas']['signatureCapabilities'];
+      /**
+             * Format: uint32
+             * @description minimum FinP2P protocol version required to execute this policy's instruction graph; absent or 0 = protocol baseline (version 1)
+             */
+      requiredProtocolVersion?: number;
     };
     createPolicyRequest: {
       /** @description unique policy id */
@@ -1172,6 +1310,12 @@ export interface components {
       assetMatchingCriteria?: components['schemas']['assetMatchingCriteria'];
       constraints?: components['schemas']['constraints'];
       settlementStrategy?: components['schemas']['settlementStrategyType'][];
+      signingCapabilities?: components['schemas']['signatureCapabilities'];
+      /**
+             * Format: uint32
+             * @description minimum FinP2P protocol version required to execute this policy's instruction graph; absent or 0 = protocol baseline (version 1)
+             */
+      requiredProtocolVersion?: number;
     };
     updatePolicyRequest: {
       /** @description unique policy id */
@@ -1182,7 +1326,7 @@ export interface components {
              */
       priority: number;
       /** @enum {string} */
-      intent: 'primarySale' | 'buyingIntent' | 'sellingIntent' | 'loanIntent' | 'redemptionIntent' | 'privateOfferIntent' | 'requestForTransferIntent';
+      intent: 'primarySale' | 'buyingIntent' | 'sellingIntent' | 'loanIntent' | 'redemptionIntent' | 'privateOfferIntent' | 'requestForTransferIntent' | 'moveIntent';
       /** @description description of the policy */
       description: string;
       /** @description whether policy should be applied to all assets */
@@ -1196,6 +1340,12 @@ export interface components {
              */
       version: number;
       settlementStrategy?: components['schemas']['settlementStrategyType'][];
+      signingCapabilities?: components['schemas']['signatureCapabilities'];
+      /**
+             * Format: uint32
+             * @description minimum FinP2P protocol version required to execute this policy's instruction graph; absent or 0 = protocol baseline (version 1)
+             */
+      requiredProtocolVersion?: number;
     };
     /**
          * @description type of settlement strategy
@@ -1211,6 +1361,13 @@ export interface components {
     assetMatchingCriteria: {
       assetNameRegexp?: string | null;
       assetCodes?: string[];
+      /**
+             * @description Optional allow-list of ledger names. When non-empty, the policy
+             *     attaches only to assets whose ledger binding name matches one of
+             *     the listed values (case-insensitive). Empty or omitted = no
+             *     constraint on the asset's ledger binding.
+             */
+      ledgerNames?: string[];
       ledgerAssetIdentifiers?: components['schemas']['ledgerAssetIdentifier'][];
       financialAssetIdentifiers?: components['schemas']['financialAssetIdentifier'][];
     } | null;
@@ -1237,7 +1394,7 @@ export interface components {
     };
     instruction: {
       /** @enum {string} */
-      instruction: 'Hold' | 'Transfer' | 'Release' | 'Await' | 'Issue' | 'RevertHold' | 'Redeem';
+      instruction: 'Hold' | 'Transfer' | 'Release' | 'Await' | 'Issue' | 'RevertHold' | 'Redeem' | 'Move';
       /** Format: uint32 */
       sequence: number;
       executors?: ('self' | 'counterparty')[];
@@ -1365,13 +1522,12 @@ export interface components {
     APIErrors: {
       errors: components['schemas']['APIError'][];
     };
-    pollingResultsStrategy: {
+    randomPollingInterval: {
       /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
       type: 'random';
-      polling: components['schemas']['randomPollingInterval'] | components['schemas']['absolutePollingInterval'] | components['schemas']['relativePollingInterval'];
     };
     absolutePollingInterval: {
       /**
@@ -1394,12 +1550,13 @@ export interface components {
              */
       duration: string;
     };
-    randomPollingInterval: {
+    pollingResultsStrategy: {
       /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-      type: 'randomPollingInterval';
+      type: 'poll';
+      polling: components['schemas']['randomPollingInterval'] | components['schemas']['absolutePollingInterval'] | components['schemas']['relativePollingInterval'];
     };
     callbackEndpoint: {
       /**
@@ -1445,9 +1602,9 @@ export interface components {
              * @enum {string}
              */
       assetIdentifierType: 'CAIP-19';
-      network: string;
+      network?: string;
       tokenId: string;
-      standard: string;
+      standard?: string;
     };
     ledgerAssetIdentifier: components['schemas']['ledgerAssetIdentifierTypeCAIP-19'];
     finP2PEVMOperatorDetails: {
@@ -1487,7 +1644,21 @@ export interface components {
       type: 'createAsset';
       operation: components['schemas']['createAssetOperation'];
     };
-    depositOperationErrorInformation: Record<string, never>;
+    RegulationError: {
+      /** @description the type of regulation */
+      regulationType: string;
+      /** @description actionable details of the error */
+      details: string;
+    };
+    depositOperationErrorInformation: {
+      /**
+             * Format: uint32
+             * @description 1 for failure in regApps validation, 4 failure in signature verification
+             */
+      code?: number;
+      message?: string;
+      regulationErrorDetails?: components['schemas']['RegulationError'][];
+    };
     /**
          * Format: finid
          * @description Existing owner hex representation of a secp256k1 public key 33 bytes compressed
@@ -1629,12 +1800,6 @@ export interface components {
       type: 'deposit';
       operation: components['schemas']['depositOperation'];
     };
-    RegulationError: {
-      /** @description the type of regulation */
-      regulationType: string;
-      /** @description actionable details of the error */
-      details: string;
-    };
     receiptOperationErrorInformation: {
       /**
              * Format: uint32
@@ -1660,10 +1825,34 @@ export interface components {
       /** @description address of the wallet */
       address: string;
     };
+    caip10Account: {
+      /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+      type: 'caip10Account';
+      /** @description CAIP-2 chain_id, e.g. "eip155:1", "solana:5eykt4...", "hedera:mainnet" (the same token used by the CAIP-19 asset identifier network) */
+      network: string;
+      /** @description CAIP-10 account_address (chain-native address) */
+      address: string;
+    };
+    custodialAccount: {
+      /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+      type: 'custodialAccount';
+      /** @description Custody provider discriminator, e.g. "fireblocks" */
+      provider: string;
+      /** @description Provider-internal account identifier (e.g. a Fireblocks vault account id) */
+      vaultAccountId: string;
+      /** @description Optional. Narrows the custodial account to a specific asset/chain. */
+      assetId?: string;
+    };
     account: {
       asset: components['schemas']['asset'];
       finId: components['schemas']['finId'];
-      ledgerAccount?: components['schemas']['walletAccount'];
+      ledgerAccount?: components['schemas']['walletAccount'] | components['schemas']['caip10Account'] | components['schemas']['custodialAccount'];
     };
     /** @description additional ledger specific */
     'schemas-transactionDetails': {
@@ -1673,7 +1862,7 @@ export interface components {
       operationId?: string;
     };
     /** @enum {string} */
-    operationType: 'issue' | 'transfer' | 'hold' | 'release' | 'redeem';
+    operationType: 'issue' | 'transfer' | 'hold' | 'release' | 'redeem' | 'move';
     receiptExecutionContext: {
       executionPlanId: string;
       instructionSequenceNumber: number;
@@ -1682,6 +1871,19 @@ export interface components {
       intentId?: string;
       intentVersion?: string;
       executionContext?: components['schemas']['receiptExecutionContext'];
+    };
+    /** @description ordered list of hash groups */
+    'schemas-hashListTemplate': {
+      /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+      type: 'hashList';
+      hashGroups: components['schemas']['hashGroup'][];
+      /** @description hex representation of the combined hash groups hash value */
+      hash: string;
+      /** @description Template shape version. When omitted, the verifier resolves the version from the signature proof context. */
+      templateVersion?: number;
     };
     'schemas-EIP712FieldDefinition': {
       name?: string;
@@ -1708,8 +1910,10 @@ export interface components {
       primaryType: string;
       /** @description hex representation of template hash */
       hash: string;
+      /** @description Template shape version. When omitted, the verifier resolves the version from the signature proof context. */
+      templateVersion?: number;
     };
-    'schemas-signatureTemplate': components['schemas']['hashListTemplate'] | components['schemas']['schemas-EIP712Template'];
+    'schemas-signatureTemplate': components['schemas']['schemas-hashListTemplate'] | components['schemas']['schemas-EIP712Template'];
     /** @description represent a signature template information */
     'schemas-signature': {
       /** @description hex representation of the signature */
@@ -1804,7 +2008,96 @@ export interface components {
       type: 'approval';
       operation: components['schemas']['ExecutionPlanApprovalOperation'];
     };
-    operationStatus: components['schemas']['operationStatusCreateAsset'] | components['schemas']['operationStatusDeposit'] | components['schemas']['operationStatusReceipt'] | components['schemas']['operationStatusApproval'];
+    AccountChallengeWalletConnect: {
+      /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+      type: 'walletConnect';
+      /** @description WalletConnect URI or QR-encodable payload. */
+      uri: string;
+    };
+    AccountChallengeSignatureTemplate: {
+      /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+      type: 'signatureTemplate';
+      /**
+             * @description Hex-encoded data the client must sign with the wallet's private key and submit via
+             *     `POST /accounts/{cid}/proof`.
+             */
+      payload: string;
+    };
+    AccountChallengeDeposit: {
+      /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+      type: 'deposit';
+      /** @description Address claimed by the user. */
+      fromAddress: string;
+      /** @description Destination address the LA watches. */
+      toAddress: string;
+      /** @description Required deposit amount (string for precision). */
+      amount: string;
+    };
+    AccountChallengeFireblocksApproval: {
+      /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+      type: 'fireblocksApproval';
+      /** @description Fireblocks-side request id; user approves in the Fireblocks app. */
+      fireblocksRequestId: string;
+    };
+    /**
+         * @description LA-issued challenge that the user must fulfill. Discriminated by `type`. New variants
+         *     can be added without breaking existing clients.
+         */
+    AccountChallenge: components['schemas']['AccountChallengeWalletConnect'] | components['schemas']['AccountChallengeSignatureTemplate'] | components['schemas']['AccountChallengeDeposit'] | components['schemas']['AccountChallengeFireblocksApproval'];
+    noneAccount: Record<string, never>;
+    networkAccount: components['schemas']['walletAccount'] | components['schemas']['caip10Account'] | components['schemas']['custodialAccount'] | components['schemas']['noneAccount'];
+    /** @description Canonical account record returned on workflow completion via `GET /operations/status/{cid}`. */
+    networkAccountRecord: {
+      /** @description LA-assigned account identifier. */
+      id: string;
+      networkAccount: components['schemas']['networkAccount'];
+    };
+    networkAccountOperationErrorInformation: {
+      /** Format: uint32 */
+      code: number;
+      message: string;
+    };
+    /**
+         * @description Status of an investor network-account create/bind/unbind operation, polled via
+         *     `GET /operations/status/{cid}`. While a challenge is outstanding, `challenge` is
+         *     present; on completion `response` carries the canonical `{ id, wallet }`; on failure
+         *     `error` carries the LA-level code/message.
+         */
+    networkAccountOperation: components['schemas']['OperationBase'] & {
+      challenge?: components['schemas']['AccountChallenge'];
+      response?: components['schemas']['networkAccountRecord'];
+      error?: components['schemas']['networkAccountOperationErrorInformation'];
+      /**
+             * Format: int64
+             * @description Onboarding deadline the ledger adapter grants, in seconds from now, when it
+             *     supplies (or revises) one on this status — e.g. alongside a challenge delivered
+             *     via callback in proxy mode, where the adapter's own deadline could not ride the
+             *     proxy's immediate acceptance. The asset node re-arms the workflow deadline from
+             *     a non-zero value. Omitted/zero => previously armed deadline stands.
+             */
+      expiresInSeconds?: number;
+    };
+    operationStatusAccount: {
+      /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+      type: 'account';
+      operation: components['schemas']['networkAccountOperation'];
+    };
+    operationStatus: components['schemas']['operationStatusCreateAsset'] | components['schemas']['operationStatusDeposit'] | components['schemas']['operationStatusReceipt'] | components['schemas']['operationStatusApproval'] | components['schemas']['operationStatusAccount'];
     CustomError: {
       code: number;
       message: string;
@@ -1897,8 +2190,6 @@ export interface components {
       account: components['schemas']['importTxAccount'];
       asset: components['schemas']['finp2pAsset'];
     };
-    noneAccount: Record<string, never>;
-    networkAccount: components['schemas']['walletAccount'] | components['schemas']['noneAccount'];
     /** @description describes account information */
     importTxLedgerAssetAccount: {
       finp2pAccount: components['schemas']['importTxAssetAccount'];
@@ -1930,6 +2221,13 @@ export interface components {
     finp2pAssetAccount: {
       account: components['schemas']['schemas-finIdAccount'];
       asset: components['schemas']['finp2pAsset'];
+      /**
+             * @description Optional. Investor network account to use for this leg. Must have been
+             *     previously bound via `POST /profiles/investor/{investorId}/account`.
+             *     Whitelist-validated against `investor.data.accounts[org][asset]`
+             *     before forwarding to the LA. Failure → error code 7351 (AccountNotWhitelistedErr, 400).
+             */
+      networkAccount?: components['schemas']['networkAccount'];
     };
     sourceAccountAssetInstruction: {
       sourceAccount: components['schemas']['finp2pAssetAccount'];
@@ -1969,7 +2267,7 @@ export interface components {
     };
     sellingSettlementBase: {
       settlementTerm: components['schemas']['settlementTerm'];
-      settlementInstruction: components['schemas']['destinationAccountAssetInstruction'];
+      settlementInstruction?: components['schemas']['destinationAccountAssetInstruction'];
     };
     sellingSettlements: components['schemas']['sellingSettlementBase'][];
     primarySale: {
@@ -1988,7 +2286,7 @@ export interface components {
     };
     buyingSettlementBase: {
       settlementTerm: components['schemas']['settlementTerm'];
-      settlementInstruction: components['schemas']['sourceAccountAssetInstruction'];
+      settlementInstruction?: components['schemas']['sourceAccountAssetInstruction'];
     };
     presignedSignaturePolicy: {
       /**
@@ -2014,7 +2312,7 @@ export interface components {
       /** @description resource id of the buyer */
       buyer: string;
       asset: components['schemas']['buyingAsset'];
-      settlement?: components['schemas']['buyingSettlementBase'];
+      settlement: components['schemas']['buyingSettlementBase'];
       signaturePolicy?: components['schemas']['presignedSignaturePolicy'] | components['schemas']['manualSignaturePolicy'];
     };
     sellingIntent: {
@@ -2038,7 +2336,7 @@ export interface components {
     };
     loanIntentSettlementBase: {
       settlementTerm: components['schemas']['settlementTerm'];
-      settlementInstruction: components['schemas']['borrowerLenderAccountAssetInstruction'];
+      settlementInstruction?: components['schemas']['borrowerLenderAccountAssetInstruction'];
     };
     loanIntentSettlements: components['schemas']['loanIntentSettlementBase'][];
     repaymentTerm: {
@@ -2093,7 +2391,7 @@ export interface components {
       borrower: components['schemas']['schemas-ownerId'];
       lender: components['schemas']['schemas-ownerId'];
       asset: components['schemas']['loanIntentAsset'];
-      settlement?: components['schemas']['loanIntentSettlements'];
+      settlement: components['schemas']['loanIntentSettlements'];
       loanInstruction?: components['schemas']['loanInstruction'];
       signaturePolicy?: components['schemas']['presignedSignaturePolicy'];
     };
@@ -2101,6 +2399,13 @@ export interface components {
     finp2pAssetAccountOptional: {
       account?: components['schemas']['schemas-finIdAccount'];
       asset: components['schemas']['finp2pAsset'];
+      /**
+             * @description Optional. Investor network account to use for this leg. Must have been
+             *     previously bound via `POST /profiles/investor/{investorId}/account`.
+             *     Whitelist-validated against `investor.data.accounts[org][asset]`
+             *     before forwarding to the LA. Failure → error code 7351 (AccountNotWhitelistedErr, 400).
+             */
+      networkAccount?: components['schemas']['networkAccount'];
     };
     optionalDestinationAccountAssetInstruction: {
       destinationAccount: components['schemas']['finp2pAssetAccountOptional'];
@@ -2125,7 +2430,7 @@ export interface components {
       type: 'redemptionIntent';
       issuer: components['schemas']['schemas-ownerId'];
       asset: components['schemas']['redemptionAsset'];
-      settlement?: components['schemas']['buyingSettlements'];
+      settlement: components['schemas']['buyingSettlements'];
       conditions?: components['schemas']['redemptionIntentConditions'];
       signaturePolicy?: components['schemas']['presignedSignaturePolicy'] | components['schemas']['manualSignaturePolicy'];
     };
@@ -2145,7 +2450,7 @@ export interface components {
       buyer: components['schemas']['schemas-ownerId'];
       seller: components['schemas']['schemas-ownerId'];
       asset: components['schemas']['privateOfferIntentAsset'];
-      settlement?: components['schemas']['sellingSettlements'];
+      settlement: components['schemas']['sellingSettlements'];
       signaturePolicy?: components['schemas']['presignedSignaturePolicy'] | components['schemas']['manualSignaturePolicy'];
     };
     requestForTransferSendAssetInstruction: {
@@ -2180,7 +2485,30 @@ export interface components {
       asset: components['schemas']['requestForTransferIntentAsset'];
       signaturePolicy?: components['schemas']['presignedSignaturePolicy'] | components['schemas']['manualSignaturePolicy'];
     };
-    intent: components['schemas']['primarySale'] | components['schemas']['buyingIntent'] | components['schemas']['sellingIntent'] | components['schemas']['loanIntent'] | components['schemas']['redemptionIntent'] | components['schemas']['privateOfferIntent'] | components['schemas']['requestForTransferIntent'];
+    /** @description a Move destination asset. Superset of finp2pAsset (same required id + ledgerIdentifier), plus an optional pre-funded pool the Transfer drains into the destination for the hold-transfer-* variants. */
+    moveDestination: {
+      id: components['schemas']['resourceId'];
+      ledgerIdentifier: components['schemas']['ledgerAssetIdentifier'];
+      fromSegregatedAccount?: components['schemas']['schemas-finIdAccount'];
+      /** @description owner of the pre-funded pool account — the Transfer seller (debited party) for receipts and regulation. Required when fromSegregatedAccount is set. */
+      fromSegregatedAccountOwner?: components['schemas']['resourceId'];
+    };
+    /** @description asset-level migration path declared by the source asset's organization; source + one-or-more destination assets (no quantity). Optional sourceToSegregatedAccount receives held source tokens on release (instead of burning); each destination may carry a pre-funded fromSegregatedAccount pool for the hold-transfer-* variants. The executor picks one destination at execution. */
+    moveAsset: {
+      sourceAsset: components['schemas']['finp2pAsset'];
+      destinationAssets: components['schemas']['moveDestination'][];
+      sourceToSegregatedAccount?: components['schemas']['schemas-finIdAccount'];
+    };
+    moveIntent: {
+      /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+      type: 'moveIntent';
+      asset: components['schemas']['moveAsset'];
+      signaturePolicy?: components['schemas']['presignedSignaturePolicy'] | components['schemas']['manualSignaturePolicy'];
+    };
+    intent: components['schemas']['primarySale'] | components['schemas']['buyingIntent'] | components['schemas']['sellingIntent'] | components['schemas']['loanIntent'] | components['schemas']['redemptionIntent'] | components['schemas']['privateOfferIntent'] | components['schemas']['requestForTransferIntent'] | components['schemas']['moveIntent'];
     /** @description describes account information */
     ledgerAccountAsset: {
       finp2pAccount: components['schemas']['finp2pAssetAccount'];
@@ -2202,6 +2530,10 @@ export interface components {
       assetTerm: components['schemas']['assetTerm'];
       assetInstruction: components['schemas']['BorrowerLenderAccountLedgerAssetInstruction'];
     };
+    /** @description Optional. A map of key:value string pairs for custom tracing, reconciliation, and business context. Opaque to the Router. */
+    customMetadata: {
+      [key: string]: string;
+    };
     /** @description Additional input and output details for UTXO supporting DLTs */
     receiptTransactionDetails: {
       /** @description Transaction id */
@@ -2213,7 +2545,8 @@ export interface components {
       transactionDetails: components['schemas']['receiptTransactionDetails'];
     };
     /** @enum {string} */
-    intentType: 'primarySale' | 'buyingIntent' | 'sellingIntent' | 'loanIntent' | 'redemptionIntent' | 'privateOfferIntent' | 'requestForTransferIntent';
+    intentType: 'primarySale' | 'buyingIntent' | 'sellingIntent' | 'loanIntent' | 'redemptionIntent' | 'privateOfferIntent' | 'requestForTransferIntent' | 'moveIntent';
+    /** @description Financial instruments (equities, bonds, funds, etc.). 12-character ISO 6166 code. */
     financialAssetIdentifierTypeISIN: {
       /**
              * @description Classification type standards (enum property replaced by openapi-typescript)
@@ -2223,6 +2556,7 @@ export interface components {
       /** @description The classification standard used to identify the asset */
       assetIdentifierValue: string;
     };
+    /** @description Fiat currencies. */
     financialAssetIdentifierTypeISO4217: {
       /**
              * @description Classification type standards (enum property replaced by openapi-typescript)
@@ -2232,6 +2566,7 @@ export interface components {
       /** @description The classification standard used to identify the asset */
       assetIdentifierValue: string;
     };
+    /** @description Asset is not registered under a global identification scheme. */
     financialAssetIdentifierTypeNONE: {
       /**
              * @description Classification type standards (enum property replaced by openapi-typescript)
@@ -2239,6 +2574,7 @@ export interface components {
              */
       assetIdentifierType: 'NONE';
     };
+    /** @description Globally recognized code identifying the asset across networks, routers, and counterparties. Used for balance aggregation and cross-router asset recognition. Format is validated for structure only. */
     financialAssetIdentifier: components['schemas']['financialAssetIdentifierTypeISIN'] | components['schemas']['financialAssetIdentifierTypeISO4217'] | components['schemas']['financialAssetIdentifierTypeNONE'];
   };
   responses: never;
@@ -3150,7 +3486,7 @@ export interface operations {
       };
     };
   };
-  'Override approvals config': {
+  setApprovalsConfig: {
     parameters: {
       query?: never;
       header?: never;
@@ -3161,7 +3497,6 @@ export interface operations {
       content: {
         /**
                  * @example {
-                 *       "ownerId": "bank-x:101:511c1d7f-4ed8-410d-887c-a10e3e499a01",
                  *       "tokenization": {
                  *         "http-endpoint-1": {
                  *           "config_type": "http",
@@ -3244,7 +3579,160 @@ export interface operations {
       };
     };
   };
-  'update approvals config': {
+  updateApprovalsConfig: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        'application/json': components['schemas']['approvalConfigUpdate'];
+      };
+    };
+    responses: {
+      /** @description Configuration updated successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 1002,
+                     *           "message": "Invalid request format"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 2202,
+                     *           "message": "Internal service failure"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+    };
+  };
+  setProposalsConfig: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        /**
+                 * @example {
+                 *       "tokenization": {
+                 *         "http-endpoint-1": {
+                 *           "config_type": "http",
+                 *           "endpoint": "http://approver-service.internal/approvals",
+                 *           "timeout": "45s",
+                 *           "proposals": [
+                 *             "reset",
+                 *             "cancel",
+                 *             "instruction"
+                 *           ]
+                 *         },
+                 *         "ledger-approver-1": {
+                 *           "config_type": "ledger",
+                 *           "name": "ledger-approver-1",
+                 *           "proposals": [
+                 *             "reset",
+                 *             "instruction"
+                 *           ]
+                 *         }
+                 *       },
+                 *       "payments": {
+                 *         "ledger-approver-2": {
+                 *           "config_type": "ledger",
+                 *           "name": "payments-ledger-approver",
+                 *           "proposals": [
+                 *             "instruction"
+                 *           ]
+                 *         }
+                 *       }
+                 *     }
+                 */
+        'application/json': components['schemas']['approvalConfig'];
+      };
+    };
+    responses: {
+      /** @description Created the new configuration successfully */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 1002,
+                     *           "message": "Invalid request format"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 2202,
+                     *           "message": "Internal service failure"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+    };
+  };
+  updateProposalsConfig: {
     parameters: {
       query?: never;
       header?: never;
@@ -4045,9 +4533,11 @@ export interface operations {
   };
   findPolicies: {
     parameters: {
-      query: {
+      query?: {
         /** @description asset matching type */
-        assetMatchingType: string;
+        assetMatchingType?: string;
+        /** @description filter policies whose ledgerNames allow-list contains this ledger (or have no ledger constraint) */
+        ledgerName?: string;
       };
       header?: never;
       path?: never;
@@ -4765,23 +5255,15 @@ export interface operations {
           endpoint: string;
           auth?: components['schemas']['adapterAuthOptions'];
           idempotency?: components['schemas']['adapterIdempotencyOptions'];
+          retryStrategy?: components['schemas']['adapterRetryStrategy'];
           /** @description display name */
           displayName?: string;
-          /**
-                     * @description request timeout (e.g. 300s)
-                     * @default 300s
-                     */
-          requestTimeout?: string;
-          /**
-                     * @description backoff (e.g. 60s)
-                     * @default 60s
-                     */
-          backoff?: string;
-          /**
-                     * @description single request timeout (e.g. 90s)
-                     * @default 90s
-                     */
-          singleRequestTimeout?: string;
+          /** @description request timeout (e.g. 300s) */
+          requestTimeout: string;
+          /** @description backoff (e.g. 60s) */
+          backoff: string;
+          /** @description single request timeout (e.g. 90s) */
+          singleRequestTimeout: string;
         };
       };
     };
@@ -4792,6 +5274,44 @@ export interface operations {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 1002,
+                     *           "message": "Invalid request format"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 2202,
+                     *           "message": "Internal service failure"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
       };
     };
   };
@@ -4814,6 +5334,7 @@ export interface operations {
           displayName?: string | null;
           auth?: components['schemas']['adapterAuthOptionsOpt'] | null;
           idempotency?: components['schemas']['adapterIdempotencyOptionsOpt'] | null;
+          retryStrategy?: components['schemas']['adapterRetryStrategy'] | null;
           /** @description request timeout (e.g. 300s) */
           requestTimeout?: string | null;
           /** @description backoff (e.g. 60s) */
@@ -4830,6 +5351,44 @@ export interface operations {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 1002,
+                     *           "message": "Invalid request format"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 2202,
+                     *           "message": "Internal service failure"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
       };
     };
   };
@@ -4856,6 +5415,7 @@ export interface operations {
           singleRequestTimeout?: string | null;
           auth?: components['schemas']['adapterAuthOptionsOpt'] | null;
           idempotency?: components['schemas']['adapterIdempotencyOptionsOpt'] | null;
+          retryStrategy?: components['schemas']['adapterRetryStrategy'] | null;
           /** @description A human-readable name for the ledger that appears in user interfaces */
           displayName?: string | null;
           /**
@@ -4930,23 +5490,15 @@ export interface operations {
           endpoint: string;
           auth?: components['schemas']['adapterAuthOptions'];
           idempotency?: components['schemas']['adapterIdempotencyOptions'];
+          retryStrategy?: components['schemas']['adapterRetryStrategy'];
           /** @description A human-readable name for the ledger that appears in user interfaces */
           displayName?: string;
-          /**
-                     * @description The maximum time allowed for the entire request operation to complete, including all retry attempts. After this duration, the request will fail with a timeout error
-                     * @default 300s
-                     */
-          requestTimeout?: string;
-          /**
-                     * @description The waiting period between consecutive retry attempts when a request fails. This delay helps prevent overwhelming the ledger adapter during temporary failures
-                     * @default 60s
-                     */
-          backoff?: string;
-          /**
-                     * @description The maximum time allowed for each individual request attempt. If a single attempt exceeds this duration, it will be retried according to the backoff configuration
-                     * @default 90s
-                     */
-          singleRequestTimeout?: string;
+          /** @description The maximum time allowed for the entire request operation to complete, including all retry attempts. After this duration, the request will fail with a timeout error */
+          requestTimeout: string;
+          /** @description The waiting period between consecutive retry attempts when a request fails. This delay helps prevent overwhelming the ledger adapter during temporary failures */
+          backoff: string;
+          /** @description The maximum time allowed for each individual request attempt. If a single attempt exceeds this duration, it will be retried according to the backoff configuration */
+          singleRequestTimeout: string;
           /**
                      * @description Indicates whether balance synchronization is enabled for this ledger
                      * @default true
@@ -5044,6 +5596,44 @@ export interface operations {
           'application/json': components['schemas']['dataProviderResponse'];
         };
       };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 1002,
+                     *           "message": "Invalid request format"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 2202,
+                     *           "message": "Internal service failure"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
     };
   };
   'update data provider binding': {
@@ -5080,6 +5670,159 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['dataProviderResponse'];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 1002,
+                     *           "message": "Invalid request format"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 2202,
+                     *           "message": "Internal service failure"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+    };
+  };
+  getNodeCapabilities: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description successful operation */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['nodeCapabilities'];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 6102,
+                     *           "message": "Data mapping error"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 2000,
+                     *           "message": "General server error"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+      /** @description Bad Gateway */
+      502: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 2300,
+                     *           "message": "An internal communication error"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+      /** @description Service Unavailable */
+      503: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 2002,
+                     *           "message": "Service unavailable"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 2003,
+                     *           "message": "Gateway timeout"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
         };
       };
     };

--- a/finp2p-client/src/flows.ts
+++ b/finp2p-client/src/flows.ts
@@ -144,8 +144,6 @@ export interface CreateAssetParams {
   | { assetIdentifierType: 'ISIN'; assetIdentifierValue: string }
   | { assetIdentifierType: 'ISO4217'; assetIdentifierValue: string }
   | { assetIdentifierType: 'NONE' };
-  /** Org's on-chain settlement wallet for this asset ({ type, address }). */
-  orgSettlementAccount?: FinAPIComponents['schemas']['walletAccount'];
   /** Whether to fall back to a default policy when none matches. Defaults to true server-side. */
   allowPolicyDefaultFallback?: boolean;
   /** Decimal places the asset supports (0–18). */
@@ -161,7 +159,7 @@ export interface CreateAssetParams {
  *
  * Fields that are **immutable** post-creation and therefore not on this
  * shape: type, issuerId, denomination, ledgerAssetBinding,
- * financialIdentifier, intentTypes, orgSettlementAccount, decimalPlaces.
+ * financialIdentifier, intentTypes, decimalPlaces.
  * Intent allow-list changes go through dedicated routes under
  * `/profiles/asset/{id}/intent[/...]`.
  */
@@ -212,7 +210,6 @@ export async function createAsset(client: FinP2PClient, params: CreateAssetParam
     metadata: params.metadata,
     verifiers: params.verifiers,
     financialIdentifier: params.financialIdentifier,
-    orgSettlementAccount: params.orgSettlementAccount,
     allowPolicyDefaultFallback: params.allowPolicyDefaultFallback,
     decimalPlaces: params.decimalPlaces,
     autoShare: params.autoShare,
@@ -365,7 +362,9 @@ export async function createPrivateOfferIntent(client: FinP2PClient, params: Pri
         },
       },
     }]
-    : undefined;
+    // `settlement` is required on privateOfferIntent as of router 0.28; when the
+    // caller supplies no settlement leg, declare it explicitly as noSettlement.
+    : [{ settlementTerm: { type: 'noSettlement' as const } }];
 
   const res = await unwrapOperation<{ id: string }>(client, client.createIntent(params.asset.id, {
     start, end,

--- a/finp2p-client/src/oss/graphql.d.ts
+++ b/finp2p-client/src/oss/graphql.d.ts
@@ -289,7 +289,7 @@ export type BuyingIntent = {
   buyer?: Maybe<Scalars['String']['output']>;
   /** Destination account - where buyer receives the asset */
   destination: FinP2PAssetAccount;
-  settlementInstruction: BuyingSettlementInstruction;
+  settlementInstruction?: Maybe<BuyingSettlementInstruction>;
   /** Settlement term */
   settlementTerm?: Maybe<SettlementTerm>;
   signaturePolicy: BuyingSignaturePolicy;
@@ -305,13 +305,22 @@ export type BuyingSettlementInstruction = {
 
 export type BuyingSignaturePolicy = ManualIntentSignaturePolicy | PresignedBuyingIntentSignaturePolicy;
 
+/** CAIP-10 chain-agnostic on-chain account */
+export type Caip10Account = {
+  __typename?: 'Caip10Account';
+  /** CAIP-10 account address (chain-native address) */
+  address: Scalars['String']['output'];
+  /** CAIP-2 chain_id, e.g. eip155:1 (the same token used by the CAIP-19 asset identifier network) */
+  network: Scalars['String']['output'];
+};
+
 /** CAIP-19 format ledger identifier */
 export type Caip19Identifier = {
   __typename?: 'Caip19Identifier';
   /** CAIP-2 network identifier (e.g., eip155:1, solana:mainnet) */
-  network: Scalars['String']['output'];
+  network?: Maybe<Scalars['String']['output']>;
   /** Token standard (e.g., erc20, erc721) */
-  standard: Scalars['String']['output'];
+  standard?: Maybe<Scalars['String']['output']>;
   /** Token ID or contract address */
   tokenId: Scalars['String']['output'];
 };
@@ -381,6 +390,17 @@ export type CryptoWalletAccount = {
   __typename?: 'CryptoWalletAccount';
   /** Wallet address represented as a hexadecimal string prefixed with 0x */
   address: Scalars['String']['output'];
+};
+
+/** Custodial account reference (e.g. a Fireblocks vault account) that is not a single on-chain address */
+export type CustodialAccount = {
+  __typename?: 'CustodialAccount';
+  /** Optional. Narrows the custodial account to a specific asset/chain. */
+  assetId?: Maybe<Scalars['String']['output']>;
+  /** Custody provider discriminator, e.g. fireblocks */
+  provider: Scalars['String']['output'];
+  /** Provider-internal account identifier (e.g. a Fireblocks vault account id) */
+  vaultAccountId: Scalars['String']['output'];
 };
 
 export type Custodian = {
@@ -560,6 +580,8 @@ export type ExecutionPlan = {
   contract: ExecutionPlanContract;
   /** plan creation (timestamp in sec) */
   creationTimestamp: Scalars['Int']['output'];
+  /** Custom key-value metadata for tracing and reconciliation */
+  customMetadata?: Maybe<Array<KeyValuePair>>;
   /** resource id of execution plan */
   id: Scalars['String']['output'];
   /** plan's list of instructions */
@@ -570,10 +592,21 @@ export type ExecutionPlan = {
   lastModified: Scalars['Int']['output'];
   /** organizations which participate in the execution plan */
   organizations: Array<ExecutionOrganization>;
+  /** All workflows related to this plan (plan-level and per-instruction) — the top-level `workflows` query pre-scoped to the plan, with the same filter/pagination/ordering. Use pageInfo.totalCount for the count and a filter (e.g. health_status EQ UNHEALTHY) for the problematic subset. Defaults to creationTimestamp ASC. */
+  relatedWorkflows: Workflows;
   /** lifecycle status of the execution plan */
   status: ExecutionPlanStatus;
   /** version of the execution plan */
   version: Scalars['Int']['output'];
+  /** Plan-level workflows: workflows scoped to the plan itself (e.g. plan_approval, and plan-scoped signature_request) — NOT the per-instruction workflows, which are under instructions.workflows. Fully populated (state, health, availableActions, references, metadata), same as the top-level `workflows` query. */
+  workflows: Array<Workflow>;
+};
+
+
+export type ExecutionPlanRelatedWorkflowsArgs = {
+  filter?: InputMaybe<Array<Filter>>;
+  orderBy?: InputMaybe<WorkflowOrder>;
+  paginate?: InputMaybe<PaginateInput>;
 };
 
 export type ExecutionPlanContract = {
@@ -582,7 +615,7 @@ export type ExecutionPlanContract = {
   investors: Array<ExecutionPlanInvestor>;
 };
 
-export type ExecutionPlanContractDetails = BuyingContractDetails | IssuanceContractDetails | LoanContractDetails | PrivateOfferContractDetails | RedemptionContractDetails | RequestForTransferContractDetails | SellingContractDetails | TransferContractDetails;
+export type ExecutionPlanContractDetails = BuyingContractDetails | IssuanceContractDetails | LoanContractDetails | MoveContractDetails | PrivateOfferContractDetails | RedemptionContractDetails | RequestForTransferContractDetails | SellingContractDetails | TransferContractDetails;
 
 export type ExecutionPlanInstruction = {
   __typename?: 'ExecutionPlanInstruction';
@@ -751,9 +784,9 @@ export type FinancialIdentifier = {
 };
 
 export enum FinancialIdentifierType {
-  Custom = 'CUSTOM',
   Isin = 'ISIN',
   Iso4217 = 'ISO4217',
+  None = 'NONE',
   Unspecified = 'UNSPECIFIED',
 }
 
@@ -853,7 +886,7 @@ export type InstructionApprovals = {
 
 export type InstructionCompletionState = ErrorState | SuccessState | UnknownState;
 
-export type InstructionDetails = AwaitInstruction | HoldInstruction | IssueInstruction | RedeemInstruction | ReleaseInstruction | RevertHoldInstruction | TransferInstruction;
+export type InstructionDetails = AwaitInstruction | HoldInstruction | IssueInstruction | MoveInstruction | RedeemInstruction | ReleaseInstruction | RevertHoldInstruction | TransferInstruction;
 
 export type InstructionTransition = {
   __typename?: 'InstructionTransition';
@@ -865,6 +898,8 @@ export type InstructionTransition = {
 /** Represent an Asset's Transaction Intent occasion in which the Asset's tokens are issued. */
 export type Intent = {
   __typename?: 'Intent';
+  /** Custom key-value metadata for tracing and reconciliation */
+  customMetadata?: Maybe<Array<KeyValuePair>>;
   /** End time of the intent. */
   end: Scalars['Int']['output'];
   id: Scalars['String']['output'];
@@ -872,6 +907,8 @@ export type Intent = {
   intent?: Maybe<IntentDetails>;
   /** Profile metadata, contains ACL information of the profile. */
   metadata: ProfileMetadata;
+  /** Reason the intent was rejected, prefixed with the rejecting organization (owner side only). */
+  rejectReason?: Maybe<Scalars['String']['output']>;
   /** Remaining quantity in the transaction. */
   remainingQuantity: Scalars['String']['output'];
   /** Start time of the intent. */
@@ -884,7 +921,13 @@ export type Intent = {
   version: Scalars['String']['output'];
 };
 
-export type IntentDetails = BuyingIntent | LoanIntent | PrimarySale | PrivateOfferIntent | RedemptionIntent | RequestForTransferIntent | SellingIntent;
+export type IntentDetails = BuyingIntent | LoanIntent | MoveIntent | PrimarySale | PrivateOfferIntent | RedemptionIntent | RequestForTransferIntent | SellingIntent;
+
+/** Fields to subscribe on */
+export enum IntentField {
+  RemainingQuantity = 'RemainingQuantity',
+  Status = 'Status',
+}
 
 export enum IntentStatus {
   Active = 'ACTIVE',
@@ -898,8 +941,10 @@ export enum IntentStatus {
 export enum IntentTypes {
   Buying = 'BUYING',
   Loan = 'LOAN',
+  Move = 'MOVE',
   PrimarySale = 'PRIMARY_SALE',
   PrivateOffer = 'PRIVATE_OFFER',
+  Redemption = 'REDEMPTION',
   RequestForTransfer = 'REQUEST_FOR_TRANSFER',
   Selling = 'SELLING',
 }
@@ -921,6 +966,19 @@ export type InterestRate = {
 export type Investor = {
   __typename?: 'Investor';
   resourceId: Scalars['String']['output'];
+};
+
+/** An investor's LA-managed network account bound to a specific organization and asset. */
+export type InvestorNetworkAccount = {
+  __typename?: 'InvestorNetworkAccount';
+  /** The bound network identity — a union of variants (wallet today; caip10/custodial when projected). Exactly one variant is set. */
+  account?: Maybe<NetworkAccount>;
+  /** Asset the network account is bound to. */
+  assetId: Scalars['String']['output'];
+  /** LA-assigned account identifier. */
+  id: Scalars['String']['output'];
+  /** Organization that manages this network account. */
+  organizationId: Scalars['String']['output'];
 };
 
 export enum InvestorRole {
@@ -987,6 +1045,12 @@ export type Issuers = {
   nodes?: Maybe<Array<Issuer>>;
   /** Keeps pagination info in-case limit input wes provided */
   pageInfo?: Maybe<PageInfo>;
+};
+
+export type KeyValuePair = {
+  __typename?: 'KeyValuePair';
+  key: Scalars['String']['output'];
+  value: Scalars['String']['output'];
 };
 
 /** Ledger account asset - combines FinP2P account with optional network account */
@@ -1095,7 +1159,7 @@ export type LoanIntent = {
   lenderAccount: FinP2PAssetAccount;
   loanInstruction: LoanInstruction;
   /** Signature policy type */
-  loanSettlementInstruction: LoanSettlementInstruction;
+  loanSettlementInstruction?: Maybe<LoanSettlementInstruction>;
   /** Settlement term */
   settlementTerm?: Maybe<SettlementTerm>;
   signaturePolicy: LoanSignaturePolicy;
@@ -1156,12 +1220,49 @@ export type Messages = {
   nodes?: Maybe<Array<Message>>;
 };
 
-/** Network account - represents external network accounts like wallets */
-export type NetworkAccount = {
-  __typename?: 'NetworkAccount';
-  /** Wallet account if present */
-  wallet?: Maybe<WalletAccount>;
+export type MoveContractDetails = {
+  __typename?: 'MoveContractDetails';
+  asset: AssetOrder;
 };
+
+/** A Move destination asset. Superset of FinP2PAsset (same resourceId + ledgerIdentifier), plus an optional pre-funded pool the Transfer drains into the destination for the hold-transfer-* variants. */
+export type MoveDestination = {
+  __typename?: 'MoveDestination';
+  /** Optional pre-funded pool account drained into this destination by the hold-transfer-* variants (null otherwise) */
+  fromSegregatedAccount?: Maybe<FinP2PAccount>;
+  /** Ledger identifier for the destination asset */
+  ledgerIdentifier?: Maybe<LedgerIdentifier>;
+  /** Resource ID of the destination FinP2P asset */
+  resourceId: Scalars['String']['output'];
+};
+
+export type MoveInstruction = {
+  __typename?: 'MoveInstruction';
+  /** asset's move amount */
+  amount: Scalars['String']['output'];
+  /** destination account information */
+  destination: LedgerAccountAsset;
+  /** source account information */
+  source: LedgerAccountAsset;
+};
+
+export type MoveIntent = {
+  __typename?: 'MoveIntent';
+  /** Allowed destination assets of the migration path (the executor picks one at execution) */
+  destinationAssets?: Maybe<Array<MoveDestination>>;
+  signaturePolicy: MoveSignaturePolicy;
+  /** Signature policy type */
+  signaturePolicyType: SignaturePolicyType;
+  /** Source asset of the migration path (resourceId + ledgerIdentifier; accounts are supplied per-owner at execution) */
+  sourceAsset?: Maybe<FinP2PAsset>;
+  /** Optional segregated account that receives released source tokens for the hold-*-release variants (instead of burning via Redeem) */
+  sourceToSegregatedAccount?: Maybe<FinP2PAccount>;
+};
+
+export type MoveSignaturePolicy = ManualIntentSignaturePolicy | PresignedMoveIntentSignaturePolicy;
+
+/** Network account — exactly one variant, mirroring the proto NetworkAccount oneof. */
+export type NetworkAccount = Caip10Account | CustodialAccount | WalletAccount;
 
 export type NoProof = {
   __typename?: 'NoProof';
@@ -1196,6 +1297,7 @@ export type NotDelivered = {
 export enum OperationType {
   Hold = 'Hold',
   Issue = 'Issue',
+  Move = 'Move',
   Redeem = 'Redeem',
   Release = 'Release',
   Transfer = 'Transfer',
@@ -1392,6 +1494,11 @@ export type PresignedLoanIntentSignaturePolicy = {
   _ignore?: Maybe<Scalars['Boolean']['output']>;
 };
 
+export type PresignedMoveIntentSignaturePolicy = {
+  __typename?: 'PresignedMoveIntentSignaturePolicy';
+  _ignore?: Maybe<Scalars['Boolean']['output']>;
+};
+
 export type PresignedPrivateOfferIntentSignaturePolicy = {
   __typename?: 'PresignedPrivateOfferIntentSignaturePolicy';
   _ignore?: Maybe<Scalars['Boolean']['output']>;
@@ -1418,7 +1525,7 @@ export type PrimarySale = {
   assetTerm: AssetTerm;
   /** Issuer id */
   issuerId: Scalars['String']['output'];
-  sellingSettlementInstruction: SellingSettlementInstruction;
+  sellingSettlementInstruction?: Maybe<SellingSettlementInstruction>;
   /** Settlement term */
   settlementTerm?: Maybe<SettlementTerm>;
   /** Source account - issuer's account from which asset is sold */
@@ -1439,7 +1546,7 @@ export type PrivateOfferIntent = {
   buyer?: Maybe<Scalars['String']['output']>;
   /** resource id of the seller */
   seller?: Maybe<Scalars['String']['output']>;
-  sellingSettlementInstruction: SellingSettlementInstruction;
+  sellingSettlementInstruction?: Maybe<SellingSettlementInstruction>;
   /** Settlement term */
   settlementTerm?: Maybe<SettlementTerm>;
   signaturePolicy: PrivateOfferSignaturePolicy;
@@ -1815,7 +1922,7 @@ export type SellingIntent = {
   assetTerm: AssetTerm;
   /** resource id of the seller */
   seller?: Maybe<Scalars['String']['output']>;
-  sellingSettlementInstruction: SellingSettlementInstruction;
+  sellingSettlementInstruction?: Maybe<SellingSettlementInstruction>;
   /** Settlement term */
   settlementTerm?: Maybe<SettlementTerm>;
   signaturePolicy: SellingSignaturePolicy;
@@ -1858,6 +1965,8 @@ export type Signature = {
   signature: Scalars['String']['output'];
   template: Template;
   templateType: TemplateType;
+  /** Template shape version. Defaults to 1 when the producer is on a pre-versioning finp2p-core release. */
+  templateVersion: Scalars['Int']['output'];
 };
 
 export enum SignaturePolicyType {
@@ -1873,6 +1982,7 @@ export type SignatureProof = {
 export type SignatureProofPolicy = {
   __typename?: 'SignatureProofPolicy';
   signatureTemplate: SignatureTemplate;
+  templateVersion: Scalars['Int']['output'];
   verifyingKey: Scalars['String']['output'];
 };
 
@@ -1895,6 +2005,10 @@ export type StatusTransition = {
 export type Subscription = {
   __typename?: 'Subscription';
   assetDataChanged: AssetDataItem;
+  /** Fires when a new intent is committed. Filters AND together; if a filter is omitted it matches everything. ownerOrgIds matches the org ids OSS derives for the intent. For Move this is the source asset's org; for two-sided intents like RequestForTransfer and Loan it may include both sides. */
+  intentAdded: Intent;
+  /** Fires when an intent field listed in fieldNames changes. Same filter semantics as intentAdded. */
+  intentChanged: Intent;
   planAdded: ExecutionPlan;
   plansChangedBy: ExecutionPlan;
   receiptAdded: Receipt;
@@ -1907,6 +2021,21 @@ export type SubscriptionAssetDataChangedArgs = {
   dataTypes?: InputMaybe<Array<DataType>>;
   identifierType?: InputMaybe<AssetDataIdentifierType>;
   identifierValue?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type SubscriptionIntentAddedArgs = {
+  assetIds?: InputMaybe<Array<Scalars['String']['input']>>;
+  intentTypes?: InputMaybe<Array<IntentTypes>>;
+  ownerOrgIds?: InputMaybe<Array<Scalars['String']['input']>>;
+};
+
+
+export type SubscriptionIntentChangedArgs = {
+  assetIds?: InputMaybe<Array<Scalars['String']['input']>>;
+  fieldNames: Array<IntentField>;
+  intentTypes?: InputMaybe<Array<IntentTypes>>;
+  ownerOrgIds?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 
@@ -1932,7 +2061,13 @@ export type Template = Eip712Template | HashlistTemplate;
 export type TokenBalance = {
   __typename?: 'TokenBalance';
   assetId: Scalars['String']['output'];
+  availableQuantity: Scalars['String']['output'];
+  heldQuantity: Scalars['String']['output'];
   quantity: Scalars['String']['output'];
+  syncedAvailableQuantity: Scalars['String']['output'];
+  syncedHeldQuantity: Scalars['String']['output'];
+  syncedQuantity: Scalars['String']['output'];
+  syncedQuantityTimestamp: Scalars['Int']['output'];
   transactionsDetails?: Maybe<Array<TransactionDetails>>;
   userId: Scalars['String']['output'];
 };
@@ -2000,6 +2135,8 @@ export type User = Profile & {
   /** Profile metadata, contains ACL information of the profile. */
   metadata: ProfileMetadata;
   name: Scalars['String']['output'];
+  /** Investor network accounts (LA-managed wallets) bound to a specific organization and asset. */
+  networkAccounts?: Maybe<Array<InvestorNetworkAccount>>;
   /** Organization id to whom this profile is associated with. */
   organizationId: Scalars['String']['output'];
   /** user resource version */
@@ -2029,6 +2166,12 @@ export type UserHoldingsArgs = {
 
 /** Represents an User in the network. */
 export type UserInboxArgs = {
+  filter?: InputMaybe<Array<Filter>>;
+};
+
+
+/** Represents an User in the network. */
+export type UserNetworkAccountsArgs = {
   filter?: InputMaybe<Array<Filter>>;
 };
 
@@ -2086,15 +2229,19 @@ export type Workflow = {
   health?: Maybe<WorkflowHealth>;
   /** Id of the workflow */
   id: Scalars['String']['output'];
+  /** Workflow last-modified timestamp (epoch millis) */
+  lastModified: Scalars['Int']['output'];
   /** metadata of the workflow */
   metadata: WorkflowMetadata;
   /** Name of the workflow */
   name: Scalars['String']['output'];
   /** list of reference information of the workflow */
   references: Array<Reference>;
+  /** Current state of the workflow (always populated; the state machine's current node, e.g. the initial state before any transition is applied) */
+  state: Scalars['String']['output'];
   /** Current status of the workflow */
   status: Scalars['String']['output'];
-  /** Current transition id of the workflow */
+  /** Id of the last applied transition (empty until the first transition; use `state` for the workflow's current position) */
   transitionId: Scalars['String']['output'];
   /** version of the workflow */
   version: Scalars['Int']['output'];
@@ -2150,6 +2297,8 @@ export type WorkflowHealthMetadata = {
 /** Health status enumeration */
 export enum WorkflowHealthStatus {
   Healthy = 'HEALTHY',
+  /** Actively retrying but still working (durable signal, core #1251) — not an error state */
+  Retrying = 'RETRYING',
   Stale = 'STALE',
   Stuck = 'STUCK',
   Unhealthy = 'UNHEALTHY',
@@ -2158,6 +2307,8 @@ export enum WorkflowHealthStatus {
 export type WorkflowMetadata = {
   __typename?: 'WorkflowMetadata';
   correlationIds?: Maybe<Array<Scalars['String']['output']>>;
+  /** Non-resetting retry aggregate across all states (never-give-up visibility, core #1251) */
+  cumulativeRetries: Scalars['Int']['output'];
   currentStateRetry: Scalars['Int']['output'];
   retry: Scalars['Int']['output'];
   traceId: Scalars['String']['output'];
@@ -2172,7 +2323,9 @@ export type WorkflowOrder = {
 
 export enum WorkflowOrderField {
   CorrelationId = 'CORRELATION_ID',
+  CreationTimestamp = 'CREATION_TIMESTAMP',
   HealthStatus = 'HEALTH_STATUS',
+  LastModified = 'LAST_MODIFIED',
   /** workflow order */
   Name = 'NAME',
   ReferenceId = 'REFERENCE_ID',

--- a/finp2p-client/src/oss/graphql.d.ts
+++ b/finp2p-client/src/oss/graphql.d.ts
@@ -107,8 +107,6 @@ export type Asset = Profile & {
   /** Profile metadata, contains ACL information of the profile. */
   metadata: ProfileMetadata;
   name: Scalars['String']['output'];
-  /** omnibus account for the asset, if applicable */
-  orgSettlementAccount?: Maybe<NetworkAccount>;
   /** Organization id to whom this profile is associated with. */
   organizationId: Scalars['String']['output'];
   /** Describe the policies active on the asset */

--- a/finp2p-client/src/oss/graphql/assets.graphql
+++ b/finp2p-client/src/oss/graphql/assets.graphql
@@ -43,12 +43,6 @@ query GetAssets($filter: [Filter!], $paginate: PaginateInput) {
             ledgerAssetInfo {
                 ...assetInfo
             }
-            orgSettlementAccount {
-                wallet {
-                    type
-                    address
-                }
-            }
             intents {
                 nodes {
                     id

--- a/finp2p-client/src/oss/graphql/owners.graphql
+++ b/finp2p-client/src/oss/graphql/owners.graphql
@@ -1,7 +1,8 @@
 query GetOwners(
     $filter: [Filter!],
     $includeCerts: Boolean = true,
-    $includeHoldings: Boolean = true
+    $includeHoldings: Boolean = true,
+    $includeNetworkAccounts: Boolean = false
 ) {
     users(filter: $filter) {
         nodes {
@@ -41,6 +42,14 @@ query GetOwners(
                     syncedBalance
                 }
             }
+            networkAccounts @include(if: $includeNetworkAccounts) {
+                organizationId
+                assetId
+                id
+                account {
+                    ... networkAccount
+                }
+            }
         }
     }
 }
@@ -49,5 +58,25 @@ fragment asset on AssetDetails {
     type: __typename
     ... on FinP2PAsset {
         resourceId
+    }
+}
+
+# `__typename` is aliased to `kind` rather than `type` because WalletAccount
+# already has a field named `type` — aliasing both to the same response key
+# would be a field conflict.
+fragment networkAccount on NetworkAccount {
+    kind: __typename
+    ... on WalletAccount {
+        type
+        address
+    }
+    ... on Caip10Account {
+        network
+        address
+    }
+    ... on CustodialAccount {
+        provider
+        vaultAccountId
+        assetId
     }
 }

--- a/finp2p-client/src/oss/graphql/plans.graphql
+++ b/finp2p-client/src/oss/graphql/plans.graphql
@@ -110,9 +110,19 @@ fragment ledgerAccountAssetFields on LedgerAccountAsset {
         }
     }
     networkAccount {
-        wallet {
+        kind: __typename
+        ... on WalletAccount {
             type
             address
+        }
+        ... on Caip10Account {
+            network
+            address
+        }
+        ... on CustodialAccount {
+            provider
+            vaultAccountId
+            assetId
         }
     }
 }

--- a/finp2p-client/src/oss/graphql/receipts.graphql
+++ b/finp2p-client/src/oss/graphql/receipts.graphql
@@ -52,9 +52,19 @@ fragment ledgerAccountAsset on LedgerAccountAsset {
         }
     }
     networkAccount {
-        wallet {
+        kind: __typename
+        ... on WalletAccount {
             type
             address
+        }
+        ... on Caip10Account {
+            network
+            address
+        }
+        ... on CustodialAccount {
+            provider
+            vaultAccountId
+            assetId
         }
     }
 }

--- a/finp2p-client/src/oss/model.ts
+++ b/finp2p-client/src/oss/model.ts
@@ -109,7 +109,6 @@ export type OssAsset = {
     nodes: OssIntent[]
   }
   ledgerAssetInfo: LedgerAssetInfo
-  orgSettlementAccount?: OssNetworkAccount | null
 };
 
 export type OssNetworkAccount = {

--- a/finp2p-client/src/oss/model.ts
+++ b/finp2p-client/src/oss/model.ts
@@ -115,6 +115,28 @@ export type OssNetworkAccount = {
   wallet?: { type: string; address: string } | null
 };
 
+/**
+ * One variant of the OSS `NetworkAccount` union, discriminated by `kind`
+ * (an alias of `__typename`; see the `networkAccount` fragment for why it
+ * isn't called `type`).
+ */
+export type OssNetworkAccountVariant =
+  | { kind: 'WalletAccount', type: string, address: string }
+  | { kind: 'Caip10Account', network: string, address: string }
+  | { kind: 'CustodialAccount', provider: string, vaultAccountId: string, assetId?: string | null };
+
+/**
+ * An investor's onboarded network account as projected into the OSS read
+ * model, scoped to one `(organizationId, assetId)` pair. `id` is the
+ * adapter-assigned identifier — the same one `removeInvestorAccount` takes.
+ */
+export type OssInvestorNetworkAccount = {
+  organizationId: string,
+  assetId: string,
+  id: string,
+  account: OssNetworkAccountVariant | null
+};
+
 export type OssPageInfo = {
   endCursor: string | null;
   hasNextPage: boolean;
@@ -168,6 +190,8 @@ export type OssOwner = {
       syncedBalance: string,
     }[]
   }
+  /** Only selected when the query is run with `includeNetworkAccounts: true`. */
+  networkAccounts?: OssInvestorNetworkAccount[] | null
   metadata: {
     acl: string[]
   }

--- a/finp2p-client/src/oss/model.ts
+++ b/finp2p-client/src/oss/model.ts
@@ -4,9 +4,14 @@ export type LedgerAssetInfo = {
   ledgerReference?: LedgerReference
 };
 
+/**
+ * `network` and `standard` are nullable upstream (only `tokenId` is non-null in
+ * the OSS schema), so they are optional here rather than promising a string the
+ * server may not send.
+ */
 export type Caip19Identifier = {
-  network: string;
-  standard: string;
+  network?: string | null;
+  standard?: string | null;
   tokenId: string;
 };
 
@@ -109,10 +114,6 @@ export type OssAsset = {
     nodes: OssIntent[]
   }
   ledgerAssetInfo: LedgerAssetInfo
-};
-
-export type OssNetworkAccount = {
-  wallet?: { type: string; address: string } | null
 };
 
 /**
@@ -289,7 +290,7 @@ export type OssLedgerAccountAsset = {
       custodian?: { orgId: string } | null;
     } | null;
   };
-  networkAccount?: { wallet?: { type: string; address: string } | null } | null;
+  networkAccount?: OssNetworkAccountVariant | null;
 };
 
 export type OssAssetOrder = {

--- a/finp2p-client/src/oss/oss.client.ts
+++ b/finp2p-client/src/oss/oss.client.ts
@@ -9,7 +9,7 @@ import LEDGERS from './graphql/ledgers.graphql';
 import APPROVAL_CONFIGS from './graphql/approval-configs.graphql';
 import PLANS from './graphql/plans.graphql';
 import RECEIPTS from './graphql/receipts.graphql';
-import { makeOssPage, OssApprovalConfigNodes, OssAsset, OssAssetNodes, OssCertificate, OssExecutionPlan, OssExecutionPlanNodes, OssLedgerBindingNodes, OssOrganizationNodes, OssOwnerNodes, OssPage, OssPaginate, OssReceipt, OssReceiptNodes, OssUser, OssUserNodes } from './model';
+import { makeOssPage, OssApprovalConfigNodes, OssAsset, OssAssetNodes, OssCertificate, OssExecutionPlan, OssExecutionPlanNodes, OssInvestorNetworkAccount, OssLedgerBindingNodes, OssOrganizationNodes, OssOwnerNodes, OssPage, OssPaginate, OssReceipt, OssReceiptNodes, OssUser, OssUserNodes } from './model';
 import { ItemNotFoundError } from './errors';
 import { normalizeBaseUrl } from '../finapi/utils';
 
@@ -79,6 +79,39 @@ export class OssClient {
       throw new ItemNotFoundError(finId, 'Owner');
     }
     return resp.users.nodes[0];
+  }
+
+  /**
+   * List the network accounts onboarded for an investor, as projected into the
+   * OSS read model. This is the read-back side of the onboarding flow — the
+   * `id` on each entry is what `removeInvestorAccount` takes.
+   *
+   * Pass `assetId` and/or `organizationId` to narrow to a single scope;
+   * filtering happens client-side because `networkAccounts` is a nested field
+   * and the OSS filter applies to the `users` selection.
+   */
+  async getOwnerNetworkAccounts(
+    ownerId: string,
+    scope: { organizationId?: string; assetId?: string } = {},
+  ): Promise<OssInvestorNetworkAccount[]> {
+    const resp = await this.queryOss<OssOwnerNodes>(OWNERS, {
+      filter: {
+        key: 'id',
+        operator: 'EQ',
+        value: ownerId,
+      },
+      includeCerts: false,
+      includeHoldings: false,
+      includeNetworkAccounts: true,
+    });
+    if (resp.users.nodes.length == 0) {
+      throw new ItemNotFoundError(ownerId, 'Owner');
+    }
+    const accounts = resp.users.nodes[0].networkAccounts ?? [];
+    return accounts.filter((a) => (
+      (scope.organizationId === undefined || a.organizationId === scope.organizationId)
+      && (scope.assetId === undefined || a.assetId === scope.assetId)
+    ));
   }
 
   async getAssets(


### PR DESCRIPTION
Syncs the API specs from `finp2p-core@master` (ours were at 2026-05-01) plus the OSS GraphQL schema from `owneraio/oss`, and wires the investor network-account onboarding surface Alex added across [core#2362](https://github.com/owneraio/finp2p-core/pull/2362), [core#2552](https://github.com/owneraio/finp2p-core/pull/2552), [core#2564](https://github.com/owneraio/finp2p-core/pull/2564), [core#2573](https://github.com/owneraio/finp2p-core/pull/2573), [oss#540](https://github.com/owneraio/oss/pull/540) and [oss#557](https://github.com/owneraio/oss/pull/557).

`finp2p-client` only — no consumer bumps here, so this can publish before a skeleton/sample-adapter PR follows.

## What the feature is

An investor can have an on-chain **network account** onboarded per `(organization, asset)`, which operation legs may then name explicitly via the optional `networkAccount` field on the shared account schemas. The router whitelist-validates it against `investor.data.accounts[org][asset]` and rejects with 7351 `AccountNotWhitelisted` if it was never onboarded.

Four new methods on `FinAPIClient`, delegated through the `FinP2PClient` facade:

| Method | Route |
|--------|-------|
| `createInvestorAccount` | `POST /profiles/investor/{investorId}/account/create` — adapter generates the account and holds the keys |
| `bindInvestorAccount` | `POST /profiles/investor/{investorId}/account/bind` — caller supplies an existing account + `ownershipSignature` |
| `submitAccountProof` | `POST /profiles/investor/{investorId}/account/proof` — fulfils a `signatureTemplate` challenge |
| `removeInvestorAccount` | `DELETE /profiles/investor/{investorId}/account/{accountId}` |

All four return `202 { cid }`. The ledger adapter then issues a challenge; `getOperationStatus(cid)` carries `challenge` while parked and `{ id, networkAccount }` on completion. Only `signatureTemplate` round-trips through `submitAccountProof` — `walletConnect`, `deposit` and `fireblocksApproval` are fulfilled out of band and the adapter reports verification directly.

The loop closes on the OSS side with `getOwnerNetworkAccounts(ownerId, { organizationId?, assetId? })` → `OssInvestorNetworkAccount[]`, whose `id` is what `removeInvestorAccount` takes.

New exported types: `CreateInvestorAccountBody`, `BindInvestorAccountBody`, `SubmitAccountProofBody`, `NetworkAccount`, `NetworkAccountChallenge`, `OssInvestorNetworkAccount`, `OssNetworkAccountVariant`. Phase-2 leg selection and all three account variants (`walletAccount` / `caip10Account` / `custodialAccount`) come through the regenerated types.

`Idempotency-Key` is **required** on all four REST routes — the only application-API routes where it isn't optional. Defaulted to `generateNonce().toString('hex')`, which already produced exactly the 24-random + 8-byte-epoch shape the `nonce` schema specifies; it just was never wired to a header before. Every method takes an optional trailing `idempotencyKey` to override.

## Specs

REST specs taken pristine from `core/api` rather than the generated variants: `application-api.base.yaml`, `common-external-components.yaml`, `dlt-adapter-api.yaml`, `custody-adapter-api.yaml`, and `operational-api.gen.yaml` → `operational-api.yaml`. `apis/ownership.graphql` comes from `owneraio/oss@master:graphql/ownership.graphql`. All three generators re-run.

`ownership.graphql` is re-synced wholesale, never hand-patched to match a query — it is the only thing constraining the OSS queries, so a hand-edited schema silently legitimises a broken selection set.

## Three breaking changes the swap surfaced

1. `orgSettlementAccount` is gone from `POST /profiles/asset` — dropped from `CreateAssetParams` and the `createAsset` body.
2. `privateOfferIntent.settlement` is now required; the no-settlement path sent `undefined` and now sends an explicit `noSettlement` term.
3. The OSS asset query still selected `orgSettlementAccount`, which GraphQL rejects as an unknown field. That would have failed `getAsset()` outright, and with it `getAssetProofPolicy`, which the skeleton depends on for proof generation. Removed from the query, `ownership.graphql` and the `OssAsset` type. **This reverses `feature/query-org-settlement-acc`** — though [oss#540](https://github.com/owneraio/oss/pull/540) is literally titled "expose investor network accounts (GraphQL); drop omnibus", so the field is intentionally gone upstream, not merely absent from the REST body. The now-unused exported `OssNetworkAccount` type is left in place so importers don't break.

## Union selections fixed (review catch)

`receipts.graphql` and `plans.graphql` still selected `networkAccount { wallet { type address } }`. `NetworkAccount` is a union upstream, `wallet` is not a field on it, and a real server rejects the entire document — the same failure this branch fixed for `orgSettlementAccount`. `plans.graphql` spreads `ledgerAccountAssetFields` across every instruction leg, so plan reads failed wholesale, not partially. `model.ts` carried the same wrong shape.

Worth stating plainly: the branch previously contained **both** forms — the read-back fragment used the union while those two used the object. Those cannot both be valid against any single server, so this was an internal contradiction rather than mere staleness.

All three now use inline fragments on the three variants, discriminated by `kind` (an alias of `__typename`) — deliberately *not* `type`, the way the sibling `asset` fragment does it, because `WalletAccount` already has a field named `type` and both aliasing to the same response key is a field conflict.

### Root cause, and the guard that closes it

Nothing validated the queries. `grahpqlgen.ts` declared only `schema` and no `documents`, so codegen emitted schema types and never looked at the query documents — a field existing nowhere in the schema passed clean. That is why the mismatch survived my earlier claim that "codegen validates every document", which was simply wrong.

This PR adds `documents` to the codegen config plus a validation-only `graphqlvalidate.ts` (output to `node_modules/.cache`, so it rewrites nothing) wired into `prebuild`. CI runs `npm run build`, so a query/schema mismatch now fails CI with a file:line pointer. Verified by reintroducing the reported bug — build exits 1 on `Cannot query field "wallet" on type "NetworkAccount"` at `plans.graphql:113:9`.

### OSS version floor

`NetworkAccount` was an object with a `wallet` field until [oss#557](https://github.com/owneraio/oss/pull/557) (2026-07-29) made it a union. **The two forms are mutually exclusive**, so these queries require OSS at or past that commit; against an older deployment they fail. This is a genuine deployment constraint, and it is the resolution of "you can't treat OSS master as authoritative for one field and ignore it for two others" — everything here now targets master consistently. Targeting a pre-#557 router means reverting the vendored schema and all three selections together.

Note the asymmetry that made the earlier `orgSettlementAccount` fix safe either way: *removing* a field from a selection set is valid against both old and new servers, whereas switching to inline fragments is a hard cutover.

## Other review fixes

- **`OssNetworkAccount` dropped.** Kept last round "so importers don't break", but its `{ wallet? }` shape no longer matches upstream and nothing references it. An exported type steering consumers toward an invalid selection set is a worse compat story than removing it.
- **`Caip19Identifier.network`/`standard`** are nullable upstream; the hand-written copy in `model.ts` promised non-null `string`. (The generated copy was already correct after the schema re-sync.)
- **Idempotency-key retry semantics documented.** A fresh key is minted per call — right default for independent requests, but no deduplication on retry, so a caller owning its retry loop must thread one key through every attempt.
- **`dlt-adapter-api.yaml` / `custody-adapter-api.yaml`** are reference-only with no generation target; CLAUDE.md now says so, since their drift is undetected.
- **Smoke checks committed** as `scripts/smoke-investor-accounts.js` (`npm run smoke`) with real assertions instead of console output. Negative-tested: fails on a missing header, on non-unique auto keys, and on the object-form union selection. Not wired into CI (the workflow runs `build` only).

## Verification

`npm run build` clean from a wiped `dist` — now `validate:graphql` + eslint + tsc + copy. Beyond typechecking, both halves were exercised against local HTTP servers via `npm run smoke`:

- REST: correct paths and methods, bodies serialized as expected, `Idempotency-Key` present and unique per call, 64-hex auto-generated keys, explicit override honored, `202` responses parsed.
- OSS: correct query variables, `networkAccounts` present in the document, no `wallet` selection on the union, all three account variants discriminate on `kind`, `organizationId`/`assetId` scoping filters correctly, and an unknown owner raises `ItemNotFoundError`.

Each assertion was negative-tested by breaking the behaviour it covers and confirming it fails.

## Relationship to `feature/onboard`

`feature/onboard` (published as `finp2p-client-v0.28.23-onboard.3`) carries an overlapping version of this work. It predates [core#2564](https://github.com/owneraio/finp2p-core/pull/2564), so it lacks `caip10Account`/`custodialAccount` in the client's specs and `finId` in its `dlt-adapter-api.yaml` copy; its `application-api.base.yaml` is also a generated-flavoured file carrying `x-allowEmpty` and injected 408/504 error responses. This branch takes the clean base specs instead. **Needs coordination with @ShakhzodIkromov before merge.**

Version `0.28.22` → **`0.28.23`**, the actual next patch. The `0.28.23-onboard.*` tags are release candidates, and semver orders a stable release after its own prereleases (`0.28.23-onboard.3` < `0.28.23`), so `0.28.23` supersedes the RCs rather than colliding with them; no stable `finp2p-client-v0.28.23` tag exists. Earlier revisions of this branch used `0.28.24`, following the previous release's practice of skipping any slot holding prerelease tags — stricter than semver needs, and it leaves gaps for RCs that were never meant to hold the slot. The commit message on `dd4202e` still says `0.28.23 -> 0.28.24`; superseded by `b13e7c4`, not force-pushed so review comments stay anchored.

## Merge order vs #227

Both PRs merge cleanly into master individually, but whichever lands second hits 12 files / 166 conflict hunks — symmetric either order. Only **3 of those hunks are hand-written** (`package.json` version, two doc comments); 75 are generated (`model-gen.ts`, `op-model-gen.ts`, `graphql.d.ts`, `package-lock.json`) and 87 are vendored specs. Those must be regenerated / re-synced, not hand-merged.

The substantive issue is not textual: **the two PRs target different OSS versions.** #227 carries the pre-[oss#557](https://github.com/owneraio/oss/pull/557) object form (`type NetworkAccount { wallet }` plus queries selecting `wallet`) and is internally consistent; this PR carries the union form. They are mutually exclusive, so resolving hunk-by-hunk risks a document a real server rejects.

The `validate:graphql` gate added here catches exactly that. Built against a realistic mixed resolution (#227's schema + this PR's queries) it fails with 9 errors and file:line pointers:

```
Fragment cannot be spread here as objects of type "NetworkAccount" can never be of type "WalletAccount".
  at src/oss/graphql/owners.graphql:69:5
Unknown type "Caip10Account". Did you mean ... "WalletAccount"?
```

So whatever the order, keep `grahpqlgen.ts` + `prebuild` from this PR — #227 has no `documents:` key, and without it a mixed state ships silently.

**Suggested order: this PR first, then rebase #227 on it.** #227's `finp2p-client` changes are then largely superseded (its specs predate core#2564/#2573 and oss#557), so its resolution reduces to dropping its `finp2p-client/` spec and generated-type changes, keeping its skeleton/sample-adapter/vanilla-service work, and bumping the client only if it needs further client changes. Note #227 currently lands prerelease versions on master (client `0.28.23-onboard.3`, skeleton `0.28.25-onboard.10`, vanilla-service `0.28.7-onboard.1`); after this PR publishes `0.28.23`, resolving the client version toward #227's side would roll master backwards onto an existing RC tag.

## Follow-ups, not in this PR

- `skeleton/apis/dlt-adapter-api.yaml` is still missing `accountOwnershipSignature` — separate PR, per the skeleton-then-consumer split.
- The `fireblocksApproval` field-name mismatch (`requestId` app-side vs `fireblocksRequestId` adapter-side) is untouched; looks like an oversight in core#2362 and needs @AlexZip85 to confirm which is intended rather than a silent mapping on our side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
