### PR TITLE
skeleton: investor network account onboarding (rebase of #227)

### DIFF
--- a/sample-adapter/package-lock.json
+++ b/sample-adapter/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@owneraio/finp2p-client": "^0.28.10",
-        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.15",
+        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.25-onboard.6",
         "axios": "1.11.0",
         "ethers": "^6.11.1",
         "express": "5.0.0",
@@ -2628,6 +2628,47 @@
         "express": "5.x.x"
       }
     },
+    "node_modules/@owneraio/adapter-tests/node_modules/@owneraio/finp2p-nodejs-skeleton-adapter": {
+      "version": "0.28.24",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.24/c082ab5ba91dc34958cf59e905a034109e440440",
+      "integrity": "sha512-tqLFl2uHynY6sAYdZ3olF0NnlrYFK085KKNVmTpFxVthIjn/vVJoeyEyNpqPA2UAhJw6mpL5FEpQfVKlRe+KEQ==",
+      "dev": true,
+      "license": "TBD",
+      "dependencies": {
+        "axios": "1.11.0",
+        "bs58": "^6.0.0",
+        "ethers": "^6.11.1",
+        "express": "5.0.0",
+        "express-validator": "^6.14.0",
+        "express-winston": "^4.2.0",
+        "keccak": "^3.0.2",
+        "secp256k1": "^3.7.1",
+        "winston": "^3.18.3"
+      },
+      "peerDependencies": {
+        "@owneraio/finp2p-client": "^0.28.6",
+        "pg": "^8.15.6"
+      }
+    },
+    "node_modules/@owneraio/adapter-tests/node_modules/@owneraio/finp2p-nodejs-skeleton-adapter/node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/@owneraio/adapter-tests/node_modules/@owneraio/finp2p-nodejs-skeleton-adapter/node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@owneraio/adapter-tests/node_modules/axios": {
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
@@ -2683,9 +2724,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-nodejs-skeleton-adapter": {
-      "version": "0.28.15",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.15/990156ffae13b881f4066186b117d73927c5edd9",
-      "integrity": "sha512-YpIzwIHIqfgbgnpcyNN5YMGUZy5TotpndCsoTxNXx0+3/JNRbKBg2uCwzWWuu2DOQymMn8A4zMgbjwaVhJX0Dg==",
+      "version": "0.28.25-onboard.6",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.25-onboard.6/c99954cddeb614446d2fdfb76b652f173fb07e3d",
+      "integrity": "sha512-M0jZRMB8G+/w/qVLTlLid8xPCxx/zlQx+sNXdsaEBMyxp6rP8/2LoTbIiAwnwlVi2slTlksEZ4apxv8pdU/S1w==",
       "license": "TBD",
       "dependencies": {
         "axios": "1.11.0",

--- a/sample-adapter/package.json
+++ b/sample-adapter/package.json
@@ -19,8 +19,8 @@
     "registry": "https://npm.pkg.github.com"
   },
   "dependencies": {
-    "@owneraio/finp2p-client": "^0.28.10",
-    "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.15",
+    "@owneraio/finp2p-client": "^0.28.23",
+    "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.25",
     "axios": "1.11.0",
     "ethers": "^6.11.1",
     "express": "5.0.0",

--- a/sample-adapter/src/app.ts
+++ b/sample-adapter/src/app.ts
@@ -11,6 +11,8 @@ import {
   PaymentsServiceImpl,
   ProofProvider,
   AccountMappingServiceImpl,
+  NetworkAccountServiceImpl,
+  NotSupportedNetworkAccountService,
   workflows,
   storage as skeletonStorage,
 } from '@owneraio/finp2p-nodejs-skeleton-adapter';
@@ -68,6 +70,7 @@ function createApp(orgId: string, finP2PClient: FinP2PClient | undefined, config
   let pool: Pool | undefined;
   let mappingService: routes.AccountMappingService | undefined;
   let mappingConfig: routes.AccountMappingConfig | undefined;
+  let networkAccountService: routes.NetworkAccountService = new NotSupportedNetworkAccountService();
 
   if (config?.connectionString) {
     pool = new Pool({ connectionString: config.connectionString });
@@ -105,6 +108,8 @@ function createApp(orgId: string, finP2PClient: FinP2PClient | undefined, config
 
     const accountStore = new skeletonStorage.PgAccountStore(pool, schemaName);
     mappingService = new AccountMappingServiceImpl(accountStore);
+    const networkAccountStore = new skeletonStorage.PgNetworkAccountStore(pool, schemaName);
+    networkAccountService = new NetworkAccountServiceImpl(networkAccountStore);
     mappingConfig = {
       fields: [
         {
@@ -124,8 +129,8 @@ function createApp(orgId: string, finP2PClient: FinP2PClient | undefined, config
     tokenService,
     paymentsService,
     planApprovalService,
-    mappingConfig,
-    mappingService,
+    networkAccountService,
+    { mappingConfig, mappingService },
   );
 
   return { app, pool };

--- a/sample-adapter/src/services/inmemory/tokens.ts
+++ b/sample-adapter/src/services/inmemory/tokens.ts
@@ -60,11 +60,10 @@ export class TokenServiceImpl extends CommonServiceImpl implements TokenService 
     return this.storage.getBalance(finId, asset.assetId);
   }
 
-  public async issue(idempotencyKey: string, asset: Asset, destinationFinId: string, quantity: string, exCtx: ExecutionContext | undefined): Promise<ReceiptOperation> {
-    logger.info(`Issuing ${quantity} of ${asset.assetId} to ${destinationFinId}`);
+  public async issue(idempotencyKey: string, asset: Asset, destination: Destination, quantity: string, exCtx: ExecutionContext | undefined): Promise<ReceiptOperation> {
+    logger.info(`Issuing ${quantity} of ${asset.assetId} to ${destination.finId}`);
 
-    this.storage.credit(destinationFinId, quantity, asset.assetId);
-    const destination: Destination = { finId: destinationFinId };
+    this.storage.credit(destination.finId, quantity, asset.assetId);
     const tx = new Transaction(quantity, asset, undefined, destination, exCtx, 'issue', undefined);
     this.storage.registerTransaction(tx);
     let receipt = tx.toReceipt();
@@ -90,12 +89,12 @@ export class TokenServiceImpl extends CommonServiceImpl implements TokenService 
     return successfulReceiptOperation(receipt);
   }
 
-  public async redeem(idempotencyKey: string, nonce: string, sourceFinId: string, asset: Asset, quantity: string, operationId: string | undefined,
+  public async redeem(idempotencyKey: string, nonce: string, source: Source, asset: Asset, quantity: string, operationId: string | undefined,
     signature: Signature, exCtx: ExecutionContext | undefined,
   ): Promise<ReceiptOperation> {
-    logger.info(`Redeeming ${quantity} of ${asset.assetId} from ${sourceFinId}`);
+    logger.info(`Redeeming ${quantity} of ${asset.assetId} from ${source.finId}`);
 
-    // if (!await verifySignature(signature, sourceFinId)) {
+    // if (!await verifySignature(signature, source.finId)) {
     //   return failedReceiptOperation(1, 'Signature verification failed');
     // }
 
@@ -107,10 +106,9 @@ export class TokenServiceImpl extends CommonServiceImpl implements TokenService 
       // do no movement, account is effected at hold time
       this.storage.removeHoldOperation(operationId);
     } else {
-      this.storage.debit(sourceFinId, quantity, asset.assetId);
+      this.storage.debit(source.finId, quantity, asset.assetId);
     }
 
-    const source: Source = { finId: sourceFinId };
     const tx = new Transaction(quantity, asset, source, undefined, exCtx, 'redeem', operationId);
     this.storage.registerTransaction(tx);
     let receipt = tx.toReceipt();

--- a/skeleton/CLAUDE.md
+++ b/skeleton/CLAUDE.md
@@ -13,11 +13,12 @@ The goal is to narrow the scope of building a new adapter to **just implementing
 ### Route layer (`src/routes/`)
 
 - **`model-gen.ts`** &mdash; TypeScript types auto-generated from the DLT adapter API OpenAPI spec (`apis/dlt-adapter-api.yaml`). Generated via `npm run api-generate` using `openapi-typescript`, then post-processed by `scripts/postprocess-model-gen.ts` to handle circular references and export recursive types.
-- **`routes.ts`** &mdash; Express route handlers for all DLT adapter API endpoints. The `register()` function is the main entry point and is **pure routing**: it takes finalized service implementations and mounts them on HTTP endpoints. All wiring (workflow proxy wrapping, plugin construction, account-mapping store/service, FinP2P client) must happen in the caller before `register()` is invoked. Signature: `register(app, tokenService, escrowService, commonService, healthService, paymentService, planService, mappingConfig?, mappingService?): void`. Endpoints:
+- **`routes.ts`** &mdash; Express route handlers for all DLT adapter API endpoints. The `register()` function is the main entry point and is **pure routing**: it takes finalized service implementations and mounts them on HTTP endpoints. All wiring (workflow proxy wrapping, plugin construction, account-mapping store/service, FinP2P client) must happen in the caller before `register()` is invoked. Signature: `register(app, tokenService, escrowService, commonService, healthService, paymentService, planService, networkAccountService, options?): void` where `options` is `{ mappingConfig?, mappingService? }`. Endpoints:
   - **Plan**: `POST /api/plan/approve`, `POST /api/plan/proposal`, `POST /api/plan/proposal/status`
   - **Tokens**: `POST /api/assets/create`, `POST /api/assets/issue`, `POST /api/assets/transfer`, `POST /api/assets/redeem`, `POST /api/assets/getBalance`, `POST /api/asset/balance`
   - **Escrow**: `POST /api/assets/hold`, `POST /api/assets/release`, `POST /api/assets/rollback`
   - **Payments**: `POST /api/payments/depositInstruction`, `POST /api/payments/payout`
+  - **Accounts**: `POST /api/accounts/create` (202), `DELETE /api/accounts/:accountId` &mdash; `networkAccountService` is required; adapters without ledger support pass `NotSupportedNetworkAccountService` (answers 501). `POST /api/accounts/:cid/proof` is a 501 stub: the sync trust model never issues challenges, so the router never has a proof to submit
   - **Common**: `GET /api/assets/receipts/:transactionId`, `GET /api/operations/status/:cid`
   - **Health**: `GET /health`, `GET /health/liveness`, `GET /health/readiness`
 - **`mapping.ts`** &mdash; Bidirectional mapping functions between OpenAPI-generated types and domain model types from `finp2p-adapter-models`. Converts API request payloads into service method arguments and service results back into API responses.
@@ -44,6 +45,7 @@ Default implementations that adapter developers can extend or replace:
 
 - **`plan/service.ts`** &mdash; `PlanApprovalServiceImpl` &mdash; default plan approval that auto-approves if no FinP2P client is configured. When a client is available, fetches the execution plan from the router and validates instructions via plugins. Proposal endpoints (cancel/reset/instruction) default to auto-approve.
 - **`payments/payments.ts`** &mdash; `PaymentsServiceImpl` &mdash; delegates deposit/payout to plugins (sync or async variants). Returns failure if no plugin is registered.
+- **`accounts/service.ts`** &mdash; `NetworkAccountServiceImpl` &mdash; investor account onboarding, **sync trust model**: the caller-supplied wallet is recorded as-is over a `NetworkAccountStore`, no ownership challenge (same trust the old finId&rarr;wallet mapping API extended). Optional `NetworkAccountValidator` hook for ledger address-shape checks. One binding per investor per (organizationId, assetId), keyed by the investor's `finId` carried on the request (required in the OAS): a repeat create for the same finId replays the recorded binding (even with a different wallet &mdash; changing wallets is remove + create). The same address may still be bound by many investors (omnibus &mdash; one shared wallet, many investors). Both methods are single-call and terminal &mdash; safe to wrap in `createServiceProxy`. The wallet also still arrives per operation on the instruction leg (`Source.account` / `Destination.account`). Challenge-based onboarding (signatureTemplate/walletConnect/deposit/fireblocksApproval, still present in the API spec) is deliberately not modeled &mdash; business requirements are unclear; add it when they firm up.
 - **`proof/provider.ts`** &mdash; `ProofProvider` &mdash; generates cryptographic proofs (EIP-712 or hash-list) for receipts, fetching proof policies from the FinP2P node.
 - **`verify.ts`** &mdash; Signature verification utilities.
 
@@ -64,8 +66,9 @@ Default implementations that adapter developers can extend or replace:
    - `EscrowService` for hold/release/rollback
    - Optionally register plugins for payments, plan approval, transaction hooks
 4. Construct your services. If you want PostgreSQL-backed async workflows, create a `pg.Pool`, build a `WorkflowStorage(pool)`, and wrap each service with `createServiceProxy(...)` before passing them to `register()`. The caller owns the pool lifecycle.
-5. If you want account mapping, construct an `AccountStore` (e.g. `PgAccountStore(pool)`) and an `AccountMappingServiceImpl(store)`, and pass them along with an `AccountMappingConfig` to `register()`.
-6. Call `routes.register(app, tokenService, escrowService, commonService, healthService, paymentService, planService, mappingConfig?, mappingService?)`.
+5. For investor account onboarding, construct `NetworkAccountServiceImpl(store, validator?)` backed by a `NetworkAccountStore` (e.g. `PgNetworkAccountStore(pool)`); if the ledger has no account support, use `NotSupportedNetworkAccountService`.
+6. If you want account mapping (deprecated, superseded by network accounts), construct an `AccountStore` (e.g. `PgAccountStore(pool)`) and an `AccountMappingServiceImpl(store)`, and pass them via `options`.
+7. Call `routes.register(app, tokenService, escrowService, commonService, healthService, paymentService, planService, networkAccountService, { mappingConfig?, mappingService? })`.
 
 ## API spec management
 
@@ -85,6 +88,7 @@ A post-processor (`scripts/postprocess-model-gen.ts`) handles:
 When workflow persistence is enabled, the skeleton uses PostgreSQL with a `ledger_adapter` schema. Migrations:
 - `20251020114833_initial_tables.sql` &mdash; `operations` table (cid, method, status, inputs, outputs)
 - `20260105064721_add_assets_table.sql` &mdash; `assets` table (id, type, contract_address, decimals)
+- `20260727060730_create_network_accounts_table.sql` &mdash; `network_accounts` table: one binding per investor per (org, asset) &mdash; account_id PK, unique (organization_id, asset_id, fin_id), idempotency_key as trace field, account jsonb
 
 Migrations run automatically on startup via goose.
 

--- a/skeleton/CLAUDE.md
+++ b/skeleton/CLAUDE.md
@@ -18,10 +18,12 @@ The goal is to narrow the scope of building a new adapter to **just implementing
   - **Tokens**: `POST /api/assets/create`, `POST /api/assets/issue`, `POST /api/assets/transfer`, `POST /api/assets/redeem`, `POST /api/assets/getBalance`, `POST /api/asset/balance`
   - **Escrow**: `POST /api/assets/hold`, `POST /api/assets/release`, `POST /api/assets/rollback`
   - **Payments**: `POST /api/payments/depositInstruction`, `POST /api/payments/payout`
-  - **Accounts**: `POST /api/accounts/create` (202), `DELETE /api/accounts/:accountId` &mdash; `networkAccountService` is required; adapters without ledger support pass `NotSupportedNetworkAccountService` (answers 501). `POST /api/accounts/:cid/proof` is a 501 stub: the sync trust model never issues challenges, so the router never has a proof to submit
+  - **Accounts**: `POST /api/accounts/create` (202), `DELETE /api/accounts/:accountId` &mdash; `networkAccountService` defaults to `NotSupportedNetworkAccountService` (answers 501), so the account surface is opt-in and an existing adapter that passes nothing keeps compiling. `POST /api/accounts/:cid/proof` is a 501 stub: the sync trust model never issues challenges, so the router never has a proof to submit
   - **Common**: `GET /api/assets/receipts/:transactionId`, `GET /api/operations/status/:cid`
   - **Health**: `GET /health`, `GET /health/liveness`, `GET /health/readiness`
 - **`mapping.ts`** &mdash; Bidirectional mapping functions between OpenAPI-generated types and domain model types from `finp2p-adapter-models`. Converts API request payloads into service method arguments and service results back into API responses.
+
+  The OAS `networkAccount` union carries `caip10Account` and `custodialAccount` variants that the domain `NetworkAccount` cannot represent, so `networkAccountFromAPI` **rejects** them with `AccountInvalidShapeError` (400) rather than falling back to `none`. Degrading instead would report a successful bind while recording an empty account &mdash; the router whitelists `{}`, and every later operation naming the real account then fails 7351 `AccountNotWhitelisted` with nothing at bind time to explain it. Supporting those variants means extending the domain type, not relaxing the mapper.
 
 ### Workflow layer (`src/workflows/`)
 

--- a/skeleton/apis/common-external-components.yaml
+++ b/skeleton/apis/common-external-components.yaml
@@ -1,5 +1,13 @@
 components:
   schemas:
+    customMetadata:
+      type: object
+      description: >
+        Optional. A map of key:value string pairs for custom tracing, reconciliation, and business context. Opaque to the Router.
+
+      additionalProperties:
+        type: string
+        minLength: 1
     APIError:
       type: object
       required: [code, message]
@@ -152,6 +160,10 @@ components:
           enum: ['plan']
     ApiErrorClient4XX:
       type: object
+      deprecated: true
+      description: |
+        **Deprecated.** Use the standard `APIErrors` schema instead. All 4xx error
+        responses now follow the shared error format with Ownera error codes.
       required: [status, errors, type]
       properties:
         type:
@@ -191,6 +203,10 @@ components:
           enum: ['Asset metadata and config cannot be provided at the same time']
     ApiErrorServer5XX:
       type: object
+      deprecated: true
+      description: |
+        **Deprecated.** Use the standard `APIErrors` schema instead. All 5xx error
+        responses now follow the shared error format with Ownera error codes.
       required: [status, errors, type]
       properties:
         type:
@@ -217,6 +233,10 @@ components:
           type: string
           enum: ['General server error']
     ApiAnyError:
+      deprecated: true
+      description: |
+        **Deprecated.** Use the standard `APIErrors` schema instead. All error
+        responses now follow the shared error format with Ownera error codes.
       allOf:
         - oneOf:
             - $ref: '#/components/schemas/ApiErrorClient4XX'
@@ -409,7 +429,7 @@ components:
           discriminator:
             propertyName: type
             mapping:
-              random: '#/components/schemas/pollingResultsStrategy'
+              random: '#/components/schemas/randomPollingInterval'
               absolute: '#/components/schemas/absolutePollingInterval'
               relative: '#/components/schemas/relativePollingInterval'
     relativePollingInterval:
@@ -643,21 +663,71 @@ components:
       properties:
         type:
           type: string
-          pattern: .*\S.*
-          x-autoMinLength: true
+          enum: ['walletAccount']
         address:
           type: string
           description: 'address of the wallet'
           pattern: .*\S.*
           x-autoMinLength: true
     noneAccount:
-        type: object
+      type: object
+      additionalProperties: false
+    caip10Account:
+      type: object
+      required:
+        - type
+        - network
+        - address
+      properties:
+        type:
+          type: string
+          enum: ['caip10Account']
+        network:
+          type: string
+          description: 'CAIP-2 chain_id, e.g. "eip155:1", "solana:5eykt4...", "hedera:mainnet" (the same token used by the CAIP-19 asset identifier network)'
+          pattern: .*\S.*
+          x-autoMinLength: true
+        address:
+          type: string
+          description: 'CAIP-10 account_address (chain-native address)'
+          pattern: .*\S.*
+          x-autoMinLength: true
+          maxLength: 128
+    custodialAccount:
+      type: object
+      required:
+        - type
+        - provider
+        - vaultAccountId
+      properties:
+        type:
+          type: string
+          enum: ['custodialAccount']
+        provider:
+          type: string
+          description: 'Custody provider discriminator, e.g. "fireblocks"'
+          pattern: .*\S.*
+          x-autoMinLength: true
+        vaultAccountId:
+          type: string
+          description: 'Provider-internal account identifier (e.g. a Fireblocks vault account id)'
+          pattern: .*\S.*
+          x-autoMinLength: true
+        assetId:
+          type: string
+          description: 'Optional. Narrows the custodial account to a specific asset/chain.'
+          pattern: .*\S.*
+          x-autoMinLength: true
     networkAccount:
       oneOf:
         - $ref: '#/components/schemas/walletAccount'
+        - $ref: '#/components/schemas/caip10Account'
+        - $ref: '#/components/schemas/custodialAccount'
         - $ref: '#/components/schemas/noneAccount'
-
     financialAssetIdentifier:
+      description: >
+        Globally recognized code identifying the asset across networks, routers, and counterparties. Used for balance aggregation and cross-router asset recognition. Format is validated for structure only.
+
       oneOf:
         - $ref: '#/components/schemas/financialAssetIdentifierTypeISIN'
         - $ref: '#/components/schemas/financialAssetIdentifierTypeISO4217'
@@ -669,6 +739,7 @@ components:
           ISO4217: '#/components/schemas/financialAssetIdentifierTypeISO4217'
           NONE: '#/components/schemas/financialAssetIdentifierTypeNONE'
     financialAssetIdentifierTypeISIN:
+      description: Financial instruments (equities, bonds, funds, etc.). 12-character ISO 6166 code.
       type: object
       required: [assetIdentifierType, assetIdentifierValue]
       properties:
@@ -682,6 +753,7 @@ components:
           pattern: '^[A-Z]{2}[A-Z0-9]{10}$'
           x-autoMinLength: true
     financialAssetIdentifierTypeNONE:
+      description: Asset is not registered under a global identification scheme.
       type: object
       required: [assetIdentifierType]
       properties:
@@ -690,6 +762,7 @@ components:
           enum: [NONE]
           description: Classification type standards
     financialAssetIdentifierTypeISO4217:
+      description: Fiat currencies.
       type: object
       required: [assetIdentifierType, assetIdentifierValue]
       properties:
@@ -710,7 +783,7 @@ components:
           CAIP-19: '#/components/schemas/ledgerAssetIdentifierTypeCAIP-19'
     ledgerAssetIdentifierTypeCAIP-19:
       type: object
-      required: [assetIdentifierType, network, tokenId, standard]
+      required: [assetIdentifierType, tokenId]
       properties:
         assetIdentifierType:
           type: string
@@ -756,14 +829,9 @@ components:
           minLength: 1
     assetType:
       type: string
-      enum: [ Equity, Debt, Loans, Fund, RealEstate, Commodity, Fiat, Cryptocurrency, TokenizedCash, DigitalNatives, Basket, Other ]
+      enum: [Equity, Debt, Loans, Fund, RealEstate, Commodity, Fiat, Cryptocurrency, TokenizedCash, DigitalNatives, Basket, Other]
       pattern: '^[a-zA-Z0-9\- ]*$'
-      description: |
-        The type of the asset 
-        Payment asset classification:
-        - Fiat: Government-issued currencies identified by ISO 4217 codes (e.g., USD, EUR, GBP)
-        - Cryptocurrency: Blockchain-based digital currencies identified by appropriate crypto identifiers (e.g., BTC, ETH)
-        - TokenizedCash: Blockchain-based digital cash maintaining 1:1 fiat peg (stablecoins, deposit tokens, CBDCs)
+      description: "The type of the asset \nPayment asset classification:\n- Fiat: Government-issued currencies identified by ISO 4217 codes (e.g., USD, EUR, GBP)\n- Cryptocurrency: Blockchain-based digital currencies identified by appropriate crypto identifiers (e.g., BTC, ETH)\n- TokenizedCash: Blockchain-based digital cash maintaining 1:1 fiat peg (stablecoins, deposit tokens, CBDCs)\n"
       maxLength: 150
     finIdAccount:
       type: object
@@ -787,26 +855,33 @@ components:
           $ref: '#/components/schemas/finIdAccount'
         asset:
           $ref: '#/components/schemas/finp2pAsset'
+        networkAccount:
+          $ref: '#/components/schemas/networkAccount'
+          description: |
+            Optional. Investor network account to use for this leg. Must have been
+            previously bound via `POST /profiles/investor/{investorId}/account`.
+            Whitelist-validated against `investor.data.accounts[org][asset]`
+            before forwarding to the LA. Failure → error code 7351 (AccountNotWhitelistedErr, 400).
     finp2pAssetWithNoAccount:
       type: object
       description: 'describes asset information'
-      required: [ asset ]
+      required: [asset]
       properties:
         asset:
           $ref: '#/components/schemas/finp2pAsset'
     finp2pAsset:
-        type: object
-        description: 'describes asset information'
-        required: [id, ledgerIdentifier]
-        properties:
-          id:
-            $ref: '#/components/schemas/resourceId'
-          ledgerIdentifier:
-            $ref: '#/components/schemas/ledgerAssetIdentifier'
+      type: object
+      description: 'describes asset information'
+      required: [id, ledgerIdentifier]
+      properties:
+        id:
+          $ref: '#/components/schemas/resourceId'
+        ledgerIdentifier:
+          $ref: '#/components/schemas/ledgerAssetIdentifier'
     ledgerAccountAsset:
       type: object
       description: 'describes account information'
-      required: [ finp2pAccount ]
+      required: [finp2pAccount]
       properties:
         finp2pAccount:
           $ref: '#/components/schemas/finp2pAssetAccount'
@@ -821,26 +896,33 @@ components:
           $ref: '#/components/schemas/finIdAccount'
         asset:
           $ref: '#/components/schemas/finp2pAsset'
+        networkAccount:
+          $ref: '#/components/schemas/networkAccount'
+          description: |
+            Optional. Investor network account to use for this leg. Must have been
+            previously bound via `POST /profiles/investor/{investorId}/account`.
+            Whitelist-validated against `investor.data.accounts[org][asset]`
+            before forwarding to the LA. Failure → error code 7351 (AccountNotWhitelistedErr, 400).
     importTxAccount:
-        type: object
-        required:
-            - finId
-        properties:
-            finId:
-              $ref: "#/components/schemas/finId"
+      type: object
+      required:
+        - finId
+      properties:
+        finId:
+          $ref: "#/components/schemas/finId"
     importTxAssetAccount:
       type: object
       description: 'describes account information'
-      required: [ account, asset ]
+      required: [account, asset]
       properties:
         account:
-            $ref: '#/components/schemas/importTxAccount'
+          $ref: '#/components/schemas/importTxAccount'
         asset:
           $ref: '#/components/schemas/finp2pAsset'
     importTxLedgerAssetAccount:
       type: object
       description: 'describes account information'
-      required: [ finp2pAccount ]
+      required: [finp2pAccount]
       properties:
         finp2pAccount:
           $ref: '#/components/schemas/importTxAssetAccount'
@@ -924,7 +1006,7 @@ components:
     # Intent Schemas
     intentType:
       type: string
-      enum: ['primarySale', 'buyingIntent', 'sellingIntent', 'loanIntent', 'redemptionIntent', 'privateOfferIntent', 'requestForTransferIntent']
+      enum: ['primarySale', 'buyingIntent', 'sellingIntent', 'loanIntent', 'redemptionIntent', 'privateOfferIntent', 'requestForTransferIntent', 'moveIntent']
     intent:
       type: object
       oneOf:
@@ -935,6 +1017,7 @@ components:
         - $ref: '#/components/schemas/redemptionIntent'
         - $ref: '#/components/schemas/privateOfferIntent'
         - $ref: '#/components/schemas/requestForTransferIntent'
+        - $ref: '#/components/schemas/moveIntent'
       discriminator:
         propertyName: type
         mapping:
@@ -945,6 +1028,7 @@ components:
           redemptionIntent: '#/components/schemas/redemptionIntent'
           privateOfferIntent: '#/components/schemas/privateOfferIntent'
           requestForTransferIntent: '#/components/schemas/requestForTransferIntent'
+          moveIntent: '#/components/schemas/moveIntent'
     primarySale:
       type: object
       required: [type, issuer, asset, settlement]
@@ -960,7 +1044,7 @@ components:
           $ref: '#/components/schemas/sellingSettlements'
     buyingIntent:
       type: object
-      required: [type, buyer, asset]
+      required: [type, buyer, asset, settlement]
       properties:
         type:
           type: string
@@ -1007,7 +1091,7 @@ components:
               manualPolicy: '#/components/schemas/manualSignaturePolicy'
     loanIntent:
       type: object
-      required: [type, creatorType, borrower, lender, asset]
+      required: [type, creatorType, borrower, lender, asset, settlement]
       properties:
         type:
           type: string
@@ -1034,7 +1118,7 @@ components:
               presignedPolicy: '#/components/schemas/presignedSignaturePolicy'
     redemptionIntent:
       type: object
-      required: [type, issuer, asset]
+      required: [type, issuer, asset, settlement]
       properties:
         type:
           type: string
@@ -1054,11 +1138,11 @@ components:
           discriminator:
             propertyName: type
             mapping:
-              preSignedPolicy: '#/components/schemas/presignedSignaturePolicy'
+              presignedPolicy: '#/components/schemas/presignedSignaturePolicy'
               manualPolicy: '#/components/schemas/manualSignaturePolicy'
     privateOfferIntent:
       type: object
-      required: [type, buyer, seller, asset]
+      required: [type, buyer, seller, asset, settlement]
       properties:
         type:
           type: string
@@ -1080,6 +1164,54 @@ components:
             mapping:
               presignedPolicy: '#/components/schemas/presignedSignaturePolicy'
               manualPolicy: '#/components/schemas/manualSignaturePolicy'
+    moveIntent:
+      type: object
+      # A Move intent carries no issuer — it is an org-level migration declared by
+      # the source asset's own organization (creation is restricted to that org).
+      required: [type, asset]
+      properties:
+        type:
+          type: string
+          enum: [moveIntent]
+        asset:
+          $ref: '#/components/schemas/moveAsset'
+        signaturePolicy:
+          oneOf:
+            - $ref: '#/components/schemas/presignedSignaturePolicy'
+            - $ref: '#/components/schemas/manualSignaturePolicy'
+          discriminator:
+            propertyName: type
+            mapping:
+              presignedPolicy: '#/components/schemas/presignedSignaturePolicy'
+              manualPolicy: '#/components/schemas/manualSignaturePolicy'
+    moveDestination:
+      type: object
+      description: 'a Move destination asset. Superset of finp2pAsset (same required id + ledgerIdentifier), plus an optional pre-funded pool the Transfer drains into the destination for the hold-transfer-* variants.'
+      required: [id, ledgerIdentifier]
+      properties:
+        id:
+          $ref: '#/components/schemas/resourceId'
+        ledgerIdentifier:
+          $ref: '#/components/schemas/ledgerAssetIdentifier'
+        fromSegregatedAccount:
+          $ref: '#/components/schemas/finIdAccount'
+        fromSegregatedAccountOwner:
+          description: 'owner of the pre-funded pool account — the Transfer seller (debited party) for receipts and regulation. Required when fromSegregatedAccount is set.'
+          $ref: '#/components/schemas/resourceId'
+    moveAsset:
+      type: object
+      description: 'asset-level migration path declared by the source asset''s organization; source + one-or-more destination assets (no quantity). Optional sourceToSegregatedAccount receives held source tokens on release (instead of burning); each destination may carry a pre-funded fromSegregatedAccount pool for the hold-transfer-* variants. The executor picks one destination at execution.'
+      required: [sourceAsset, destinationAssets]
+      properties:
+        sourceAsset:
+          $ref: '#/components/schemas/finp2pAsset'
+        destinationAssets:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/moveDestination'
+        sourceToSegregatedAccount:
+          $ref: '#/components/schemas/finIdAccount'
     requestForTransferIntent:
       type: object
       required: [type, sender, receiver, asset]
@@ -1129,7 +1261,7 @@ components:
           $ref: '#/components/schemas/destinationAccountAssetInstruction'
     issuingAsset:
       type: object
-      required: [ assetInstruction, assetTerm ]
+      required: [assetInstruction, assetTerm]
       properties:
         assetTerm:
           $ref: '#/components/schemas/assetTerm'
@@ -1137,7 +1269,7 @@ components:
           $ref: '#/components/schemas/sourceOnlyAssetDestinationAccountLedgerAssetInstruction'
     redemptionAsset:
       type: object
-      required: [ assetInstruction, assetTerm ]
+      required: [assetInstruction, assetTerm]
       properties:
         assetTerm:
           $ref: '#/components/schemas/assetTerm'
@@ -1153,7 +1285,7 @@ components:
           $ref: '#/components/schemas/borrowerLenderAccountAssetInstruction'
     loanExecuteAsset:
       type: object
-      required: [ assetInstruction, assetTerm ]
+      required: [assetInstruction, assetTerm]
       properties:
         assetTerm:
           $ref: '#/components/schemas/assetTerm'
@@ -1188,7 +1320,7 @@ components:
         $ref: '#/components/schemas/sellingSettlementBase'
     sellingSettlementBase:
       type: object
-      required: [settlementTerm, settlementInstruction]
+      required: [settlementTerm]
       properties:
         settlementTerm:
           $ref: '#/components/schemas/settlementTerm'
@@ -1201,7 +1333,7 @@ components:
         $ref: '#/components/schemas/buyingSettlementBase'
     buyingSettlementBase:
       type: object
-      required: [settlementInstruction, settlementTerm]
+      required: [settlementTerm]
       properties:
         settlementTerm:
           $ref: '#/components/schemas/settlementTerm'
@@ -1214,7 +1346,7 @@ components:
         $ref: '#/components/schemas/loanIntentSettlementBase'
     loanIntentSettlementBase:
       type: object
-      required: [settlementInstruction, settlementTerm]
+      required: [settlementTerm]
       properties:
         settlementTerm:
           $ref: '#/components/schemas/settlementTerm'
@@ -1234,29 +1366,29 @@ components:
         - $ref: '#/components/schemas/fullSettlementOption'
     partialSettlementOption:
       type: 'object'
-      required: [ 'type', 'unitValue' ]
+      required: ['type', 'unitValue']
       properties:
         type:
           type: 'string'
-          enum: [ 'partialSettlement' ]
+          enum: ['partialSettlement']
         unitValue:
           $ref: '#/components/schemas/unitValue'
     fullSettlementOption:
       type: 'object'
-      required: [ 'type', 'amount' ]
+      required: ['type', 'amount']
       properties:
         type:
           type: 'string'
-          enum: [ 'fullSettlement' ]
+          enum: ['fullSettlement']
         amount:
           $ref: '#/components/schemas/amount'
     noSettlementOption:
       type: 'object'
-      required: [ 'type' ]
+      required: ['type']
       properties:
         type:
           type: 'string'
-          enum: [ 'noSettlement' ]
+          enum: ['noSettlement']
     assetTerm:
       type: object
       required: [amount]
@@ -1285,7 +1417,7 @@ components:
           $ref: '#/components/schemas/finp2pAssetAccount'
     sourceDestinationAccountLedgerAssetInstruction:
       type: object
-      required: [ sourceAccount, destinationAccount ]
+      required: [sourceAccount, destinationAccount]
       properties:
         sourceAccount:
           $ref: '#/components/schemas/finp2pAssetAccount'
@@ -1293,7 +1425,7 @@ components:
           $ref: '#/components/schemas/finp2pAssetAccount'
     sourceOnlyAssetDestinationAccountLedgerAssetInstruction:
       type: object
-      required: [ sourceAccount, destinationAccount ]
+      required: [sourceAccount, destinationAccount]
       properties:
         sourceAccount:
           $ref: '#/components/schemas/finp2pAssetWithNoAccount'
@@ -1307,7 +1439,7 @@ components:
           $ref: '#/components/schemas/finp2pAssetAccountOptional'
     optionalDestinationAccountAssetInstruction:
       type: object
-      required: [ destinationAccount ]
+      required: [destinationAccount]
       properties:
         destinationAccount:
           $ref: '#/components/schemas/finp2pAssetAccountOptional'

--- a/skeleton/apis/dlt-adapter-api.yaml
+++ b/skeleton/apis/dlt-adapter-api.yaml
@@ -1,34 +1,34 @@
-openapi: 3.0.1
+openapi: '3.0.1'
 info:
-  title: Ledger Adapter Specification
-  description: This is the API specification for the Ledger Adapter with whom the FinP2P Router will interact in order to execute and query the underlying implementation.
+  title: 'Ledger Adapter Specification'
+  description: 'This is the API specification for the Ledger Adapter with whom the FinP2P Router will interact in order to execute and query the underlying implementation.'
   termsOfService: 'https://ownera.io/terms/'
   contact:
-    email: support@ownera.io
-  version: x.x.x
+    email: 'support@ownera.io'
+  version: 'x.x.x'
 tags:
-  - name: payments
-    description: Payments
-  - name: management
-    description: Management
-  - name: issuance
-    description: Issuance
-  - name: transactions
-    description: Transactions
-  - name: escrow
-    description: Escrow
-  - name: operations
-    description: Operations
-  - name: health
-    description: health
+  - name: 'payments'
+    description: 'Payments'
+  - name: 'management'
+    description: 'Management'
+  - name: 'issuance'
+    description: 'Issuance'
+  - name: 'transactions'
+    description: 'Transactions'
+  - name: 'escrow'
+    description: 'Escrow'
+  - name: 'operations'
+    description: 'Operations'
+  - name: 'health'
+    description: 'health'
 paths:
   /plan/approve:
     post:
       tags:
-        - execution
-      summary: Approve execution plan
-      description: Expects a ledger to approve the upcoming execution plan
-      operationId: approveExecutionPlan
+        - 'execution'
+      summary: 'Approve execution plan'
+      description: 'Expects a ledger to approve the upcoming execution plan'
+      operationId: 'approveExecutionPlan'
       requestBody:
         content:
           application/json:
@@ -36,24 +36,38 @@ paths:
               $ref: 'common-external-components.yaml#/components/schemas/ApproveExecutionPlanRequest'
       responses:
         '200':
-          description: successful operation
+          description: 'successful operation'
           content:
             application/json:
               schema:
                 $ref: 'common-external-components.yaml#/components/schemas/ApproveExecutionPlanResponse'
         '400':
-          description: Invalid Input
-          content: {}
+          description: 'Bad Request'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 1002
+                    message: 'Invalid request format'
         '500':
-          description: System error
-          content: {}
+          description: 'Internal Server Error'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 2202
+                    message: 'Internal service failure'
   /plan/proposal:
     post:
       tags:
-        - execution
-      summary: Approve a plan proposal plan
-      description: Request adapter approval or rejection to a proposal in an execution plan
-      operationId: executionPlanProposal
+        - 'execution'
+      summary: 'Approve a plan proposal plan'
+      description: 'Request adapter approval or rejection to a proposal in an execution plan'
+      operationId: 'executionPlanProposal'
       requestBody:
         content:
           application/json:
@@ -61,24 +75,38 @@ paths:
               $ref: 'common-external-components.yaml#/components/schemas/executionPlanProposalRequest'
       responses:
         '200':
-          description: successful operation
+          description: 'successful operation'
           content:
             application/json:
               schema:
                 $ref: 'common-external-components.yaml#/components/schemas/ApproveExecutionPlanResponse'
         '400':
-          description: Invalid Input
-          content: {}
+          description: 'Bad Request'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 1002
+                    message: 'Invalid request format'
         '500':
-          description: System error
-          content: {}
+          description: 'Internal Server Error'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 2202
+                    message: 'Internal service failure'
   /plan/proposal/status:
     post:
       tags:
-        - execution
-      summary: Notify the adapter on the agreement status (Approve/Rejected) for a specific proposal
-      description: notify the adapter on proposal status
-      operationId: executionPlanProposalStatus
+        - 'execution'
+      summary: 'Notify the adapter on the agreement status (Approve/Rejected) for a specific proposal'
+      description: 'notify the adapter on proposal status'
+      operationId: 'executionPlanProposalStatus'
       requestBody:
         content:
           application/json:
@@ -86,30 +114,44 @@ paths:
               $ref: 'common-external-components.yaml#/components/schemas/executionPlanProposalStatusRequest'
       responses:
         '200':
-          description: successful operation
+          description: 'successful operation'
           content: {}
         '204':
-          description: successful operation
+          description: 'successful operation'
           content: {}
         '400':
-          description: Invalid Input
-          content: {}
+          description: 'Bad Request'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 1002
+                    message: 'Invalid request format'
         '500':
-          description: System error
-          content: {}
+          description: 'Internal Server Error'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 2202
+                    message: 'Internal service failure'
   /payments/depositInstruction:
     post:
       tags:
-        - payments
-      summary: Deposit instruction
-      description: Create a deposit instruction for an owner
-      operationId: depositInstruction
+        - 'payments'
+      summary: 'Deposit instruction'
+      description: 'Create a deposit instruction for an owner'
+      operationId: 'depositInstruction'
       parameters:
-        - in: header
-          name: Idempotency-Key
-          description: hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds)
+        - in: 'header'
+          name: 'Idempotency-Key'
+          description: 'hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds)'
           schema:
-            type: string
+            type: 'string'
           required: true
       requestBody:
         content:
@@ -118,30 +160,44 @@ paths:
               $ref: '#/components/schemas/DepositInstructionRequest'
       responses:
         '200':
-          description: successful operation
+          description: 'successful operation'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/DepositInstructionResponse'
         '400':
-          description: Invalid Input
-          content: {}
+          description: 'Bad Request'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 1002
+                    message: 'Invalid request format'
         '500':
-          description: System error
-          content: {}
+          description: 'Internal Server Error'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 2202
+                    message: 'Internal service failure'
   /payments/payout:
     post:
       tags:
-        - payments
-      summary: Payout request
-      description: Payout owner assets to external destination
-      operationId: payout
+        - 'payments'
+      summary: 'Payout request'
+      description: 'Payout owner assets to external destination'
+      operationId: 'payout'
       parameters:
-        - in: header
-          name: Idempotency-Key
-          description: hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds)
+        - in: 'header'
+          name: 'Idempotency-Key'
+          description: 'hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds)'
           schema:
-            type: string
+            type: 'string'
           required: true
       requestBody:
         content:
@@ -150,25 +206,39 @@ paths:
               $ref: '#/components/schemas/PayoutRequest'
       responses:
         '200':
-          description: successful operation
+          description: 'successful operation'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/PayoutResponse'
         '400':
-          description: Invalid Input
-          content: {}
+          description: 'Bad Request'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 1002
+                    message: 'Invalid request format'
         '500':
-          description: System error
-          content: {}
+          description: 'Internal Server Error'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 2202
+                    message: 'Internal service failure'
   /assets/getBalance:
     post:
       deprecated: true
       tags:
-        - transactions
-      summary: Get asset balance
-      description: Get asset balance for specified owner
-      operationId: getAssetBalance
+        - 'transactions'
+      summary: 'Get asset balance'
+      description: 'Get asset balance for specified owner'
+      operationId: 'getAssetBalance'
       requestBody:
         content:
           application/json:
@@ -176,30 +246,54 @@ paths:
               $ref: '#/components/schemas/GetAssetBalanceRequest'
       responses:
         '200':
-          description: successful operation
+          description: 'successful operation'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetAssetBalanceResponse'
+        '400':
+          description: 'Bad Request'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 1002
+                    message: 'Invalid request format'
         '404':
-          description: Owner not found
-          content: {}
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 1100
+                    message: 'Resource not found'
         '500':
-          description: System error
-          content: {}
+          description: 'Internal Server Error'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 2202
+                    message: 'Internal service failure'
   /assets/create:
     post:
       tags:
-        - management
-      summary: Create asset
-      description: Create a new asset
-      operationId: createAsset
+        - 'management'
+      summary: 'Create asset'
+      description: 'Create a new asset'
+      operationId: 'createAsset'
       parameters:
-        - in: header
-          name: Idempotency-Key
-          description: hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds)
+        - in: 'header'
+          name: 'Idempotency-Key'
+          description: 'hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds)'
           schema:
-            type: string
+            type: 'string'
           required: true
       requestBody:
         content:
@@ -208,30 +302,44 @@ paths:
               $ref: '#/components/schemas/CreateAssetRequest'
       responses:
         '200':
-          description: successful operation
+          description: 'successful operation'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/CreateAssetResponse'
         '400':
-          description: Invalid Input
-          content: {}
+          description: 'Bad Request'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 1002
+                    message: 'Invalid request format'
         '500':
-          description: System error
-          content: {}
+          description: 'Internal Server Error'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 2202
+                    message: 'Internal service failure'
   /assets/issue:
     post:
       tags:
-        - issuance
-      summary: Issue asset token
-      description: Issue specified amount of asset tokens for the owner
-      operationId: issueAssets
+        - 'issuance'
+      summary: 'Issue asset token'
+      description: 'Issue specified amount of asset tokens for the owner'
+      operationId: 'issueAssets'
       parameters:
-        - in: header
-          name: Idempotency-Key
-          description: hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds)
+        - in: 'header'
+          name: 'Idempotency-Key'
+          description: 'hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds)'
           schema:
-            type: string
+            type: 'string'
           required: true
       requestBody:
         content:
@@ -240,30 +348,44 @@ paths:
               $ref: '#/components/schemas/IssueAssetsRequest'
       responses:
         '200':
-          description: successful operation
+          description: 'successful operation'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/IssueAssetsResponse'
         '400':
-          description: Invalid Input
-          content: {}
+          description: 'Bad Request'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 1002
+                    message: 'Invalid request format'
         '500':
-          description: System error
-          content: {}
+          description: 'Internal Server Error'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 2202
+                    message: 'Internal service failure'
   /assets/redeem:
     post:
       tags:
-        - issuance
-      summary: Asset Token Redeem
-      description: Redeem existing asset token for new owner. Redeem of ownership is done by eliminating existing tokens owned by the owner.
-      operationId: redeemAssets
+        - 'issuance'
+      summary: 'Asset Token Redeem'
+      description: 'Redeem existing asset token for new owner. Redeem of ownership is done by eliminating existing tokens owned by the owner.'
+      operationId: 'redeemAssets'
       parameters:
-        - in: header
-          name: Idempotency-Key
-          description: hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds)
+        - in: 'header'
+          name: 'Idempotency-Key'
+          description: 'hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds)'
           schema:
-            type: string
+            type: 'string'
           required: true
       requestBody:
         content:
@@ -272,30 +394,90 @@ paths:
               $ref: '#/components/schemas/RedeemAssetsRequest'
       responses:
         '200':
-          description: successful operation
+          description: 'successful operation'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/RedeemAssetsResponse'
         '400':
-          description: Invalid Input
-          content: {}
+          description: 'Bad Request'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 1002
+                    message: 'Invalid request format'
         '500':
-          description: System error
-          content: {}
+          description: 'Internal Server Error'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 2202
+                    message: 'Internal service failure'
+  /assets/move:
+    post:
+      tags:
+        - 'transactions'
+      summary: 'Asset Token Move'
+      description: 'Move existing asset token to another ledger'
+      operationId: 'moveAssets'
+      parameters:
+        - in: 'header'
+          name: 'Idempotency-Key'
+          description: 'hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds)'
+          schema:
+            type: 'string'
+          required: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MoveAssetsRequest'
+      responses:
+        '200':
+          description: 'successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MoveAssetsResponse'
+        '400':
+          description: 'Bad Request'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 1002
+                    message: 'Invalid request format'
+        '500':
+          description: 'Internal Server Error'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 2202
+                    message: 'Internal service failure'
   /assets/transfer:
     post:
       tags:
-        - transactions
-      summary: Asset Token Transfer
-      description: Transfer existing asset token to a new owner. Transfer of ownership is done by eliminating existing tokens owned by the sender and creating new tokens with the new owner.
-      operationId: transferAsset
+        - 'transactions'
+      summary: 'Asset Token Transfer'
+      description: 'Transfer existing asset token to a new owner. Transfer of ownership is done by eliminating existing tokens owned by the sender and creating new tokens with the new owner.'
+      operationId: 'transferAsset'
       parameters:
-        - in: header
-          name: Idempotency-Key
-          description: hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds)
+        - in: 'header'
+          name: 'Idempotency-Key'
+          description: 'hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds)'
           schema:
-            type: string
+            type: 'string'
           required: true
       requestBody:
         content:
@@ -304,59 +486,204 @@ paths:
               $ref: '#/components/schemas/TransferAssetRequest'
       responses:
         '200':
-          description: successful operation
+          description: 'successful operation'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TransferAssetResponse'
         '400':
-          description: Invalid Input
-          content: {}
+          description: 'Bad Request'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 1002
+                    message: 'Invalid request format'
         '500':
-          description: System error
-          content: {}
-  /assets/receipts/{transactionId}:
-    get:
+          description: 'Internal Server Error'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 2202
+                    message: 'Internal service failure'
+  /accounts/create:
+    post:
       tags:
-        - transactions
-      summary: Get Receipt
-      description: Get asset transaction receipt
-      operationId: getReceipt
+        - 'management'
+      summary: 'Create or bind an investor account on this LA (Phase 1)'
+      description: |
+        Single LA-side endpoint covering both flows:
+
+        - **Create new** — `bindInfo` is absent. The LA generates a fresh wallet on the
+          asset's network.
+        - **Bind existing** — `bindInfo` carries the caller-supplied `networkAccount`
+          and `ownershipSignature` (proof-of-ownership hint).
+
+        The LA issues a **challenge** (signatureTemplate / walletConnect / deposit /
+        fireblocksApproval / …) which the user must fulfill. Two response shapes:
+
+        - `207 Multi-Status` — challenge ready immediately; body has `challenge` and
+          `operationResponseStrategy`.
+        - `202 Accepted` — LA needs more time; body has `cid` and
+          `operationResponseStrategy`. Asset node polls or awaits callback per strategy;
+          the challenge arrives via `GET /operations/status/{cid}`.
+
+        The `ledger.accounts.wallets` jsonb column is updated **only after challenge verification**.
+      operationId: 'createAccount'
       parameters:
-        - name: transactionId
-          in: path
-          description: ID of the asset transaction
-          required: true
+        - in: 'header'
+          name: 'Idempotency-Key'
+          description: 'hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds)'
           schema:
-            type: string
-            pattern: .*\S.*
+            type: 'string'
+          required: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateAccountRequest'
+        required: true
+      responses:
+        '202':
+          description: 'Challenge will be issued asynchronously; poll `/operations/status/{cid}`.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountOperationAccepted'
+        '207':
+          description: 'Challenge issued immediately as part of the response.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountOperationChallenge'
+  /accounts/{cid}/proof:
+    post:
+      tags:
+        - 'management'
+      summary: 'Submit signature proof for a signatureTemplate challenge (Phase 1)'
+      description: |
+        Used only when the challenge `type` is `signatureTemplate`. The asset node forwards
+        the client's signature; the LA verifies it against the challenge payload. Verification
+        outcome is reported via the workflow's normal response strategy.
+      operationId: 'submitAccountProof'
+      parameters:
+        - in: 'header'
+          name: 'Idempotency-Key'
+          description: 'hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds)'
+          schema:
+            type: 'string'
+          required: true
+        - name: 'cid'
+          in: 'path'
+          required: true
+          description: 'Correlation id of the account workflow.'
+          schema:
+            type: 'string'
+            x-allowEmpty: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubmitAccountProofRequest'
+        required: true
+      responses:
+        '200':
+          description: 'Proof accepted; verification continues per response strategy.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountOperationAccepted'
+  /accounts/{accountId}:
+    delete:
+      tags:
+        - 'management'
+      summary: 'Unbind an investor account (Phase 1)'
+      description: |
+        Removes the account entry from the `ledger.accounts.wallets` jsonb column. Async; cid in response.
+      operationId: 'removeAccount'
+      parameters:
+        - in: 'header'
+          name: 'Idempotency-Key'
+          description: 'hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds)'
+          schema:
+            type: 'string'
+          required: true
+        - name: 'accountId'
+          in: 'path'
+          required: true
+          description: 'LA-assigned account identifier.'
+          schema:
+            type: 'string'
+            pattern: '.*\S.*'
             x-autoMinLength: true
       responses:
         '200':
-          description: successful operation
+          description: 'successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountOperationAccepted'
+  /assets/receipts/{transactionId}:
+    get:
+      tags:
+        - 'transactions'
+      summary: 'Get Receipt'
+      description: 'Get asset transaction receipt'
+      operationId: 'getReceipt'
+      parameters:
+        - name: 'transactionId'
+          in: 'path'
+          description: 'ID of the asset transaction'
+          required: true
+          schema:
+            type: 'string'
+            pattern: '.*\S.*'
+            x-autoMinLength: true
+      responses:
+        '200':
+          description: 'successful operation'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetReceiptResponse'
         '404':
-          description: Transaction not found
-          content: {}
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 1100
+                    message: 'Resource not found'
         '500':
-          description: System error
-          content: {}
+          description: 'Internal Server Error'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 2202
+                    message: 'Internal service failure'
   /assets/hold:
     post:
       tags:
-        - escrow
-      summary: Hold Asset
-      description: Hold the owner asset
-      operationId: holdOperation
+        - 'escrow'
+      summary: 'Hold Asset'
+      description: 'Hold the owner asset'
+      operationId: 'holdOperation'
       parameters:
-        - in: header
-          name: Idempotency-Key
-          description: hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds)
+        - in: 'header'
+          name: 'Idempotency-Key'
+          description: 'hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds)'
           schema:
-            type: string
+            type: 'string'
           required: true
       requestBody:
         content:
@@ -365,30 +692,54 @@ paths:
               $ref: '#/components/schemas/HoldOperationRequest'
       responses:
         '200':
-          description: successful operation
+          description: 'successful operation'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HoldOperationResponse'
         '400':
-          description: Invalid Input
-          content: {}
+          description: 'Bad Request'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 1002
+                    message: 'Invalid request format'
+        '404':
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 1100
+                    message: 'Resource not found'
         '500':
-          description: System error
-          content: {}
+          description: 'Internal Server Error'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 2202
+                    message: 'Internal service failure'
   /assets/release:
     post:
       tags:
-        - escrow
-      summary: Release Asset
-      description: Release held assets
-      operationId: releaseOperation
+        - 'escrow'
+      summary: 'Release Asset'
+      description: 'Release held assets'
+      operationId: 'releaseOperation'
       parameters:
-        - in: header
-          name: Idempotency-Key
-          description: hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds)
+        - in: 'header'
+          name: 'Idempotency-Key'
+          description: 'hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds)'
           schema:
-            type: string
+            type: 'string'
           required: true
       requestBody:
         content:
@@ -397,30 +748,44 @@ paths:
               $ref: '#/components/schemas/ReleaseOperationRequest'
       responses:
         '200':
-          description: successful operation
+          description: 'successful operation'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ReleaseOperationResponse'
         '400':
-          description: Invalid Input
-          content: {}
+          description: 'Bad Request'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 1002
+                    message: 'Invalid request format'
         '500':
-          description: System error
-          content: {}
+          description: 'Internal Server Error'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 2202
+                    message: 'Internal service failure'
   /assets/rollback:
     post:
       tags:
-        - escrow
-      summary: Rollback held asset
-      description: Release back held asset to the owner
-      operationId: rollbackOperation
+        - 'escrow'
+      summary: 'Rollback held asset'
+      description: 'Release back held asset to the owner'
+      operationId: 'rollbackOperation'
       parameters:
-        - in: header
-          name: Idempotency-Key
-          description: hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds)
+        - in: 'header'
+          name: 'Idempotency-Key'
+          description: 'hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds)'
           schema:
-            type: string
+            type: 'string'
           required: true
       requestBody:
         content:
@@ -429,52 +794,80 @@ paths:
               $ref: '#/components/schemas/RollbackOperationRequest'
       responses:
         '200':
-          description: successful operation
+          description: 'successful operation'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/RollbackOperationResponse'
         '400':
-          description: Invalid Input
-          content: {}
+          description: 'Bad Request'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 1002
+                    message: 'Invalid request format'
         '500':
-          description: System error
-          content: {}
+          description: 'Internal Server Error'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 2202
+                    message: 'Internal service failure'
   /operations/status/{cid}:
     get:
       tags:
-        - operations
+        - 'operations'
       summary: 'Get Operation Status'
       description: 'Get the operation status by an operation correlation id'
-      operationId: getOperation
+      operationId: 'getOperation'
       parameters:
-        - name: cid
-          in: path
+        - name: 'cid'
+          in: 'path'
           description: 'correlation id of an operation'
           required: true
           schema:
-            type: string
+            type: 'string'
             x-allowEmpty: true
       responses:
         '200':
-          description: successful operation
+          description: 'successful operation'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetOperationStatusResponse'
         '404':
-          description: Transaction not found
-          content: {}
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 1100
+                    message: 'Resource not found'
         '500':
-          description: System error
-          content: {}
+          description: 'Internal Server Error'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 2202
+                    message: 'Internal service failure'
   /asset/balance:
     post:
       tags:
-        - transactions
-      summary: Get asset balance information
-      description: Get asset balance information for finId
-      operationId: GetAssetBalanceInfo
+        - 'transactions'
+      summary: 'Get asset balance information'
+      description: 'Get asset balance information for finId'
+      operationId: 'GetAssetBalanceInfo'
       requestBody:
         required: true
         content:
@@ -483,57 +876,78 @@ paths:
               $ref: '#/components/schemas/AssetBalanceInfoRequest'
       responses:
         '200':
-          description: successful operation
+          description: 'successful operation'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/AssetBalanceInfoResponse'
+        '400':
+          description: 'Bad Request'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 1002
+                    message: 'Invalid request format'
         '404':
-          description: Owner not found
-          content: {}
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 1100
+                    message: 'Resource not found'
         '500':
-          description: System error
-          content: {}
+          description: 'Internal Server Error'
+          content:
+            application/json:
+              schema:
+                $ref: 'common-external-components.yaml#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - code: 2202
+                    message: 'Internal service failure'
   /health:
     get:
-      summary: Health check
-      description: Returns the health status of the service.
-      operationId: getHealth
+      summary: 'Health check'
+      description: 'Returns the health status of the service.'
+      operationId: 'getHealth'
       tags:
-        - health
+        - 'health'
       responses:
         '200':
-          description: Service is healthy
+          description: 'Service is healthy'
           content:
             application/json:
               schema:
-                type: object
+                type: 'object'
                 properties:
                   status:
-                    type: string
-                    example: ok
-                    pattern: .*\S.*
+                    type: 'string'
+                    example: 'ok'
+                    pattern: '.*\S.*'
                     x-autoMinLength: true
         '503':
-          description: Service is unavailable
+          description: 'Service is unavailable'
           content:
             application/json:
               schema:
-                type: object
+                type: 'object'
                 properties:
                   status:
-                    type: string
-                    example: unavailable
-                    pattern: .*\S.*
+                    type: 'string'
+                    example: 'unavailable'
+                    pattern: '.*\S.*'
                     x-autoMinLength: true
 components:
   schemas:
     DepositInstructionRequest:
-      type: object
-      required:
-        - destination
-        - owner
-        - asset
+      type: 'object'
+      required: ['destination', 'owner', 'asset']
       properties:
         destination:
           $ref: '#/components/schemas/depositPayoutAccount'
@@ -542,12 +956,12 @@ components:
         asset:
           $ref: 'common-external-components.yaml#/components/schemas/depositAsset'
         amount:
-          type: string
-          description: Amount to deposit
-          pattern: .*\S.*
+          type: 'string'
+          description: 'Amount to deposit'
+          pattern: '.*\S.*'
           x-autoMinLength: true
         details:
-          type: object
+          type: 'object'
         nonce:
           $ref: 'common-external-components.yaml#/components/schemas/nonce'
         signature:
@@ -556,20 +970,17 @@ components:
       allOf:
         - $ref: '#/components/schemas/depositOperation'
     PayoutRequest:
-      type: object
-      required:
-        - source
-        - quantity
-        - asset
+      type: 'object'
+      required: ['source', 'quantity', 'asset']
       properties:
         source:
           $ref: '#/components/schemas/depositPayoutAccount'
         destination:
           $ref: '#/components/schemas/depositPayoutAccount'
         quantity:
-          type: string
+          type: 'string'
           description: 'How many units of the asset'
-          pattern: .*\S.*
+          pattern: '.*\S.*'
           x-autoMinLength: true
         payoutInstruction:
           $ref: '#/components/schemas/payoutInstruction'
@@ -583,9 +994,8 @@ components:
       allOf:
         - $ref: '#/components/schemas/receiptOperation'
     GetAssetBalanceRequest:
-      type: object
-      required:
-        - owner
+      type: 'object'
+      required: ['owner']
       properties:
         owner:
           $ref: '#/components/schemas/account'
@@ -593,13 +1003,12 @@ components:
       allOf:
         - $ref: '#/components/schemas/balance'
     CreateAssetRequest:
-      type: object
-      required:
-        - asset
+      type: 'object'
+      required: ['asset']
       properties:
         metadata:
-          type: object
-          description: The asset metadata
+          type: 'object'
+          description: 'The asset metadata'
           additionalProperties: true
         asset:
           $ref: 'common-external-components.yaml#/components/schemas/finp2pAssetBase'
@@ -614,35 +1023,29 @@ components:
     CreateAssetResponse:
       allOf:
         - $ref: 'common-external-components.yaml#/components/schemas/OperationBase'
-        - type: object
+        - type: 'object'
           properties:
             error:
               $ref: '#/components/schemas/createAssetOperationErrorInformation'
             response:
               $ref: '#/components/schemas/assetCreateResponse'
     IssueAssetsRequest:
-      type: object
-      required:
-        - nonce
-        - destination
-        - quantity
-        - settlementRef
-        - signature
+      type: 'object'
+      required: ['nonce', 'destination', 'quantity', 'settlementRef', 'signature']
       properties:
         nonce:
           $ref: 'common-external-components.yaml#/components/schemas/nonce'
         destination:
           $ref: '#/components/schemas/account'
         quantity:
-          type: string
+          type: 'string'
           description: 'How many units of the asset tokens'
-          pattern: .*\S.*
+          pattern: '.*\S.*'
           x-autoMinLength: true
         settlementRef:
-          type: string
+          type: 'string'
           description: 'Reference to the corresponding settlement operation'
-          pattern: .*\S.*
-          x-autoMinLength: true
+          x-allowEmpty: true
         signature:
           $ref: '#/components/schemas/signature'
         executionContext:
@@ -651,33 +1054,27 @@ components:
       allOf:
         - $ref: '#/components/schemas/receiptOperation'
     RedeemAssetsRequest:
-      type: object
-      required:
-        - nonce
-        - source
-        - quantity
-        - settlementRef
-        - signature
+      type: 'object'
+      required: ['nonce', 'source', 'quantity', 'settlementRef', 'signature']
       properties:
         nonce:
           $ref: 'common-external-components.yaml#/components/schemas/nonce'
         operationId:
-          type: string
+          type: 'string'
           x-go-type-skip-optional-pointer: true
-          pattern: .*\S.*
+          pattern: '.*\S.*'
           x-autoMinLength: true
         source:
           $ref: '#/components/schemas/account'
         quantity:
-          type: string
+          type: 'string'
           description: 'How many units of the asset tokens'
-          pattern: .*\S.*
+          pattern: '.*\S.*'
           x-autoMinLength: true
         settlementRef:
-          type: string
+          type: 'string'
           description: 'Reference to the corresponding payment operation'
-          pattern: .*\S.*
-          x-autoMinLength: true
+          x-allowEmpty: true
         signature:
           $ref: '#/components/schemas/signature'
         executionContext:
@@ -686,14 +1083,8 @@ components:
       allOf:
         - $ref: '#/components/schemas/receiptOperation'
     TransferAssetRequest:
-      type: object
-      required:
-        - nonce
-        - source
-        - destination
-        - quantity
-        - settlementRef
-        - signature
+      type: 'object'
+      required: ['nonce', 'source', 'destination', 'quantity', 'settlementRef', 'signature']
       properties:
         nonce:
           $ref: 'common-external-components.yaml#/components/schemas/nonce'
@@ -702,15 +1093,14 @@ components:
         destination:
           $ref: '#/components/schemas/account'
         quantity:
-          type: string
+          type: 'string'
           description: 'How many units of the asset tokens'
-          pattern: .*\S.*
+          pattern: '.*\S.*'
           x-autoMinLength: true
         settlementRef:
-          type: string
+          type: 'string'
           description: 'Reference to the corresponding payment operation'
-          pattern: .*\S.*
-          x-autoMinLength: true
+          x-allowEmpty: true
         signature:
           $ref: '#/components/schemas/signature'
         executionContext:
@@ -718,38 +1108,59 @@ components:
     TransferAssetResponse:
       allOf:
         - $ref: '#/components/schemas/receiptOperation'
-    GetReceiptResponse:
-      allOf:
-        - $ref: '#/components/schemas/receiptOperation'
-    HoldOperationRequest:
-      type: object
-      required:
-        - nonce
-        - operationId
-        - source
-        - quantity
-        - expiry
-        - signature
+    MoveAssetsRequest:
+      type: 'object'
+      required: ['nonce', 'source', 'destination', 'quantity', 'signature']
       properties:
         nonce:
           $ref: 'common-external-components.yaml#/components/schemas/nonce'
         operationId:
-          type: string
-          description: 'A unique operation ID assigned to the hold request, used to track and reference the asset for future release or rollback actions'
-          pattern: .*\S.*
+          type: 'string'
+          x-go-type-skip-optional-pointer: true
+          pattern: '.*\S.*'
           x-autoMinLength: true
         source:
           $ref: '#/components/schemas/account'
         destination:
           $ref: '#/components/schemas/account'
         quantity:
-          type: string
+          type: 'string'
           description: 'How many units of the asset tokens'
-          pattern: .*\S.*
+          pattern: '.*\S.*'
+          x-autoMinLength: true
+        signature:
+          $ref: '#/components/schemas/signature'
+        executionContext:
+          $ref: '#/components/schemas/executionContext'
+    MoveAssetsResponse:
+      allOf:
+        - $ref: '#/components/schemas/receiptOperation'
+    GetReceiptResponse:
+      allOf:
+        - $ref: '#/components/schemas/receiptOperation'
+    HoldOperationRequest:
+      type: 'object'
+      required: ['nonce', 'operationId', 'source', 'quantity', 'expiry', 'signature']
+      properties:
+        nonce:
+          $ref: 'common-external-components.yaml#/components/schemas/nonce'
+        operationId:
+          type: 'string'
+          description: 'A unique operation ID assigned to the hold request, used to track and reference the asset for future release or rollback actions'
+          pattern: '.*\S.*'
+          x-autoMinLength: true
+        source:
+          $ref: '#/components/schemas/account'
+        destination:
+          $ref: '#/components/schemas/account'
+        quantity:
+          type: 'string'
+          description: 'How many units of the asset tokens'
+          pattern: '.*\S.*'
           x-autoMinLength: true
         expiry:
-          type: integer
-          format: uint64
+          type: 'integer'
+          format: 'uint64'
           description: 'ttl expiry value indicating the escrow hold time limitation'
         signature:
           $ref: '#/components/schemas/signature'
@@ -759,26 +1170,22 @@ components:
       allOf:
         - $ref: '#/components/schemas/receiptOperation'
     ReleaseOperationRequest:
-      type: object
-      required:
-        - operationId
-        - source
-        - destination
-        - quantity
+      type: 'object'
+      required: ['operationId', 'source', 'destination', 'quantity']
       properties:
         operationId:
-          type: string
+          type: 'string'
           description: 'The operation ID from the hold request, required to authorize the asset release'
-          pattern: .*\S.*
+          pattern: '.*\S.*'
           x-autoMinLength: true
         source:
           $ref: '#/components/schemas/account'
         destination:
           $ref: '#/components/schemas/account'
         quantity:
-          type: string
+          type: 'string'
           description: 'How many units of the asset tokens'
-          pattern: .*\S.*
+          pattern: '.*\S.*'
           x-autoMinLength: true
         executionContext:
           $ref: '#/components/schemas/executionContext'
@@ -786,23 +1193,20 @@ components:
       allOf:
         - $ref: '#/components/schemas/receiptOperation'
     RollbackOperationRequest:
-      type: object
-      required:
-        - operationId
-        - source
-        - quantity
+      type: 'object'
+      required: ['operationId', 'source', 'quantity']
       properties:
         operationId:
-          type: string
+          type: 'string'
           description: 'The operation ID from the hold request, required to revert the asset hold'
-          pattern: .*\S.*
+          pattern: '.*\S.*'
           x-autoMinLength: true
         source:
           $ref: '#/components/schemas/account'
         quantity:
-          type: string
+          type: 'string'
           description: 'How many units of the asset tokens'
-          pattern: .*\S.*
+          pattern: '.*\S.*'
           x-autoMinLength: true
         executionContext:
           $ref: '#/components/schemas/executionContext'
@@ -810,359 +1214,552 @@ components:
       allOf:
         - $ref: '#/components/schemas/receiptOperation'
     GetOperationStatusRequest:
-      type: object
+      type: 'object'
       properties:
         cid:
-          type: string
+          type: 'string'
           description: 'correlation id of an operation'
           x-allowEmpty: true
     GetOperationStatusResponse:
       $ref: '#/components/schemas/operationStatus'
     depositInstruction:
-      required:
-        - account
-      type: object
+      required: ['account']
+      type: 'object'
       properties:
         account:
           $ref: '#/components/schemas/depositPayoutAccount'
         asset:
           $ref: 'common-external-components.yaml#/components/schemas/depositAsset'
         description:
-          type: string
+          type: 'string'
           description: 'Instructions for the deposit operation'
-          pattern: .*\S.*
+          pattern: '.*\S.*'
           x-autoMinLength: true
         paymentOptions:
           $ref: 'common-external-components.yaml#/components/schemas/paymentMethods'
         details:
           deprecated: true
-          type: object
-          description: Any addition deposit specific information, deprecated use "payment method options" instead fields
+          type: 'object'
+          description: 'Any addition deposit specific information, deprecated use "payment method options" instead fields'
         operationId:
-          type: string
-          description: operation id reference while will correlate with any receipt associated with the deposit operation
-          pattern: .*\S.*
+          type: 'string'
+          description: 'operation id reference while will correlate with any receipt associated with the deposit operation'
+          pattern: '.*\S.*'
           x-autoMinLength: true
     asset:
       allOf:
-        - type: object
-          required: [ledgerIdentifier]
+        - type: 'object'
+          required: ['ledgerIdentifier']
           properties:
             ledgerIdentifier:
-               $ref: 'common-external-components.yaml#/components/schemas/ledgerAssetIdentifier'
+              $ref: 'common-external-components.yaml#/components/schemas/ledgerAssetIdentifier'
         - $ref: 'common-external-components.yaml#/components/schemas/finp2pAssetBase'
     payoutAsset:
       $ref: 'common-external-components.yaml#/components/schemas/finp2pAsset'
     payoutInstruction:
-      type: object
-      required:
-        - description
+      type: 'object'
+      required: ['description']
       properties:
         description:
-          type: string
+          type: 'string'
           description: 'withdrawal description'
-          pattern: .*\S.*
+          pattern: '.*\S.*'
           x-autoMinLength: true
-
     account:
-      type: object
-      required:
-        - asset
-        - finId
+      type: 'object'
+      required: ['asset', 'finId']
       properties:
         asset:
           $ref: '#/components/schemas/asset'
         finId:
-          $ref: "common-external-components.yaml#/components/schemas/finId"
+          $ref: 'common-external-components.yaml#/components/schemas/finId'
         ledgerAccount:
           oneOf:
             - $ref: '#/components/schemas/walletLedgerAccount'
+            - $ref: '#/components/schemas/caip10LedgerAccount'
+            - $ref: '#/components/schemas/custodialLedgerAccount'
           discriminator:
-            propertyName: type
+            propertyName: 'type'
             mapping:
               walletAccount: '#/components/schemas/walletLedgerAccount'
-
+              caip10Account: '#/components/schemas/caip10LedgerAccount'
+              custodialAccount: '#/components/schemas/custodialLedgerAccount'
     walletLedgerAccount:
       $ref: 'common-external-components.yaml#/components/schemas/walletAccount'
-
+    caip10LedgerAccount:
+      $ref: 'common-external-components.yaml#/components/schemas/caip10Account'
+    custodialLedgerAccount:
+      $ref: 'common-external-components.yaml#/components/schemas/custodialAccount'
     depositPayoutAccount:
-      type: object
-      required:
-        - finId
-        - account
+      type: 'object'
+      required: ['finId', 'account']
       properties:
         finId:
-          $ref: "common-external-components.yaml#/components/schemas/finId"
+          $ref: 'common-external-components.yaml#/components/schemas/finId'
         account:
           oneOf:
             - $ref: '#/components/schemas/finIdAccountBase'
           discriminator:
-            propertyName: type
+            propertyName: 'type'
             mapping:
               finId: '#/components/schemas/finIdAccountBase'
     finIdAccountBase:
-      type: object
-      required:
-        - finId
-        - type
+      type: 'object'
+      required: ['finId', 'type']
       properties:
         type:
-          type: string
-          enum: ["finId"]
+          type: 'string'
+          enum: ['finId']
         finId:
-          $ref: "common-external-components.yaml#/components/schemas/finId"
+          $ref: 'common-external-components.yaml#/components/schemas/finId'
     balance:
-      type: object
-      required:
-        - asset
-        - balance
+      type: 'object'
+      required: ['asset', 'balance']
       properties:
         asset:
           $ref: '#/components/schemas/asset'
         balance:
-          type: string
-          description: the number of asset tokens
-          pattern: .*\S.*
+          type: 'string'
+          description: 'the number of asset tokens'
+          pattern: '.*\S.*'
           x-autoMinLength: true
     receiptOperation:
       allOf:
         - $ref: 'common-external-components.yaml#/components/schemas/OperationBase'
-        - type: object
+        - type: 'object'
           properties:
             error:
               $ref: '#/components/schemas/receiptOperationErrorInformation'
             response:
               $ref: '#/components/schemas/receipt'
+    # -------- Investor accounts (Phase 1) --------
+    CreateAccountRequest:
+      type: 'object'
+      description: |
+        Body for `POST /accounts/create`. Single LA-side endpoint covering both create-new
+        and bind-existing flows.
+
+        - **Create new** — omit `bindInfo`. The LA generates a wallet on the asset's network.
+        - **Bind existing** — populate `bindInfo` with the caller-supplied wallet and a
+          proof-of-ownership signature hint. The LA still issues a challenge for final verification.
+
+        The response is either `207` (challenge ready) or `202` (challenge pending) — see the
+        endpoint definition.
+      required: ['organizationId', 'assetId', 'finId']
+      properties:
+        organizationId:
+          type: 'string'
+          pattern: '.*\S.*'
+          x-autoMinLength: true
+        assetId:
+          type: 'string'
+          pattern: '.*\S.*'
+          x-autoMinLength: true
+        finId:
+          $ref: 'common-external-components.yaml#/components/schemas/finId'
+          description: |
+            The investor this account is being onboarded for, identified by their canonical
+            finId (hex-encoded compressed secp256k1 public key — the same identity that appears
+            on this investor's ledger operation legs). Resolved by the asset node from the
+            investor profile; lets the ledger adapter couple the resulting network account to
+            the investor so it can enforce wallet↔finId ownership on later operations. Required:
+            an investor without a resolvable finId cannot onboard a network account.
+        bindInfo:
+          $ref: '#/components/schemas/BindInfo'
+    BindInfo:
+      type: 'object'
+      description: |
+        Bind-info block. When present in `CreateAccountRequest`, signals the bind-existing flow.
+      required: ['networkAccount', 'ownershipSignature']
+      properties:
+        networkAccount:
+          $ref: 'common-external-components.yaml#/components/schemas/networkAccount'
+        ownershipSignature:
+          $ref: '#/components/schemas/signature'
+          description: |
+            Proof-of-ownership hint over the network account. The LA may verify this upfront,
+            but the authoritative ownership proof is the challenge-fulfillment step.
+    SubmitAccountProofRequest:
+      type: 'object'
+      description: |
+        Body for `POST /accounts/{cid}/proof`. Used only for `signatureTemplate` challenges.
+      required: ['ownershipSignature']
+      properties:
+        ownershipSignature:
+          $ref: '#/components/schemas/signature'
+          description: 'Signature over the LA''s `signatureTemplate` challenge payload.'
+    AccountOperationAccepted:
+      description: |
+        Returned for `202` and for `200` from `proof` / `delete`. When `isCompleted` is
+        false, the result is not yet available and `cid` lets the asset node poll
+        `/operations/status/{cid}` or receive a callback per `operationResponseStrategy`.
+        When the adapter completes the operation synchronously, `isCompleted` is true and
+        exactly one of `response` (the account it created) or `error` is present.
+      allOf:
+        - $ref: 'common-external-components.yaml#/components/schemas/OperationBase'
+        - type: 'object'
+          properties:
+            operationMetadata:
+              $ref: 'common-external-components.yaml#/components/schemas/OperationMetadata'
+            response:
+              $ref: '#/components/schemas/networkAccountRecord'
+            error:
+              $ref: '#/components/schemas/networkAccountOperationErrorInformation'
+            expiresInSeconds:
+              type: 'integer'
+              format: 'int64'
+              description: |
+                Onboarding deadline the ledger adapter grants for this create/bind, in
+                seconds from now. The asset node arms the workflow's whole-process timeout
+                from this value (set once, at acceptance). Omitted/zero => no auto-expiry.
+    AccountOperationChallenge:
+      description: |
+        Returned for `207` from `POST /accounts/create`. Structurally a superset of
+        AccountOperationAccepted (the router decodes both create responses into this
+        one type), adding the LA-issued challenge.
+      allOf:
+        - $ref: '#/components/schemas/AccountOperationAccepted'
+        - type: 'object'
+          required: ['challenge']
+          properties:
+            challenge:
+              $ref: '#/components/schemas/AccountChallenge'
+    AccountChallenge:
+      description: |
+        LA-issued challenge that the user must fulfill. Discriminated by `type`. New variants
+        can be added without breaking existing clients.
+      type: 'object'
+      required: ['type']
+      oneOf:
+        - $ref: '#/components/schemas/AccountChallengeWalletConnect'
+        - $ref: '#/components/schemas/AccountChallengeSignatureTemplate'
+        - $ref: '#/components/schemas/AccountChallengeDeposit'
+        - $ref: '#/components/schemas/AccountChallengeFireblocksApproval'
+      discriminator:
+        propertyName: 'type'
+        mapping:
+          walletConnect: '#/components/schemas/AccountChallengeWalletConnect'
+          signatureTemplate: '#/components/schemas/AccountChallengeSignatureTemplate'
+          deposit: '#/components/schemas/AccountChallengeDeposit'
+          fireblocksApproval: '#/components/schemas/AccountChallengeFireblocksApproval'
+    AccountChallengeWalletConnect:
+      type: 'object'
+      required: ['type', 'uri']
+      properties:
+        type: {type: 'string', enum: ['walletConnect']}
+        uri:
+          type: 'string'
+          description: 'WalletConnect URI or QR-encodable payload.'
+          pattern: '.*\S.*'
+          x-autoMinLength: true
+    AccountChallengeSignatureTemplate:
+      type: 'object'
+      required: ['type', 'payload']
+      properties:
+        type: {type: 'string', enum: ['signatureTemplate']}
+        payload:
+          type: 'string'
+          description: |
+            Hex-encoded data the client must sign with the wallet's private key and submit via
+            `POST /accounts/{cid}/proof`.
+          pattern: '.*\S.*'
+          x-autoMinLength: true
+    AccountChallengeDeposit:
+      type: 'object'
+      required: ['type', 'fromAddress', 'toAddress', 'amount']
+      properties:
+        type: {type: 'string', enum: ['deposit']}
+        fromAddress: {type: 'string', description: 'Address claimed by the user.', pattern: '.*\S.*', x-autoMinLength: true}
+        toAddress: {type: 'string', description: 'Destination address the LA watches.', pattern: '.*\S.*', x-autoMinLength: true}
+        amount: {type: 'string', description: 'Required deposit amount (string for precision).', pattern: '.*\S.*', x-autoMinLength: true}
+    AccountChallengeFireblocksApproval:
+      type: 'object'
+      required: ['type', 'fireblocksRequestId']
+      properties:
+        type: {type: 'string', enum: ['fireblocksApproval']}
+        fireblocksRequestId:
+          type: 'string'
+          description: 'Fireblocks-side request id; user approves in the Fireblocks app.'
+          pattern: '.*\S.*'
+          x-autoMinLength: true
+    networkAccountRecord:
+      description: |
+        Canonical account record returned on workflow completion via `GET /operations/status/{cid}`.
+      type: 'object'
+      required: ['id', 'networkAccount']
+      properties:
+        id:
+          type: 'string'
+          description: 'LA-assigned account identifier.'
+          pattern: '.*\S.*'
+          x-autoMinLength: true
+        networkAccount:
+          $ref: 'common-external-components.yaml#/components/schemas/networkAccount'
     createAssetOperation:
       allOf:
         - $ref: 'common-external-components.yaml#/components/schemas/OperationBase'
-        - type: object
+        - type: 'object'
           properties:
             error:
               $ref: '#/components/schemas/createAssetOperationErrorInformation'
             response:
               $ref: '#/components/schemas/assetCreateResponse'
     assetCreateResponse:
-      type: object
-      required:
-        - ledgerAssetInfo
+      type: 'object'
+      required: ['ledgerAssetInfo']
       properties:
         ledgerAssetInfo:
           $ref: '#/components/schemas/ledgerAssetInfo'
     depositOperation:
       allOf:
         - $ref: 'common-external-components.yaml#/components/schemas/OperationBase'
-        - type: object
+        - type: 'object'
           properties:
             error:
               $ref: '#/components/schemas/depositOperationErrorInformation'
             response:
               $ref: '#/components/schemas/depositInstruction'
     depositOperationErrorInformation:
-      type: object
+      type: 'object'
       properties:
         code:
-          type: integer
-          format: uint32
+          type: 'integer'
+          format: 'uint32'
+          description: '1 for failure in regApps validation, 4 failure in signature verification'
         message:
-          type: string
-          pattern: .*\S.*
-          x-autoMinLength: true
+          type: 'string'
+          x-allowEmpty: true
+        regulationErrorDetails:
+          type: 'array'
+          items:
+            $ref: 'common-external-components.yaml#/components/schemas/RegulationError'
     createAssetOperationErrorInformation:
-      type: object
+      type: 'object'
       properties:
         code:
-          type: integer
-          format: uint32
+          type: 'integer'
+          format: 'uint32'
         message:
-          type: string
-          pattern: .*\S.*
+          type: 'string'
+          pattern: '.*\S.*'
           x-autoMinLength: true
     receiptOperationErrorInformation:
-      type: object
-      required:
-        - code
-        - message
+      type: 'object'
+      required: ['code', 'message']
       properties:
         code:
-          type: integer
-          format: uint32
-          description: 1 for failure in regApps validation, 4 failure in signature verification
+          type: 'integer'
+          format: 'uint32'
+          description: '1 for failure in regApps validation, 4 failure in signature verification'
         message:
-          type: string
-          pattern: .*\S.*
+          type: 'string'
+          pattern: '.*\S.*'
           x-autoMinLength: true
         regulationErrorDetails:
-          type: array
+          type: 'array'
           items:
             $ref: 'common-external-components.yaml#/components/schemas/RegulationError'
     executionOperationErrorInformation:
-      type: object
+      type: 'object'
       properties: {}
     executionContext:
-      type: object
-      required:
-        - executionPlanId
-        - instructionSequenceNumber
+      type: 'object'
+      required: ['executionPlanId', 'instructionSequenceNumber']
       properties:
         executionPlanId:
-          type: string
-          description: execution plan id
-          pattern: .*\S.*
+          type: 'string'
+          description: 'execution plan id'
+          pattern: '.*\S.*'
           x-autoMinLength: true
         instructionSequenceNumber:
-          type: integer
-          format: uint32
-          description: execution instruction sequence number
+          type: 'integer'
+          format: 'uint32'
+          description: 'execution instruction sequence number'
     operationStatus:
-      type: object
+      type: 'object'
       oneOf:
         - $ref: '#/components/schemas/operationStatusCreateAsset'
         - $ref: '#/components/schemas/operationStatusDeposit'
         - $ref: '#/components/schemas/operationStatusReceipt'
         - $ref: '#/components/schemas/operationStatusApproval'
+        - $ref: '#/components/schemas/operationStatusAccount'
       discriminator:
-        propertyName: type
+        propertyName: 'type'
         mapping:
           createAsset: '#/components/schemas/operationStatusCreateAsset'
           deposit: '#/components/schemas/operationStatusDeposit'
           receipt: '#/components/schemas/operationStatusReceipt'
           approval: '#/components/schemas/operationStatusApproval'
+          account: '#/components/schemas/operationStatusAccount'
     operationStatusCreateAsset:
-      type: object
-      required:
-        - type
-        - operation
+      type: 'object'
+      required: ['type', 'operation']
       properties:
         type:
-          type: string
-          enum: [createAsset]
+          type: 'string'
+          enum: ['createAsset']
         operation:
           $ref: '#/components/schemas/createAssetOperation'
     operationStatusDeposit:
-      type: object
-      required:
-        - type
-        - operation
+      type: 'object'
+      required: ['type', 'operation']
       properties:
         type:
-          type: string
-          enum: [deposit]
+          type: 'string'
+          enum: ['deposit']
         operation:
           $ref: '#/components/schemas/depositOperation'
     operationStatusReceipt:
-      type: object
-      required:
-        - type
-        - operation
+      type: 'object'
+      required: ['type', 'operation']
       properties:
         type:
-          type: string
-          enum: [receipt]
+          type: 'string'
+          enum: ['receipt']
         operation:
           $ref: '#/components/schemas/receiptOperation'
     operationStatusApproval:
-      type: object
-      required:
-        - type
-        - operation
+      type: 'object'
+      required: ['type', 'operation']
       properties:
         type:
-          type: string
-          enum: [approval]
+          type: 'string'
+          enum: ['approval']
         operation:
           $ref: 'common-external-components.yaml#/components/schemas/ExecutionPlanApprovalOperation'
+    operationStatusAccount:
+      type: 'object'
+      required: ['type', 'operation']
+      properties:
+        type:
+          type: 'string'
+          enum: ['account']
+        operation:
+          $ref: '#/components/schemas/networkAccountOperation'
+    networkAccountOperation:
+      description: |
+        Status of an investor network-account create/bind/unbind operation, polled via
+        `GET /operations/status/{cid}`. While a challenge is outstanding, `challenge` is
+        present; on completion `response` carries the canonical `{ id, wallet }`; on failure
+        `error` carries the LA-level code/message.
+      allOf:
+        - $ref: 'common-external-components.yaml#/components/schemas/OperationBase'
+        - type: 'object'
+          properties:
+            challenge:
+              $ref: '#/components/schemas/AccountChallenge'
+            response:
+              $ref: '#/components/schemas/networkAccountRecord'
+            error:
+              $ref: '#/components/schemas/networkAccountOperationErrorInformation'
+            expiresInSeconds:
+              type: 'integer'
+              format: 'int64'
+              description: |
+                Onboarding deadline the ledger adapter grants, in seconds from now, when it
+                supplies (or revises) one on this status — e.g. alongside a challenge delivered
+                via callback in proxy mode, where the adapter's own deadline could not ride the
+                proxy's immediate acceptance. The asset node re-arms the workflow deadline from
+                a non-zero value. Omitted/zero => previously armed deadline stands.
+    networkAccountOperationErrorInformation:
+      type: 'object'
+      required: ['code', 'message']
+      properties:
+        code:
+          type: 'integer'
+          format: 'uint32'
+        message:
+          type: 'string'
+          pattern: '.*\S.*'
+          x-autoMinLength: true
     signature:
-      type: object
-      required: [signature, template, hashFunc]
+      type: 'object'
+      required: ['signature', 'template', 'hashFunc']
       description: 'represent a signature template information'
       properties:
         signature:
-          type: string
+          type: 'string'
           description: 'hex representation of the signature'
-          pattern: .*\S.*
-          x-autoMinLength: true
+          x-allowEmpty: true
         template:
           $ref: '#/components/schemas/signatureTemplate'
         hashFunc:
           $ref: '#/components/schemas/hashFunction'
     signatureTemplate:
-      type: object
+      type: 'object'
       oneOf:
         - $ref: '#/components/schemas/hashListTemplate'
         - $ref: '#/components/schemas/EIP712Template'
       discriminator:
-        propertyName: type
+        propertyName: 'type'
         mapping:
           hashList: '#/components/schemas/hashListTemplate'
           EIP712: '#/components/schemas/EIP712Template'
     hashListTemplate:
       description: 'ordered list of hash groups'
-      required: [type, hashGroups, hash]
-      type: object
+      required: ['type', 'hashGroups', 'hash']
+      type: 'object'
       properties:
         type:
-          type: string
-          enum: ["hashList"]
+          type: 'string'
+          enum: ['hashList']
         hashGroups:
-          type: array
+          type: 'array'
           items:
             $ref: '#/components/schemas/hashGroup'
         hash:
-          type: string
+          type: 'string'
           description: 'hex representation of the combined hash groups hash value'
           x-allowEmpty: true
+        templateVersion:
+          type: 'integer'
+          description: 'Template shape version. When omitted, the verifier resolves the version from the signature proof context.'
     hashGroup:
-      type: object
-      required:
-        - hash
-        - fields
+      type: 'object'
+      required: ['hash', 'fields']
       properties:
         hash:
-          type: string
+          type: 'string'
           description: 'hex representation of the hash group hash value'
           x-allowEmpty: true
         fields:
           description: 'list of fields by order they appear in the hash group'
-          type: array
+          type: 'array'
           items:
             $ref: '#/components/schemas/field'
     field:
-      type: object
+      type: 'object'
       description: 'describing a field in the hash group'
-      required:
-        - name
-        - type
-        - value
+      required: ['name', 'type', 'value']
       properties:
         name:
-          type: string
+          type: 'string'
           description: 'name of field'
-          pattern: .*\S.*
+          pattern: '.*\S.*'
           x-autoMinLength: true
         type:
-          type: string
-          enum: ["string", "int", "bytes"]
+          type: 'string'
+          enum: ['string', 'int', 'bytes']
           description: 'type of field'
         value:
-          type: string
+          type: 'string'
           description: 'hex representation of the field value'
           x-allowEmpty: true
     EIP712Domain:
-      type: object
+      type: 'object'
       properties:
         name:
-          type: string
+          type: 'string'
           x-allowEmpty: true
         version:
-          type: string
+          type: 'string'
           x-allowEmpty: true
         chainId:
-          type: integer
-          format: uint64
+          type: 'integer'
+          format: 'uint64'
         verifyingContract:
-          type: string
-          format: address
+          type: 'string'
+          format: 'address'
           x-allowEmpty: true
     EIP712TypedValue:
       oneOf:
@@ -1173,106 +1770,99 @@ components:
         - $ref: '#/components/schemas/EIP712TypeObject'
         - $ref: '#/components/schemas/EIP712TypeArray'
     EIP712Types:
-      type: object
+      type: 'object'
       properties:
         definitions:
-          type: array
+          type: 'array'
           items:
             $ref: '#/components/schemas/EIP712TypeDefinition'
     EIP712TypeDefinition:
-      type: object
+      type: 'object'
       properties:
         name:
-          type: string
+          type: 'string'
           x-allowEmpty: true
         fields:
-          type: array
+          type: 'array'
           items:
             $ref: '#/components/schemas/EIP712FieldDefinition'
     EIP712FieldDefinition:
-      type: object
+      type: 'object'
       properties:
         name:
-          type: string
+          type: 'string'
           x-allowEmpty: true
         type:
-          type: string
+          type: 'string'
           x-allowEmpty: true
     EIP712Template:
-      required: [type, domain, message, primaryType, types, hash]
-      type: object
+      required: ['type', 'domain', 'message', 'primaryType', 'types', 'hash']
+      type: 'object'
       properties:
         type:
-          type: string
-          enum: ["EIP712"]
+          type: 'string'
+          enum: ['EIP712']
         domain:
           $ref: '#/components/schemas/EIP712Domain'
         message:
-          type: object
+          type: 'object'
           additionalProperties:
             $ref: '#/components/schemas/EIP712TypedValue'
         types:
           $ref: '#/components/schemas/EIP712Types'
         primaryType:
-          type: string
+          type: 'string'
           x-allowEmpty: true
         hash:
-          type: string
+          type: 'string'
           description: 'hex representation of template hash'
           x-allowEmpty: true
+        templateVersion:
+          type: 'integer'
+          description: 'Template shape version. When omitted, the verifier resolves the version from the signature proof context.'
     EIP712TypeString:
-      type: string
+      type: 'string'
       pattern: '^(?:$|0([^x].*)?|[^0].*)$' # matches string that doesn't start with hexadecimal prefix
       x-allowEmpty: true
     EIP712TypeByte:
-      type: string
+      type: 'string'
       pattern: '^0x[0-9a-fA-F]+$' # matches hexadecimal string starting with '0x'
       minLength: 3
       maxLength: 320
     EIP712TypeInteger:
-      type: integer
+      type: 'integer'
     EIP712TypeBool:
-      type: boolean
+      type: 'boolean'
     EIP712TypeObject:
-      type: object
+      type: 'object'
       additionalProperties:
         $ref: '#/components/schemas/EIP712TypedValue'
     EIP712TypeArray:
-      type: array
+      type: 'array'
       items:
         $ref: '#/components/schemas/EIP712TypedValue'
     hashFunction:
-      type: string
-      enum:
-        - unspecified
-        - sha3_256
-        - sha3-256
-        - blake2b
-        - keccak_256
-        - keccak-256
-      description: hash function types
+      type: 'string'
+      enum: ['unspecified', 'sha3_256', 'sha3-256', 'blake2b', 'keccak_256', 'keccak-256']
+      description: 'hash function types'
     receipt:
-      type: object
-      required:
-        - id
-        - quantity
-        - timestamp
-        - tradeDetails
+      type: 'object'
+      required: ['id', 'quantity', 'timestamp', 'tradeDetails']
       properties:
         id:
-          type: string
-          description: the receipt id
-          pattern: .*\S.*
+          type: 'string'
+          description: 'the receipt id'
+          pattern: '.*\S.*'
           x-autoMinLength: true
         quantity:
-          type: string
+          type: 'string'
           description: 'How many units of the asset tokens'
-          pattern: .*\S.*
+          pattern: '.*\S.*'
           x-autoMinLength: true
         timestamp:
-          type: integer
-          format: int64
-          description: transaction timestamp
+          type: 'integer'
+          format: 'int64'
+          description: 'transaction timestamp'
         source:
           $ref: '#/components/schemas/account'
         destination:
@@ -1286,10 +1876,10 @@ components:
         proof:
           $ref: '#/components/schemas/proofPolicy'
     proofPolicy:
-      description: additional proof information attached to a receipt
-      type: object
+      description: 'additional proof information attached to a receipt'
+      type: 'object'
       discriminator:
-        propertyName: type
+        propertyName: 'type'
         mapping:
           signatureProofPolicy: '#/components/schemas/signatureProofPolicy'
           noProofPolicy: '#/components/schemas/noProofPolicy'
@@ -1297,95 +1887,92 @@ components:
         - $ref: '#/components/schemas/signatureProofPolicy'
         - $ref: '#/components/schemas/noProofPolicy'
     noProofPolicy:
-      type: object
-      required: [type]
+      type: 'object'
+      required: ['type']
       properties:
         type:
-          type: string
-          enum: ["noProofPolicy"]
-      description: "no proof validation required for this policy"
+          type: 'string'
+          enum: ['noProofPolicy']
+      description: 'no proof validation required for this policy'
     signatureProofPolicy:
-      type: object
-      required: [type]
+      type: 'object'
+      required: ['type']
       properties:
         type:
-          type: string
-          enum: ["signatureProofPolicy"]
+          type: 'string'
+          enum: ['signatureProofPolicy']
         signature:
           $ref: '#/components/schemas/signature'
     transactionDetails:
-      description: additional ledger specific
-      type: object
-      required:
-        - transactionId
+      description: 'additional ledger specific'
+      type: 'object'
+      required: ['transactionId']
       properties:
         transactionId:
-          type: string
-          description: The Transaction id on the underlying ledger
-          pattern: .*\S.*
+          type: 'string'
+          description: 'The Transaction id on the underlying ledger'
+          pattern: '.*\S.*'
           x-autoMinLength: true
         operationId:
-          type: string
-          description: The Operation id
-          pattern: .*\S.*
+          type: 'string'
+          description: 'The Operation id'
+          pattern: '.*\S.*'
           x-autoMinLength: true
     operationType:
-      type: string
-      enum: ['issue', 'transfer', 'hold', 'release', 'redeem']
+      type: 'string'
+      enum: ['issue', 'transfer', 'hold', 'release', 'redeem', 'move']
     ledgerAssetInfo:
-      type: object
-      required: [ledgerIdentifier]
+      type: 'object'
+      required: ['ledgerIdentifier']
       properties:
         ledgerIdentifier:
-           $ref: 'common-external-components.yaml#/components/schemas/ledgerAssetIdentifier'
+          $ref: 'common-external-components.yaml#/components/schemas/ledgerAssetIdentifier'
         ledgerReference:
           oneOf:
             - $ref: '#/components/schemas/contractDetails'
           discriminator:
-            propertyName: type
+            propertyName: 'type'
             mapping:
               contractDetails: '#/components/schemas/contractDetails'
     contractDetails:
-      type: object
-      required: [address, type]
+      type: 'object'
+      required: ['address', 'type']
       properties:
         type:
-          type: string
+          type: 'string'
           description: 'the type of the identifier'
-          enum: ["contractDetails"]
-          pattern: .*\S.*
+          enum: ['contractDetails']
+          pattern: '.*\S.*'
           x-autoMinLength: true
         address:
-          type: string
+          type: 'string'
           description: 'the address'
-          pattern: .*\S.*
+          pattern: '.*\S.*'
           x-autoMinLength: true
         TokenStandard:
-          type: string
+          type: 'string'
           description: 'The standard of the token (e.g., ERC20, ERC721)'
-          pattern: .*\S.*
+          pattern: '.*\S.*'
           x-autoMinLength: true
         additionalContractDetails:
           anyOf:
             - $ref: '#/components/schemas/finP2PEVMOperatorDetails'
     finP2PEVMOperatorDetails:
-      type: object
+      type: 'object'
       properties:
         FinP2POperatorContractAddress:
-          type: string
+          type: 'string'
           description: 'The FinP2P Operator Contract Address'
-          pattern: .*\S.*
+          pattern: '.*\S.*'
           x-autoMinLength: true
         allowanceRequired:
-          type: boolean
+          type: 'boolean'
           description: 'Indicates if allowance is required'
     ledgerAssetBinding:
       $ref: 'common-external-components.yaml#/components/schemas/ledgerAssetIdentifier'
     AssetBalanceInfoRequest:
-      type: object
-      required:
-        - account
-        - asset
+      type: 'object'
+      required: ['account', 'asset']
       properties:
         account:
           $ref: '#/components/schemas/assetBalanceAccount'
@@ -1396,9 +1983,9 @@ components:
     assetBalanceAccount:
       $ref: '#/components/schemas/finIdAccountBase'
     balanceMarker:
-      description: marker of balance to denote the balance as of marker
+      description: 'marker of balance to denote the balance as of marker'
       discriminator:
-        propertyName: type
+        propertyName: 'type'
         mapping:
           timestamp: '#/components/schemas/balanceMarkerTimestamp'
           transactionBlock: '#/components/schemas/balanceMarkerTransactionBlock'
@@ -1406,35 +1993,33 @@ components:
         - $ref: '#/components/schemas/balanceMarkerTimestamp'
         - $ref: '#/components/schemas/balanceMarkerTransactionBlock'
     balanceMarkerTimestamp:
-      type: object
-      required: [type, timestamp]
+      type: 'object'
+      required: ['type', 'timestamp']
       properties:
         type:
-          type: string
-          enum: [timestamp]
+          type: 'string'
+          enum: ['timestamp']
         timestamp:
-          type: integer
-          format: int64
-          description: epoch timestamp in seconds
+          type: 'integer'
+          format: 'int64'
+          description: 'epoch timestamp in seconds'
     balanceMarkerTransactionBlock:
-      type: object
-      required: [type, blockNumber, transaction]
+      type: 'object'
+      required: ['type', 'blockNumber', 'transaction']
       properties:
         type:
-          type: string
-          enum: [transactionBlock]
+          type: 'string'
+          enum: ['transactionBlock']
         blockNumber:
-          type: integer
-          format: int64
+          type: 'integer'
+          format: 'int64'
         transaction:
-          type: string
-          pattern: .*\S.*
+          type: 'string'
+          pattern: '.*\S.*'
           x-autoMinLength: true
     AssetBalanceInfoResponse:
-      type: object
-      required:
-        - account
-        - asset
+      type: 'object'
+      required: ['account', 'asset']
       properties:
         account:
           $ref: '#/components/schemas/assetBalanceAccount'
@@ -1443,35 +2028,31 @@ components:
         balanceInfo:
           $ref: '#/components/schemas/assetBalance'
     assetBalance:
-      type: object
-      required:
-        - asset
-        - current
-        - available
-        - held
+      type: 'object'
+      required: ['asset', 'current', 'available', 'held']
       properties:
         asset:
           $ref: '#/components/schemas/asset'
         current:
-          type: string
+          type: 'string'
           format: '^-?\d+(\.\d+)?$'
-          description: The total amount currently in or owed by the account
-          pattern: .*\S.*
+          description: 'The total amount currently in or owed by the account'
+          pattern: '.*\S.*'
           x-autoMinLength: true
         available:
-          type: string
+          type: 'string'
           format: '^-?\d+(\.\d+)?$'
-          description: The amount immediately usable from the account
-          pattern: .*\S.*
+          description: 'The amount immediately usable from the account'
+          pattern: '.*\S.*'
           x-autoMinLength: true
         held:
-          type: string
+          type: 'string'
           format: '^-?\d+(\.\d+)?$'
-          description: The amount pending or on hold within the account
-          pattern: .*\S.*
+          description: 'The amount pending or on hold within the account'
+          pattern: '.*\S.*'
           x-autoMinLength: true
         receipts:
-          description: list of receipt associated with the balance info
-          type: array
+          description: 'list of receipt associated with the balance info'
+          type: 'array'
           items:
             $ref: '#/components/schemas/receipt'

--- a/skeleton/migrations/20260727060730_create_network_accounts_table.sql
+++ b/skeleton/migrations/20260727060730_create_network_accounts_table.sql
@@ -1,0 +1,46 @@
+-- +goose Up
+-- +goose StatementBegin
+-- +goose ENVSUB ON
+CREATE TABLE ${LEDGER_SCHEMA:-ledger_adapter}.network_accounts(
+  -- used by DELETE /accounts/{accountId}
+  account_id VARCHAR(255) PRIMARY KEY,
+  idempotency_key VARCHAR(255),
+  organization_id VARCHAR(255) NOT NULL,
+  asset_id VARCHAR(255) NOT NULL,
+  fin_id VARCHAR(255) NOT NULL,
+  account JSONB NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+CREATE UNIQUE INDEX network_accounts_org_asset_fin_id_idx
+  ON ${LEDGER_SCHEMA:-ledger_adapter}.network_accounts(organization_id, asset_id, fin_id);
+-- +goose ENVSUB OFF
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DO $$
+    DECLARE
+-- +goose ENVSUB ON
+        ledger_adapter_user TEXT := '${LEDGER_ADAPTER_USER:-}';
+        ledger_adapter_schema TEXT := '${LEDGER_SCHEMA:-ledger_adapter}';
+-- +goose ENVSUB OFF
+        users_exist BOOLEAN;
+    BEGIN
+        SELECT EXISTS(
+            SELECT 1 FROM pg_catalog.pg_roles
+            WHERE rolname = ledger_adapter_user
+        )
+        INTO users_exist;
+
+        IF users_exist THEN
+            EXECUTE format('GRANT SELECT, UPDATE, DELETE, INSERT ON TABLE %I.network_accounts TO %I;', ledger_adapter_schema, ledger_adapter_user);
+        END IF;
+    END $$;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+-- +goose ENVSUB ON
+DROP TABLE ${LEDGER_SCHEMA:-ledger_adapter}.network_accounts;
+-- +goose ENVSUB OFF
+-- +goose StatementEnd

--- a/skeleton/package-lock.json
+++ b/skeleton/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-  "version": "0.28.24",
+  "version": "0.28.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-      "version": "0.28.24",
+      "version": "0.28.25",
       "license": "TBD",
       "dependencies": {
         "axios": "1.11.0",
@@ -22,7 +22,7 @@
       "devDependencies": {
         "@babel/core": "^7.19.3",
         "@babel/preset-env": "^7.19.4",
-        "@owneraio/finp2p-client": "^0.28.6",
+        "@owneraio/finp2p-client": "^0.28.23",
         "@testcontainers/postgresql": "^11.8.0",
         "@types/express": "^4.17.13",
         "@types/jest": "^29.2.0",
@@ -2628,9 +2628,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-client": {
-      "version": "0.28.7",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-client/0.28.7/55adcf40750476d6542eba321e1ffdde355c1411",
-      "integrity": "sha512-VeuXp5A0VLx+UHQCrrzszdnUU9yytkm7Oym1zViaLRIumlPSBEpZ9V6vJD5CO2PScwrDHgisANGPZGJfsuMlRg==",
+      "version": "0.28.23",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-client/0.28.23/f752a49fbf48928577335bbc3895bafb63831a29",
+      "integrity": "sha512-Ap5IdgQ5w0w5VKEykQbh6pvo3nXZkGECLdXK8cvc/liGjCrUCLBLOYsCQfz+CH4tqZ8F2GXMh1BoybnjTcHqkg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/skeleton/package.json
+++ b/skeleton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-  "version": "0.28.24",
+  "version": "0.28.25",
   "description": "",
   "homepage": "https://ownera.io/",
   "main": "dist/index.js",
@@ -57,7 +57,7 @@
   "devDependencies": {
     "@babel/core": "^7.19.3",
     "@babel/preset-env": "^7.19.4",
-    "@owneraio/finp2p-client": "^0.28.6",
+    "@owneraio/finp2p-client": "^0.28.23",
     "@testcontainers/postgresql": "^11.8.0",
     "@types/express": "^4.17.13",
     "@types/jest": "^29.2.0",

--- a/skeleton/src/models/errors.ts
+++ b/skeleton/src/models/errors.ts
@@ -26,3 +26,47 @@ export class ConfigurationError extends Error {
     this.name = 'ConfigurationError';
   }
 }
+
+/** Requested capability is not supported by this adapter. Mapped to HTTP 501. */
+export class NotSupportedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'NotSupportedError';
+  }
+}
+
+/** The (organization, asset, account) key is already bound. Mapped to HTTP 409. */
+export class AccountAlreadyBoundError extends Error {
+
+  code: number;
+
+  constructor(message: string, code: number = 0) {
+    super(message);
+    this.name = 'AccountAlreadyBoundError';
+    this.code = code;
+  }
+}
+
+/** The supplied network account does not match the ledger's address shape. Mapped to HTTP 400. */
+export class AccountInvalidShapeError extends Error {
+
+  code: number;
+
+  constructor(message: string, code: number = 0) {
+    super(message);
+    this.name = 'AccountInvalidShapeError';
+    this.code = code;
+  }
+}
+
+/** No account operation / record for the given identifier. Mapped to HTTP 404. */
+export class AccountNotFoundError extends Error {
+
+  code: number;
+
+  constructor(message: string, code: number = 0) {
+    super(message);
+    this.name = 'AccountNotFoundError';
+    this.code = code;
+  }
+}

--- a/skeleton/src/models/errors.ts
+++ b/skeleton/src/models/errors.ts
@@ -35,7 +35,14 @@ export class NotSupportedError extends Error {
   }
 }
 
-/** The (organization, asset, account) key is already bound. Mapped to HTTP 409. */
+/**
+ * The (organization, asset, account) key is already bound. Mapped to HTTP 409.
+ *
+ * Not thrown by `NetworkAccountServiceImpl` and cannot be: a repeat create for
+ * the same finId replays the recorded binding instead of conflicting. Part of
+ * the error vocabulary for adapter implementations that want strict
+ * already-bound semantics instead.
+ */
 export class AccountAlreadyBoundError extends Error {
 
   code: number;
@@ -59,7 +66,13 @@ export class AccountInvalidShapeError extends Error {
   }
 }
 
-/** No account operation / record for the given identifier. Mapped to HTTP 404. */
+/**
+ * No account operation / record for the given identifier. Mapped to HTTP 404.
+ *
+ * Not thrown by `NetworkAccountServiceImpl`, which treats removing an absent
+ * account as success so router retries don't fail. Part of the error vocabulary
+ * for adapter implementations that want strict remove semantics instead.
+ */
 export class AccountNotFoundError extends Error {
 
   code: number;

--- a/skeleton/src/models/interfaces.ts
+++ b/skeleton/src/models/interfaces.ts
@@ -7,6 +7,7 @@ import {
   Source,
   ReceiptOperation, Balance, OperationStatus, PlanApprovalStatus, PlanProposal, DepositOperation, DepositAsset,
   AssetBind, AssetDenomination, AccountMapping,
+  AccountOperation, BindInfo, NetworkAccount,
 } from './model';
 
 
@@ -33,12 +34,12 @@ export interface TokenService {
 
   balance(asset: Asset, finId: string): Promise<Balance>;
 
-  issue(idempotencyKey: string, asset: Asset, destinationFinId: string, quantity: string, exCtx: ExecutionContext | undefined): Promise<ReceiptOperation>;
+  issue(idempotencyKey: string, asset: Asset, destination: Destination, quantity: string, exCtx: ExecutionContext | undefined): Promise<ReceiptOperation>;
 
   transfer(idempotencyKey: string, nonce: string, source: Source, destination: Destination, asset: Asset,
     quantity: string, signature: Signature, exCtx: ExecutionContext | undefined): Promise<ReceiptOperation>;
 
-  redeem(idempotencyKey: string, nonce: string, sourceFinId: string, asset: Asset, quantity: string, operationId: string | undefined,
+  redeem(idempotencyKey: string, nonce: string, source: Source, asset: Asset, quantity: string, operationId: string | undefined,
     signature: Signature, exCtx: ExecutionContext | undefined
   ): Promise<ReceiptOperation>
 
@@ -89,6 +90,43 @@ export interface AccountMappingService {
   saveAccount(finId: string, fields: Record<string, string>): Promise<AccountMapping>
 
   deleteAccount(finId: string, fieldName?: string): Promise<void>
+}
+
+/**
+ * Investor network-account onboarding (bind / unbind), sync trust model: the
+ * caller-supplied wallet is recorded without an ownership challenge — the same
+ * trust the old finId->wallet mapping API extended.
+ *
+ * Replaces the finId->wallet mapping API. The request carries the investor's
+ * finId, letting the adapter couple the binding to the investor and enforce
+ * wallet<->finId ownership on later operations; the wallet also still arrives
+ * per operation on the instruction leg (`Source.account` / `Destination.account`).
+ * The same address may be bound many times (omnibus: one shared wallet, many
+ * investors), but one investor holds at most one binding per (org, asset):
+ * a repeat create for the same finId replays the recorded binding.
+ *
+ * Both methods are single-call and terminal, so implementations may be wrapped
+ * in the workflow `createServiceProxy` like any other service.
+ */
+export interface NetworkAccountService {
+
+  /**
+   * Bind a caller-supplied investor account (bindInfo absent = create-new mode).
+   * `finId` identifies the investor being onboarded.
+   */
+  createAccount(idempotencyKey: string, organizationId: string, assetId: string,
+    finId: string, bindInfo: BindInfo | undefined): Promise<AccountOperation>
+
+  /** Unbind a previously bound account by its LA-assigned id. */
+  removeAccount(idempotencyKey: string, accountId: string): Promise<AccountOperation>
+}
+
+/**
+ * Optional pre-bind validator for network accounts (e.g. ledger address shape).
+ * Throw AccountInvalidShapeError to reject the binding.
+ */
+export interface NetworkAccountValidator {
+  validate(account: NetworkAccount): Promise<void>
 }
 
 /**

--- a/skeleton/src/models/model.ts
+++ b/skeleton/src/models/model.ts
@@ -12,9 +12,9 @@ export type LedgerAssetIdentifier = Caip19LedgerAssetIdentifier;
 
 export type Caip19LedgerAssetIdentifier = {
   assetIdentifierType: 'CAIP-19';
-  network: string;
+  network?: string;
   tokenId: string;
-  standard: string;
+  standard?: string;
 };
 
 // Per API spec, deposit assets are limited to 'finp2p' or 'custom' variants (no ledgerIdentifier)
@@ -69,8 +69,8 @@ export type Balance = {
 
 export type TokenIdentifier = {
   tokenId: string
-  network: string
-  standard: string
+  network?: string
+  standard?: string
 };
 
 
@@ -105,7 +105,8 @@ export type IntentType =
   | 'loanIntent'
   | 'redemptionIntent'
   | 'privateOfferIntent'
-  | 'requestForTransferIntent';
+  | 'requestForTransferIntent'
+  | 'moveIntent';
 
 
 
@@ -503,7 +504,76 @@ export const pendingDepositOperation = (correlationId: string, metadata: Operati
 
 // -------------------------------------------------------------------
 
-export type OperationStatus = ReceiptOperation | AssetCreationStatus | DepositOperation | PlanApprovalStatus;
+export type NetworkAccount = {
+  type: 'walletAccount';
+  address: string;
+} | {
+  type: 'none';
+};
+
+/** Canonical account record returned on onboarding completion. `id` is the LA-assigned
+ *  account identifier, later used by `DELETE /accounts/{accountId}`. */
+export type NetworkAccountRecord = {
+  id: string;
+  account: NetworkAccount;
+};
+
+export type BindInfo = {
+  account: NetworkAccount;
+  /** Proof-of-ownership hint supplied by the caller. Not verified in the trust
+   *  model — kept so implementations can log or opportunistically check it.
+   *  Absent when the caller sent no signature or one without a template (the
+   *  router forwards the raw investor hint with `template: null`). */
+  ownershipSignature?: Signature;
+};
+
+export type PendingAccountOperation = {
+  operation: 'account',
+  type: 'pending';
+  correlationId: string;
+  metadata: OperationMetadata | undefined;
+};
+
+export type SuccessfulAccountOperation = {
+  operation: 'account',
+  type: 'success';
+  correlationId: string;
+  record: NetworkAccountRecord;
+};
+
+export type FailedAccountOperation = {
+  operation: 'account',
+  type: 'failure';
+  correlationId: string;
+  error: ErrorDetails;
+};
+
+export type AccountOperation = PendingAccountOperation | SuccessfulAccountOperation | FailedAccountOperation;
+
+export const pendingAccountOperation = (correlationId: string, metadata: OperationMetadata | undefined): AccountOperation => ({
+  operation: 'account',
+  type: 'pending',
+  correlationId,
+  metadata,
+});
+
+export const successfulAccountOperation = (correlationId: string, record: NetworkAccountRecord): AccountOperation => ({
+  operation: 'account',
+  type: 'success',
+  correlationId,
+  record,
+});
+
+export const failedAccountOperation = (correlationId: string, code: number, message: string): AccountOperation => ({
+  operation: 'account',
+  type: 'failure',
+  correlationId,
+  error: { code, message },
+});
+
+// -------------------------------------------------------------------
+
+export type OperationStatus = ReceiptOperation | AssetCreationStatus | DepositOperation | PlanApprovalStatus | AccountOperation;
 
 
 // -------------------------------------------------------------------

--- a/skeleton/src/models/model.ts
+++ b/skeleton/src/models/model.ts
@@ -520,11 +520,12 @@ export type NetworkAccountRecord = {
 
 export type BindInfo = {
   account: NetworkAccount;
-  /** Proof-of-ownership hint supplied by the caller. Not verified in the trust
-   *  model — kept so implementations can log or opportunistically check it.
-   *  Absent when the caller sent no signature or one without a template (the
-   *  router forwards the raw investor hint with `template: null`). */
-  ownershipSignature?: Signature;
+  /** Raw hex proof-of-ownership hint supplied by the caller, as the router sends
+   *  it: a bare signature with no template and no hash function, since only the
+   *  challenge bytes are signed. Not verified in this trust model — kept so
+   *  implementations can log it or opportunistically check it themselves.
+   *  Absent only when the caller sent no signature at all. */
+  ownershipSignature?: string;
 };
 
 export type PendingAccountOperation = {

--- a/skeleton/src/plugins/mappers.ts
+++ b/skeleton/src/plugins/mappers.ts
@@ -10,7 +10,7 @@ import {
   Source,
 } from '../models';
 import { OpComponents } from '@owneraio/finp2p-client';
-import { contractDetailsOptToAPI, depositInstructionToAPI, tradeDetailsToAPI, transactionDetailsToAPI, proofPolicyOptToAPI } from '../routes';
+import { accountOperationToAPI, contractDetailsOptToAPI, depositInstructionToAPI, tradeDetailsToAPI, transactionDetailsToAPI, proofPolicyOptToAPI } from '../routes';
 
 const receiptToFinAPI = (receipt: Receipt): OpComponents['schemas']['receipt'] => {
   const { id, asset, source, destination, quantity, operationType, tradeDetails, transactionDetails, proof, timestamp } = receipt;
@@ -177,5 +177,10 @@ export const operationToFinAPI = (operationStatus: OperationStatus): OpComponent
       return planApprovalOperationToFinAPI(operationStatus);
     case 'receipt':
       return receiptOperationToFinAPI(operationStatus);
+    case 'account':
+      return {
+        type: 'account',
+        operation: accountOperationToAPI(operationStatus) as OpComponents['schemas']['networkAccountOperation'],
+      };
   }
 };

--- a/skeleton/src/routes/errors.ts
+++ b/skeleton/src/routes/errors.ts
@@ -1,6 +1,13 @@
 import { NextFunction, Request, Response } from 'express';
 import { logger } from '../helpers';
-import { BusinessError, ValidationError } from '../models';
+import {
+  AccountAlreadyBoundError,
+  AccountInvalidShapeError,
+  AccountNotFoundError,
+  BusinessError,
+  NotSupportedError,
+  ValidationError,
+} from '../models';
 import { components } from './model-gen';
 
 function isErrorWithStatusAndMessage(err: any): err is { status: number, message: string } {
@@ -30,7 +37,21 @@ const failureResponse = (code: number, message: string): errorResponse => {
   };
 };
 
+const apiErrors = (code: number, message: string): components['schemas']['APIErrors'] => {
+  return { errors: [{ code, message }] };
+};
+
 export const errorHandler = (err: any, req: Request, res: Response, next: NextFunction) => {
+  if (err instanceof AccountAlreadyBoundError) {
+    return res.status(409).json(apiErrors(err.code, err.message));
+  } else if (err instanceof AccountInvalidShapeError) {
+    return res.status(400).json(apiErrors(err.code, err.message));
+  } else if (err instanceof AccountNotFoundError) {
+    return res.status(404).json(apiErrors(err.code, err.message));
+  } else if (err instanceof NotSupportedError) {
+    return res.status(501).json(apiErrors(0, err.message));
+  }
+
   if (err instanceof ValidationError) {
     const { message } = err;
     return res.status(400).json(failureResponse(1, message));

--- a/skeleton/src/routes/mapping.ts
+++ b/skeleton/src/routes/mapping.ts
@@ -11,10 +11,10 @@ import {
   HashListTemplate, SignatureTemplate, PaymentMethod, PaymentMethodInstruction, WireDetails,
   AssetBind, AssetDenomination, LedgerReference, AdditionalContractDetails, LedgerAccount,
   AssetCreationResult, OperationMetadata, ValidationError, PlanProposal,
+  NetworkAccount, NetworkAccountRecord, BindInfo, AccountOperation,
 } from '../models';
 import { components } from './model-gen';
 import { LedgerAPI } from './index';
-import { logger } from '../helpers';
 
 export const assetFromAPI = (asset: components['schemas']['asset'] | components['schemas']['finp2pAsset']): Asset => {
   const assetId = 'resourceId' in asset ? asset.resourceId : asset.id;
@@ -41,7 +41,12 @@ export const depositAssetToAPI = (asset: DepositAsset): components['schemas']['d
 
 type AccountLike = components['schemas']['account'] | components['schemas']['depositPayoutAccount'];
 
-const ledgerAccountFromAPI = (ledgerAccount: components['schemas']['walletLedgerAccount']): LedgerAccount => {
+type LedgerAccountAPI =
+  components['schemas']['walletLedgerAccount']
+  | components['schemas']['caip10LedgerAccount']
+  | components['schemas']['custodialLedgerAccount'];
+
+const ledgerAccountFromAPI = (ledgerAccount: LedgerAccountAPI): LedgerAccount => {
   switch (ledgerAccount.type) {
     case 'walletAccount':
       return { type: ledgerAccount.type, address: ledgerAccount.address };
@@ -206,9 +211,9 @@ export const metadataToAPI = (metadata: OperationMetadata): components['schemas'
     case 'polling':
       return {
         operationResponseStrategy: {
-          type: 'random',
+          type: 'poll',
           polling: {
-            type: 'randomPollingInterval',
+            type: 'random',
           },
         },
       };
@@ -601,7 +606,6 @@ export const depositOperationToAPI = (op: DepositOperation): components['schemas
       return { isCompleted: false, cid, operationMetadata: metadataOptToAPI(metadata) };
     case 'failure':
       const { code, message } = op.error;
-      logger.error('Deposit failed', { code, message });
       return {
         isCompleted: true,
         cid: '',
@@ -613,6 +617,68 @@ export const depositOperationToAPI = (op: DepositOperation): components['schemas
         isCompleted: true,
         cid: '',
         response: depositInstructionToAPI(instruction),
+      };
+  }
+};
+
+export const networkAccountFromAPI = (account: components['schemas']['networkAccount']): NetworkAccount => {
+  if ('type' in account && account.type === 'walletAccount') {
+    return { type: 'walletAccount', address: account.address };
+  }
+  return { type: 'none' };
+};
+
+export const networkAccountToAPI = (account: NetworkAccount): components['schemas']['networkAccount'] => {
+  switch (account.type) {
+    case 'walletAccount':
+      return { type: 'walletAccount', address: account.address };
+    case 'none':
+      return {};
+  }
+};
+
+export const bindInfoOptFromAPI = (bindInfo: components['schemas']['BindInfo'] | undefined): BindInfo | undefined => {
+  if (!bindInfo) {
+    return undefined;
+  }
+  // The router forwards the caller's ownership hint as {signature, template: null}
+  // (finp2p-core builds Signature{Signature: hint} only) — it is unverified in the
+  // trust model, so anything signatureFromAPI can't parse maps to absent.
+  const { ownershipSignature } = bindInfo;
+  return {
+    account: networkAccountFromAPI(bindInfo.networkAccount),
+    ownershipSignature: ownershipSignature?.template ? signatureFromAPI(ownershipSignature) : undefined,
+  };
+};
+
+export const networkAccountRecordToAPI = (record: NetworkAccountRecord): components['schemas']['networkAccountRecord'] => {
+  return {
+    id: record.id,
+    networkAccount: networkAccountToAPI(record.account),
+  };
+};
+
+export const accountOperationToAPI = (op: AccountOperation): components['schemas']['networkAccountOperation'] => {
+  switch (op.type) {
+    case 'pending':
+      const { correlationId, metadata } = op;
+      return {
+        isCompleted: false,
+        cid: correlationId,
+        operationMetadata: metadataOptToAPI(metadata),
+      };
+    case 'success':
+      return {
+        isCompleted: true,
+        cid: op.correlationId,
+        response: networkAccountRecordToAPI(op.record),
+      };
+    case 'failure':
+      const { code, message } = op.error;
+      return {
+        isCompleted: true,
+        cid: op.correlationId,
+        error: { code, message },
       };
   }
 };
@@ -639,6 +705,12 @@ export const operationStatusToAPI = (op: OperationStatus): components['schemas']
       return {
         type: 'approval',
         operation: planApprovalOperationToAPI(op),
+      };
+
+    case 'account':
+      return {
+        type: 'account',
+        operation: accountOperationToAPI(op),
       };
   }
 };

--- a/skeleton/src/routes/mapping.ts
+++ b/skeleton/src/routes/mapping.ts
@@ -12,6 +12,7 @@ import {
   AssetBind, AssetDenomination, LedgerReference, AdditionalContractDetails, LedgerAccount,
   AssetCreationResult, OperationMetadata, ValidationError, PlanProposal,
   NetworkAccount, NetworkAccountRecord, BindInfo, AccountOperation,
+  AccountInvalidShapeError,
 } from '../models';
 import { components } from './model-gen';
 import { LedgerAPI } from './index';
@@ -622,10 +623,22 @@ export const depositOperationToAPI = (op: DepositOperation): components['schemas
 };
 
 export const networkAccountFromAPI = (account: components['schemas']['networkAccount']): NetworkAccount => {
-  if ('type' in account && account.type === 'walletAccount') {
-    return { type: 'walletAccount', address: account.address };
+  // noneAccount is the empty object, so there is no discriminator to switch on.
+  if (!('type' in account)) {
+    return { type: 'none' };
   }
-  return { type: 'none' };
+  switch (account.type) {
+    case 'walletAccount':
+      return { type: 'walletAccount', address: account.address };
+    default:
+      // caip10Account and custodialAccount are in the OAS union, but the domain
+      // model cannot represent them. Reject rather than degrade to `none`: a
+      // `none` binding is recorded and reported as success, the router
+      // whitelists it as `{}`, and every later operation naming the real
+      // account then fails 7351 AccountNotWhitelisted with nothing in the
+      // bind-time trail to explain why.
+      throw new AccountInvalidShapeError(`unsupported network account type: ${account.type}`);
+  }
 };
 
 export const networkAccountToAPI = (account: NetworkAccount): components['schemas']['networkAccount'] => {
@@ -641,13 +654,16 @@ export const bindInfoOptFromAPI = (bindInfo: components['schemas']['BindInfo'] |
   if (!bindInfo) {
     return undefined;
   }
-  // The router forwards the caller's ownership hint as {signature, template: null}
-  // (finp2p-core builds Signature{Signature: hint} only) — it is unverified in the
-  // trust model, so anything signatureFromAPI can't parse maps to absent.
+  // The router sends only the raw hex hint — core master models this as
+  // accountOwnershipSignature {signature}, with no template and no hash
+  // function, because there is nothing to template: only the challenge bytes
+  // are signed. Carry the hex through rather than routing it via
+  // signatureFromAPI, which requires a template and so discarded it every time
+  // against a real router.
   const { ownershipSignature } = bindInfo;
   return {
     account: networkAccountFromAPI(bindInfo.networkAccount),
-    ownershipSignature: ownershipSignature?.template ? signatureFromAPI(ownershipSignature) : undefined,
+    ownershipSignature: ownershipSignature?.signature || undefined,
   };
 };
 

--- a/skeleton/src/routes/model-gen.ts
+++ b/skeleton/src/routes/model-gen.ts
@@ -6,992 +6,1273 @@
 /** Extracted recursive types to break circular references in generated schemas */
 export type RecursiveEIP712TypedValue = (string) | (number) | (boolean) | (string) | RecursiveEIP712TypeObject | RecursiveEIP712TypeArray;
 export type RecursiveEIP712TypeObject = {
-            [key: string]: RecursiveEIP712TypedValue;
-        };
+  [key: string]: RecursiveEIP712TypedValue;
+};
 export type RecursiveEIP712TypeArray = RecursiveEIP712TypedValue[];
 export interface paths {
-    "/plan/approve": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
+  '/plan/approve': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
          * Approve execution plan
          * @description Expects a ledger to approve the upcoming execution plan
          */
-        post: operations["approveExecutionPlan"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    post: operations['approveExecutionPlan'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/plan/proposal': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/plan/proposal": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
+    get?: never;
+    put?: never;
+    /**
          * Approve a plan proposal plan
          * @description Request adapter approval or rejection to a proposal in an execution plan
          */
-        post: operations["executionPlanProposal"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    post: operations['executionPlanProposal'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/plan/proposal/status': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/plan/proposal/status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
+    get?: never;
+    put?: never;
+    /**
          * Notify the adapter on the agreement status (Approve/Rejected) for a specific proposal
          * @description notify the adapter on proposal status
          */
-        post: operations["executionPlanProposalStatus"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    post: operations['executionPlanProposalStatus'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/payments/depositInstruction': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/payments/depositInstruction": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
+    get?: never;
+    put?: never;
+    /**
          * Deposit instruction
          * @description Create a deposit instruction for an owner
          */
-        post: operations["depositInstruction"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    post: operations['depositInstruction'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/payments/payout': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/payments/payout": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
+    get?: never;
+    put?: never;
+    /**
          * Payout request
          * @description Payout owner assets to external destination
          */
-        post: operations["payout"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    post: operations['payout'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/assets/getBalance': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/assets/getBalance": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
+    get?: never;
+    put?: never;
+    /**
          * Get asset balance
          * @deprecated
          * @description Get asset balance for specified owner
          */
-        post: operations["getAssetBalance"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    post: operations['getAssetBalance'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/assets/create': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/assets/create": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
+    get?: never;
+    put?: never;
+    /**
          * Create asset
          * @description Create a new asset
          */
-        post: operations["createAsset"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    post: operations['createAsset'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/assets/issue': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/assets/issue": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
+    get?: never;
+    put?: never;
+    /**
          * Issue asset token
          * @description Issue specified amount of asset tokens for the owner
          */
-        post: operations["issueAssets"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    post: operations['issueAssets'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/assets/redeem': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/assets/redeem": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
+    get?: never;
+    put?: never;
+    /**
          * Asset Token Redeem
          * @description Redeem existing asset token for new owner. Redeem of ownership is done by eliminating existing tokens owned by the owner.
          */
-        post: operations["redeemAssets"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    post: operations['redeemAssets'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/assets/move': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/assets/transfer": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
+    get?: never;
+    put?: never;
+    /**
+         * Asset Token Move
+         * @description Move existing asset token to another ledger
+         */
+    post: operations['moveAssets'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/assets/transfer': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
          * Asset Token Transfer
          * @description Transfer existing asset token to a new owner. Transfer of ownership is done by eliminating existing tokens owned by the sender and creating new tokens with the new owner.
          */
-        post: operations["transferAsset"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    post: operations['transferAsset'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/accounts/create': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/assets/receipts/{transactionId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
+    get?: never;
+    put?: never;
+    /**
+         * Create or bind an investor account on this LA (Phase 1)
+         * @description Single LA-side endpoint covering both flows:
+         *
+         *     - **Create new** — `bindInfo` is absent. The LA generates a fresh wallet on the
+         *       asset's network.
+         *     - **Bind existing** — `bindInfo` carries the caller-supplied `networkAccount`
+         *       and `ownershipSignature` (proof-of-ownership hint).
+         *
+         *     The LA issues a **challenge** (signatureTemplate / walletConnect / deposit /
+         *     fireblocksApproval / …) which the user must fulfill. Two response shapes:
+         *
+         *     - `207 Multi-Status` — challenge ready immediately; body has `challenge` and
+         *       `operationResponseStrategy`.
+         *     - `202 Accepted` — LA needs more time; body has `cid` and
+         *       `operationResponseStrategy`. Asset node polls or awaits callback per strategy;
+         *       the challenge arrives via `GET /operations/status/{cid}`.
+         *
+         *     The `ledger.accounts.wallets` jsonb column is updated **only after challenge verification**.
+         */
+    post: operations['createAccount'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/accounts/{cid}/proof': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+         * Submit signature proof for a signatureTemplate challenge (Phase 1)
+         * @description Used only when the challenge `type` is `signatureTemplate`. The asset node forwards
+         *     the client's signature; the LA verifies it against the challenge payload. Verification
+         *     outcome is reported via the workflow's normal response strategy.
+         */
+    post: operations['submitAccountProof'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/accounts/{accountId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    /**
+         * Unbind an investor account (Phase 1)
+         * @description Removes the account entry from the `ledger.accounts.wallets` jsonb column. Async; cid in response.
+         */
+    delete: operations['removeAccount'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/assets/receipts/{transactionId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
          * Get Receipt
          * @description Get asset transaction receipt
          */
-        get: operations["getReceipt"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get: operations['getReceipt'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/assets/hold': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/assets/hold": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
+    get?: never;
+    put?: never;
+    /**
          * Hold Asset
          * @description Hold the owner asset
          */
-        post: operations["holdOperation"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    post: operations['holdOperation'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/assets/release': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/assets/release": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
+    get?: never;
+    put?: never;
+    /**
          * Release Asset
          * @description Release held assets
          */
-        post: operations["releaseOperation"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    post: operations['releaseOperation'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/assets/rollback': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/assets/rollback": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
+    get?: never;
+    put?: never;
+    /**
          * Rollback held asset
          * @description Release back held asset to the owner
          */
-        post: operations["rollbackOperation"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    post: operations['rollbackOperation'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/operations/status/{cid}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/operations/status/{cid}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
+    /**
          * Get Operation Status
          * @description Get the operation status by an operation correlation id
          */
-        get: operations["getOperation"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get: operations['getOperation'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/asset/balance': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/asset/balance": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
+    get?: never;
+    put?: never;
+    /**
          * Get asset balance information
          * @description Get asset balance information for finId
          */
-        post: operations["GetAssetBalanceInfo"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    post: operations['GetAssetBalanceInfo'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/health': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/health": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
+    /**
          * Health check
          * @description Returns the health status of the service.
          */
-        get: operations["getHealth"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
+    get: operations['getHealth'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-    schemas: {
-        DepositInstructionRequest: {
-            destination: components["schemas"]["depositPayoutAccount"];
-            owner: components["schemas"]["depositPayoutAccount"];
-            asset: components["schemas"]["depositAsset"];
-            /** @description Amount to deposit */
-            amount?: string;
-            details?: Record<string, never>;
-            nonce?: components["schemas"]["nonce"];
-            signature?: components["schemas"]["signature"];
-        };
-        DepositInstructionResponse: components["schemas"]["depositOperation"];
-        PayoutRequest: {
-            source: components["schemas"]["depositPayoutAccount"];
-            destination?: components["schemas"]["depositPayoutAccount"];
-            /** @description How many units of the asset */
-            quantity: string;
-            payoutInstruction?: components["schemas"]["payoutInstruction"];
-            asset: components["schemas"]["finp2pAsset"];
-            nonce?: components["schemas"]["nonce"];
-            signature?: components["schemas"]["signature"];
-        };
-        PayoutResponse: components["schemas"]["receiptOperation"];
-        GetAssetBalanceRequest: {
-            owner: components["schemas"]["account"];
-        };
-        GetAssetBalanceResponse: components["schemas"]["balance"];
-        CreateAssetRequest: {
-            /** @description The asset metadata */
-            metadata?: {
-                [key: string]: unknown;
-            };
-            asset: components["schemas"]["finp2pAssetBase"];
-            ledgerAssetBinding?: components["schemas"]["ledgerAssetIdentifier"];
-            name?: components["schemas"]["assetName"];
-            issuerId?: components["schemas"]["ownerResourceId"];
-            denomination?: components["schemas"]["assetDenomination"];
-        };
-        CreateAssetResponse: components["schemas"]["OperationBase"] & {
-            error?: components["schemas"]["createAssetOperationErrorInformation"];
-            response?: components["schemas"]["assetCreateResponse"];
-        };
-        IssueAssetsRequest: {
-            nonce: components["schemas"]["nonce"];
-            destination: components["schemas"]["account"];
-            /** @description How many units of the asset tokens */
-            quantity: string;
-            /** @description Reference to the corresponding settlement operation */
-            settlementRef: string;
-            signature: components["schemas"]["signature"];
-            executionContext?: components["schemas"]["executionContext"];
-        };
-        IssueAssetsResponse: components["schemas"]["receiptOperation"];
-        RedeemAssetsRequest: {
-            nonce: components["schemas"]["nonce"];
-            operationId?: string;
-            source: components["schemas"]["account"];
-            /** @description How many units of the asset tokens */
-            quantity: string;
-            /** @description Reference to the corresponding payment operation */
-            settlementRef: string;
-            signature: components["schemas"]["signature"];
-            executionContext?: components["schemas"]["executionContext"];
-        };
-        RedeemAssetsResponse: components["schemas"]["receiptOperation"];
-        TransferAssetRequest: {
-            nonce: components["schemas"]["nonce"];
-            source: components["schemas"]["account"];
-            destination: components["schemas"]["account"];
-            /** @description How many units of the asset tokens */
-            quantity: string;
-            /** @description Reference to the corresponding payment operation */
-            settlementRef: string;
-            signature: components["schemas"]["signature"];
-            executionContext?: components["schemas"]["executionContext"];
-        };
-        TransferAssetResponse: components["schemas"]["receiptOperation"];
-        GetReceiptResponse: components["schemas"]["receiptOperation"];
-        HoldOperationRequest: {
-            nonce: components["schemas"]["nonce"];
-            /** @description A unique operation ID assigned to the hold request, used to track and reference the asset for future release or rollback actions */
-            operationId: string;
-            source: components["schemas"]["account"];
-            destination?: components["schemas"]["account"];
-            /** @description How many units of the asset tokens */
-            quantity: string;
-            /**
+  schemas: {
+    DepositInstructionRequest: {
+      destination: components['schemas']['depositPayoutAccount'];
+      owner: components['schemas']['depositPayoutAccount'];
+      asset: components['schemas']['depositAsset'];
+      /** @description Amount to deposit */
+      amount?: string;
+      details?: Record<string, never>;
+      nonce?: components['schemas']['nonce'];
+      signature?: components['schemas']['signature'];
+    };
+    DepositInstructionResponse: components['schemas']['depositOperation'];
+    PayoutRequest: {
+      source: components['schemas']['depositPayoutAccount'];
+      destination?: components['schemas']['depositPayoutAccount'];
+      /** @description How many units of the asset */
+      quantity: string;
+      payoutInstruction?: components['schemas']['payoutInstruction'];
+      asset: components['schemas']['finp2pAsset'];
+      nonce?: components['schemas']['nonce'];
+      signature?: components['schemas']['signature'];
+    };
+    PayoutResponse: components['schemas']['receiptOperation'];
+    GetAssetBalanceRequest: {
+      owner: components['schemas']['account'];
+    };
+    GetAssetBalanceResponse: components['schemas']['balance'];
+    CreateAssetRequest: {
+      /** @description The asset metadata */
+      metadata?: {
+        [key: string]: unknown;
+      };
+      asset: components['schemas']['finp2pAssetBase'];
+      ledgerAssetBinding?: components['schemas']['ledgerAssetIdentifier'];
+      name?: components['schemas']['assetName'];
+      issuerId?: components['schemas']['ownerResourceId'];
+      denomination?: components['schemas']['assetDenomination'];
+    };
+    CreateAssetResponse: components['schemas']['OperationBase'] & {
+      error?: components['schemas']['createAssetOperationErrorInformation'];
+      response?: components['schemas']['assetCreateResponse'];
+    };
+    IssueAssetsRequest: {
+      nonce: components['schemas']['nonce'];
+      destination: components['schemas']['account'];
+      /** @description How many units of the asset tokens */
+      quantity: string;
+      /** @description Reference to the corresponding settlement operation */
+      settlementRef: string;
+      signature: components['schemas']['signature'];
+      executionContext?: components['schemas']['executionContext'];
+    };
+    IssueAssetsResponse: components['schemas']['receiptOperation'];
+    RedeemAssetsRequest: {
+      nonce: components['schemas']['nonce'];
+      operationId?: string;
+      source: components['schemas']['account'];
+      /** @description How many units of the asset tokens */
+      quantity: string;
+      /** @description Reference to the corresponding payment operation */
+      settlementRef: string;
+      signature: components['schemas']['signature'];
+      executionContext?: components['schemas']['executionContext'];
+    };
+    RedeemAssetsResponse: components['schemas']['receiptOperation'];
+    TransferAssetRequest: {
+      nonce: components['schemas']['nonce'];
+      source: components['schemas']['account'];
+      destination: components['schemas']['account'];
+      /** @description How many units of the asset tokens */
+      quantity: string;
+      /** @description Reference to the corresponding payment operation */
+      settlementRef: string;
+      signature: components['schemas']['signature'];
+      executionContext?: components['schemas']['executionContext'];
+    };
+    TransferAssetResponse: components['schemas']['receiptOperation'];
+    MoveAssetsRequest: {
+      nonce: components['schemas']['nonce'];
+      operationId?: string;
+      source: components['schemas']['account'];
+      destination: components['schemas']['account'];
+      /** @description How many units of the asset tokens */
+      quantity: string;
+      signature: components['schemas']['signature'];
+      executionContext?: components['schemas']['executionContext'];
+    };
+    MoveAssetsResponse: components['schemas']['receiptOperation'];
+    GetReceiptResponse: components['schemas']['receiptOperation'];
+    HoldOperationRequest: {
+      nonce: components['schemas']['nonce'];
+      /** @description A unique operation ID assigned to the hold request, used to track and reference the asset for future release or rollback actions */
+      operationId: string;
+      source: components['schemas']['account'];
+      destination?: components['schemas']['account'];
+      /** @description How many units of the asset tokens */
+      quantity: string;
+      /**
              * Format: uint64
              * @description ttl expiry value indicating the escrow hold time limitation
              */
-            expiry: number;
-            signature: components["schemas"]["signature"];
-            executionContext?: components["schemas"]["executionContext"];
-        };
-        HoldOperationResponse: components["schemas"]["receiptOperation"];
-        ReleaseOperationRequest: {
-            /** @description The operation ID from the hold request, required to authorize the asset release */
-            operationId: string;
-            source: components["schemas"]["account"];
-            destination: components["schemas"]["account"];
-            /** @description How many units of the asset tokens */
-            quantity: string;
-            executionContext?: components["schemas"]["executionContext"];
-        };
-        ReleaseOperationResponse: components["schemas"]["receiptOperation"];
-        RollbackOperationRequest: {
-            /** @description The operation ID from the hold request, required to revert the asset hold */
-            operationId: string;
-            source: components["schemas"]["account"];
-            /** @description How many units of the asset tokens */
-            quantity: string;
-            executionContext?: components["schemas"]["executionContext"];
-        };
-        RollbackOperationResponse: components["schemas"]["receiptOperation"];
-        GetOperationStatusRequest: {
-            /** @description correlation id of an operation */
-            cid?: string;
-        };
-        GetOperationStatusResponse: components["schemas"]["operationStatus"];
-        depositInstruction: {
-            account: components["schemas"]["depositPayoutAccount"];
-            asset?: components["schemas"]["depositAsset"];
-            /** @description Instructions for the deposit operation */
-            description?: string;
-            paymentOptions?: components["schemas"]["paymentMethods"];
-            /**
+      expiry: number;
+      signature: components['schemas']['signature'];
+      executionContext?: components['schemas']['executionContext'];
+    };
+    HoldOperationResponse: components['schemas']['receiptOperation'];
+    ReleaseOperationRequest: {
+      /** @description The operation ID from the hold request, required to authorize the asset release */
+      operationId: string;
+      source: components['schemas']['account'];
+      destination: components['schemas']['account'];
+      /** @description How many units of the asset tokens */
+      quantity: string;
+      executionContext?: components['schemas']['executionContext'];
+    };
+    ReleaseOperationResponse: components['schemas']['receiptOperation'];
+    RollbackOperationRequest: {
+      /** @description The operation ID from the hold request, required to revert the asset hold */
+      operationId: string;
+      source: components['schemas']['account'];
+      /** @description How many units of the asset tokens */
+      quantity: string;
+      executionContext?: components['schemas']['executionContext'];
+    };
+    RollbackOperationResponse: components['schemas']['receiptOperation'];
+    GetOperationStatusRequest: {
+      /** @description correlation id of an operation */
+      cid?: string;
+    };
+    GetOperationStatusResponse: components['schemas']['operationStatus'];
+    depositInstruction: {
+      account: components['schemas']['depositPayoutAccount'];
+      asset?: components['schemas']['depositAsset'];
+      /** @description Instructions for the deposit operation */
+      description?: string;
+      paymentOptions?: components['schemas']['paymentMethods'];
+      /**
              * @deprecated
              * @description Any addition deposit specific information, deprecated use "payment method options" instead fields
              */
-            details?: Record<string, never>;
-            /** @description operation id reference while will correlate with any receipt associated with the deposit operation */
-            operationId?: string;
-        };
-        asset: {
-            ledgerIdentifier: components["schemas"]["ledgerAssetIdentifier"];
-        } & components["schemas"]["finp2pAssetBase"];
-        payoutAsset: components["schemas"]["finp2pAsset"];
-        payoutInstruction: {
-            /** @description withdrawal description */
-            description: string;
-        };
-        account: {
-            asset: components["schemas"]["asset"];
-            finId: components["schemas"]["finId"];
-            ledgerAccount?: components["schemas"]["walletAccount"];
-        };
-        walletLedgerAccount: components["schemas"]["walletAccount"];
-        depositPayoutAccount: {
-            finId: components["schemas"]["finId"];
-            account: components["schemas"]["finIdAccountBase"];
-        };
-        finIdAccountBase: {
-            /**
+      details?: Record<string, never>;
+      /** @description operation id reference while will correlate with any receipt associated with the deposit operation */
+      operationId?: string;
+    };
+    asset: {
+      ledgerIdentifier: components['schemas']['ledgerAssetIdentifier'];
+    } & components['schemas']['finp2pAssetBase'];
+    payoutAsset: components['schemas']['finp2pAsset'];
+    payoutInstruction: {
+      /** @description withdrawal description */
+      description: string;
+    };
+    account: {
+      asset: components['schemas']['asset'];
+      finId: components['schemas']['finId'];
+      ledgerAccount?: components['schemas']['walletAccount'] | components['schemas']['caip10Account'] | components['schemas']['custodialAccount'];
+    };
+    walletLedgerAccount: components['schemas']['walletAccount'];
+    caip10LedgerAccount: components['schemas']['caip10Account'];
+    custodialLedgerAccount: components['schemas']['custodialAccount'];
+    depositPayoutAccount: {
+      finId: components['schemas']['finId'];
+      account: components['schemas']['finIdAccountBase'];
+    };
+    finIdAccountBase: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type: "finId";
-            finId: components["schemas"]["finId"];
-        };
-        balance: {
-            asset: components["schemas"]["asset"];
-            /** @description the number of asset tokens */
-            balance: string;
-        };
-        receiptOperation: components["schemas"]["OperationBase"] & {
-            error?: components["schemas"]["receiptOperationErrorInformation"];
-            response?: components["schemas"]["receipt"];
-        };
-        createAssetOperation: components["schemas"]["OperationBase"] & {
-            error?: components["schemas"]["createAssetOperationErrorInformation"];
-            response?: components["schemas"]["assetCreateResponse"];
-        };
-        assetCreateResponse: {
-            ledgerAssetInfo: components["schemas"]["ledgerAssetInfo"];
-        };
-        depositOperation: components["schemas"]["OperationBase"] & {
-            error?: components["schemas"]["depositOperationErrorInformation"];
-            response?: components["schemas"]["depositInstruction"];
-        };
-        depositOperationErrorInformation: {
-            /** Format: uint32 */
-            code?: number;
-            message?: string;
-        };
-        createAssetOperationErrorInformation: {
-            /** Format: uint32 */
-            code?: number;
-            message?: string;
-        };
-        receiptOperationErrorInformation: {
-            /**
+      type: 'finId';
+      finId: components['schemas']['finId'];
+    };
+    balance: {
+      asset: components['schemas']['asset'];
+      /** @description the number of asset tokens */
+      balance: string;
+    };
+    receiptOperation: components['schemas']['OperationBase'] & {
+      error?: components['schemas']['receiptOperationErrorInformation'];
+      response?: components['schemas']['receipt'];
+    };
+    /**
+         * @description Body for `POST /accounts/create`. Single LA-side endpoint covering both create-new
+         *     and bind-existing flows.
+         *
+         *     - **Create new** — omit `bindInfo`. The LA generates a wallet on the asset's network.
+         *     - **Bind existing** — populate `bindInfo` with the caller-supplied wallet and a
+         *       proof-of-ownership signature hint. The LA still issues a challenge for final verification.
+         *
+         *     The response is either `207` (challenge ready) or `202` (challenge pending) — see the
+         *     endpoint definition.
+         */
+    CreateAccountRequest: {
+      organizationId: string;
+      assetId: string;
+      /**
+             * @description The investor this account is being onboarded for, identified by their canonical
+             *     finId (hex-encoded compressed secp256k1 public key — the same identity that appears
+             *     on this investor's ledger operation legs). Resolved by the asset node from the
+             *     investor profile; lets the ledger adapter couple the resulting network account to
+             *     the investor so it can enforce wallet↔finId ownership on later operations. Required:
+             *     an investor without a resolvable finId cannot onboard a network account.
+             */
+      finId: components['schemas']['finId'];
+      bindInfo?: components['schemas']['BindInfo'];
+    };
+    /** @description Bind-info block. When present in `CreateAccountRequest`, signals the bind-existing flow. */
+    BindInfo: {
+      networkAccount: components['schemas']['networkAccount'];
+      /**
+             * @description Proof-of-ownership hint over the network account. The LA may verify this upfront,
+             *     but the authoritative ownership proof is the challenge-fulfillment step.
+             */
+      ownershipSignature: components['schemas']['signature'];
+    };
+    /** @description Body for `POST /accounts/{cid}/proof`. Used only for `signatureTemplate` challenges. */
+    SubmitAccountProofRequest: {
+      /** @description Signature over the LA's `signatureTemplate` challenge payload. */
+      ownershipSignature: components['schemas']['signature'];
+    };
+    /**
+         * @description Returned for `202` and for `200` from `proof` / `delete`. When `isCompleted` is
+         *     false, the result is not yet available and `cid` lets the asset node poll
+         *     `/operations/status/{cid}` or receive a callback per `operationResponseStrategy`.
+         *     When the adapter completes the operation synchronously, `isCompleted` is true and
+         *     exactly one of `response` (the account it created) or `error` is present.
+         */
+    AccountOperationAccepted: components['schemas']['OperationBase'] & {
+      operationMetadata?: components['schemas']['OperationMetadata'];
+      response?: components['schemas']['networkAccountRecord'];
+      error?: components['schemas']['networkAccountOperationErrorInformation'];
+      /**
+             * Format: int64
+             * @description Onboarding deadline the ledger adapter grants for this create/bind, in
+             *     seconds from now. The asset node arms the workflow's whole-process timeout
+             *     from this value (set once, at acceptance). Omitted/zero => no auto-expiry.
+             */
+      expiresInSeconds?: number;
+    };
+    /**
+         * @description Returned for `207` from `POST /accounts/create`. Structurally a superset of
+         *     AccountOperationAccepted (the router decodes both create responses into this
+         *     one type), adding the LA-issued challenge.
+         */
+    AccountOperationChallenge: components['schemas']['AccountOperationAccepted'] & {
+      challenge: components['schemas']['AccountChallenge'];
+    };
+    /**
+         * @description LA-issued challenge that the user must fulfill. Discriminated by `type`. New variants
+         *     can be added without breaking existing clients.
+         */
+    AccountChallenge: components['schemas']['AccountChallengeWalletConnect'] | components['schemas']['AccountChallengeSignatureTemplate'] | components['schemas']['AccountChallengeDeposit'] | components['schemas']['AccountChallengeFireblocksApproval'];
+    AccountChallengeWalletConnect: {
+      /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+      type: 'walletConnect';
+      /** @description WalletConnect URI or QR-encodable payload. */
+      uri: string;
+    };
+    AccountChallengeSignatureTemplate: {
+      /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+      type: 'signatureTemplate';
+      /**
+             * @description Hex-encoded data the client must sign with the wallet's private key and submit via
+             *     `POST /accounts/{cid}/proof`.
+             */
+      payload: string;
+    };
+    AccountChallengeDeposit: {
+      /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+      type: 'deposit';
+      /** @description Address claimed by the user. */
+      fromAddress: string;
+      /** @description Destination address the LA watches. */
+      toAddress: string;
+      /** @description Required deposit amount (string for precision). */
+      amount: string;
+    };
+    AccountChallengeFireblocksApproval: {
+      /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+      type: 'fireblocksApproval';
+      /** @description Fireblocks-side request id; user approves in the Fireblocks app. */
+      fireblocksRequestId: string;
+    };
+    /** @description Canonical account record returned on workflow completion via `GET /operations/status/{cid}`. */
+    networkAccountRecord: {
+      /** @description LA-assigned account identifier. */
+      id: string;
+      networkAccount: components['schemas']['networkAccount'];
+    };
+    createAssetOperation: components['schemas']['OperationBase'] & {
+      error?: components['schemas']['createAssetOperationErrorInformation'];
+      response?: components['schemas']['assetCreateResponse'];
+    };
+    assetCreateResponse: {
+      ledgerAssetInfo: components['schemas']['ledgerAssetInfo'];
+    };
+    depositOperation: components['schemas']['OperationBase'] & {
+      error?: components['schemas']['depositOperationErrorInformation'];
+      response?: components['schemas']['depositInstruction'];
+    };
+    depositOperationErrorInformation: {
+      /**
              * Format: uint32
              * @description 1 for failure in regApps validation, 4 failure in signature verification
              */
-            code: number;
-            message: string;
-            regulationErrorDetails?: components["schemas"]["RegulationError"][];
-        };
-        executionOperationErrorInformation: Record<string, never>;
-        executionContext: {
-            /** @description execution plan id */
-            executionPlanId: string;
-            /**
+      code?: number;
+      message?: string;
+      regulationErrorDetails?: components['schemas']['RegulationError'][];
+    };
+    createAssetOperationErrorInformation: {
+      /** Format: uint32 */
+      code?: number;
+      message?: string;
+    };
+    receiptOperationErrorInformation: {
+      /**
+             * Format: uint32
+             * @description 1 for failure in regApps validation, 4 failure in signature verification
+             */
+      code: number;
+      message: string;
+      regulationErrorDetails?: components['schemas']['RegulationError'][];
+    };
+    executionOperationErrorInformation: Record<string, never>;
+    executionContext: {
+      /** @description execution plan id */
+      executionPlanId: string;
+      /**
              * Format: uint32
              * @description execution instruction sequence number
              */
-            instructionSequenceNumber: number;
-        };
-        operationStatus: components["schemas"]["operationStatusCreateAsset"] | components["schemas"]["operationStatusDeposit"] | components["schemas"]["operationStatusReceipt"] | components["schemas"]["operationStatusApproval"];
-        operationStatusCreateAsset: {
-            /**
+      instructionSequenceNumber: number;
+    };
+    operationStatus: components['schemas']['operationStatusCreateAsset'] | components['schemas']['operationStatusDeposit'] | components['schemas']['operationStatusReceipt'] | components['schemas']['operationStatusApproval'] | components['schemas']['operationStatusAccount'];
+    operationStatusCreateAsset: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type: "createAsset";
-            operation: components["schemas"]["createAssetOperation"];
-        };
-        operationStatusDeposit: {
-            /**
+      type: 'createAsset';
+      operation: components['schemas']['createAssetOperation'];
+    };
+    operationStatusDeposit: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type: "deposit";
-            operation: components["schemas"]["depositOperation"];
-        };
-        operationStatusReceipt: {
-            /**
+      type: 'deposit';
+      operation: components['schemas']['depositOperation'];
+    };
+    operationStatusReceipt: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type: "receipt";
-            operation: components["schemas"]["receiptOperation"];
-        };
-        operationStatusApproval: {
-            /**
+      type: 'receipt';
+      operation: components['schemas']['receiptOperation'];
+    };
+    operationStatusApproval: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type: "approval";
-            operation: components["schemas"]["ExecutionPlanApprovalOperation"];
-        };
-        /** @description represent a signature template information */
-        signature: {
-            /** @description hex representation of the signature */
-            signature: string;
-            template: components["schemas"]["signatureTemplate"];
-            hashFunc: components["schemas"]["hashFunction"];
-        };
-        signatureTemplate: components["schemas"]["hashListTemplate"] | components["schemas"]["EIP712Template"];
-        /** @description ordered list of hash groups */
-        hashListTemplate: {
-            /**
+      type: 'approval';
+      operation: components['schemas']['ExecutionPlanApprovalOperation'];
+    };
+    operationStatusAccount: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type: "hashList";
-            hashGroups: components["schemas"]["hashGroup"][];
-            /** @description hex representation of the combined hash groups hash value */
-            hash: string;
-        };
-        hashGroup: {
-            /** @description hex representation of the hash group hash value */
-            hash: string;
-            /** @description list of fields by order they appear in the hash group */
-            fields: components["schemas"]["field"][];
-        };
-        /** @description describing a field in the hash group */
-        field: {
-            /** @description name of field */
-            name: string;
-            /**
+      type: 'account';
+      operation: components['schemas']['networkAccountOperation'];
+    };
+    /**
+         * @description Status of an investor network-account create/bind/unbind operation, polled via
+         *     `GET /operations/status/{cid}`. While a challenge is outstanding, `challenge` is
+         *     present; on completion `response` carries the canonical `{ id, wallet }`; on failure
+         *     `error` carries the LA-level code/message.
+         */
+    networkAccountOperation: components['schemas']['OperationBase'] & {
+      challenge?: components['schemas']['AccountChallenge'];
+      response?: components['schemas']['networkAccountRecord'];
+      error?: components['schemas']['networkAccountOperationErrorInformation'];
+      /**
+             * Format: int64
+             * @description Onboarding deadline the ledger adapter grants, in seconds from now, when it
+             *     supplies (or revises) one on this status — e.g. alongside a challenge delivered
+             *     via callback in proxy mode, where the adapter's own deadline could not ride the
+             *     proxy's immediate acceptance. The asset node re-arms the workflow deadline from
+             *     a non-zero value. Omitted/zero => previously armed deadline stands.
+             */
+      expiresInSeconds?: number;
+    };
+    networkAccountOperationErrorInformation: {
+      /** Format: uint32 */
+      code: number;
+      message: string;
+    };
+    /** @description represent a signature template information */
+    signature: {
+      /** @description hex representation of the signature */
+      signature: string;
+      template: components['schemas']['signatureTemplate'];
+      hashFunc: components['schemas']['hashFunction'];
+    };
+    signatureTemplate: components['schemas']['hashListTemplate'] | components['schemas']['EIP712Template'];
+    /** @description ordered list of hash groups */
+    hashListTemplate: {
+      /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+      type: 'hashList';
+      hashGroups: components['schemas']['hashGroup'][];
+      /** @description hex representation of the combined hash groups hash value */
+      hash: string;
+      /** @description Template shape version. When omitted, the verifier resolves the version from the signature proof context. */
+      templateVersion?: number;
+    };
+    hashGroup: {
+      /** @description hex representation of the hash group hash value */
+      hash: string;
+      /** @description list of fields by order they appear in the hash group */
+      fields: components['schemas']['field'][];
+    };
+    /** @description describing a field in the hash group */
+    field: {
+      /** @description name of field */
+      name: string;
+      /**
              * @description type of field
              * @enum {string}
              */
-            type: "string" | "int" | "bytes";
-            /** @description hex representation of the field value */
-            value: string;
-        };
-        EIP712Domain: {
-            name?: string;
-            version?: string;
-            /** Format: uint64 */
-            chainId?: number;
-            /** Format: address */
-            verifyingContract?: string;
-        };
-        EIP712TypedValue: RecursiveEIP712TypedValue;
-        EIP712Types: {
-            definitions?: components["schemas"]["EIP712TypeDefinition"][];
-        };
-        EIP712TypeDefinition: {
-            name?: string;
-            fields?: components["schemas"]["EIP712FieldDefinition"][];
-        };
-        EIP712FieldDefinition: {
-            name?: string;
-            type?: string;
-        };
-        EIP712Template: {
-            /**
+      type: 'string' | 'int' | 'bytes';
+      /** @description hex representation of the field value */
+      value: string;
+    };
+    EIP712Domain: {
+      name?: string;
+      version?: string;
+      /** Format: uint64 */
+      chainId?: number;
+      /** Format: address */
+      verifyingContract?: string;
+    };
+    EIP712TypedValue: RecursiveEIP712TypedValue;
+    EIP712Types: {
+      definitions?: components['schemas']['EIP712TypeDefinition'][];
+    };
+    EIP712TypeDefinition: {
+      name?: string;
+      fields?: components['schemas']['EIP712FieldDefinition'][];
+    };
+    EIP712FieldDefinition: {
+      name?: string;
+      type?: string;
+    };
+    EIP712Template: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type: "EIP712";
-            domain: components["schemas"]["EIP712Domain"];
-            message: {
-                [key: string]: components["schemas"]["EIP712TypedValue"];
-            };
-            types: components["schemas"]["EIP712Types"];
-            primaryType: string;
-            /** @description hex representation of template hash */
-            hash: string;
-        };
-        EIP712TypeString: string;
-        EIP712TypeByte: string;
-        EIP712TypeInteger: number;
-        EIP712TypeBool: boolean;
-        EIP712TypeObject: RecursiveEIP712TypeObject;
-        EIP712TypeArray: RecursiveEIP712TypeArray;
-        /**
+      type: 'EIP712';
+      domain: components['schemas']['EIP712Domain'];
+      message: {
+        [key: string]: components['schemas']['EIP712TypedValue'];
+      };
+      types: components['schemas']['EIP712Types'];
+      primaryType: string;
+      /** @description hex representation of template hash */
+      hash: string;
+      /** @description Template shape version. When omitted, the verifier resolves the version from the signature proof context. */
+      templateVersion?: number;
+    };
+    EIP712TypeString: string;
+    EIP712TypeByte: string;
+    EIP712TypeInteger: number;
+    EIP712TypeBool: boolean;
+    EIP712TypeObject: RecursiveEIP712TypeObject;
+    EIP712TypeArray: RecursiveEIP712TypeArray;
+    /**
          * @description hash function types
          * @enum {string}
          */
-        hashFunction: "unspecified" | "sha3_256" | "sha3-256" | "blake2b" | "keccak_256" | "keccak-256";
-        receipt: {
-            /** @description the receipt id */
-            id: string;
-            /** @description How many units of the asset tokens */
-            quantity: string;
-            /**
+    hashFunction: 'unspecified' | 'sha3_256' | 'sha3-256' | 'blake2b' | 'keccak_256' | 'keccak-256';
+    receipt: {
+      /** @description the receipt id */
+      id: string;
+      /** @description How many units of the asset tokens */
+      quantity: string;
+      /**
              * Format: int64
              * @description transaction timestamp
              */
-            timestamp: number;
-            source?: components["schemas"]["account"];
-            destination?: components["schemas"]["account"];
-            transactionDetails?: components["schemas"]["transactionDetails"];
-            operationType?: components["schemas"]["operationType"];
-            tradeDetails: components["schemas"]["receiptTradeDetails"];
-            proof?: components["schemas"]["proofPolicy"];
-        };
-        /** @description additional proof information attached to a receipt */
-        proofPolicy: components["schemas"]["signatureProofPolicy"] | components["schemas"]["noProofPolicy"];
-        /** @description no proof validation required for this policy */
-        noProofPolicy: {
-            /**
+      timestamp: number;
+      source?: components['schemas']['account'];
+      destination?: components['schemas']['account'];
+      transactionDetails?: components['schemas']['transactionDetails'];
+      operationType?: components['schemas']['operationType'];
+      tradeDetails: components['schemas']['receiptTradeDetails'];
+      proof?: components['schemas']['proofPolicy'];
+    };
+    /** @description additional proof information attached to a receipt */
+    proofPolicy: components['schemas']['signatureProofPolicy'] | components['schemas']['noProofPolicy'];
+    /** @description no proof validation required for this policy */
+    noProofPolicy: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type: "noProofPolicy";
-        };
-        signatureProofPolicy: {
-            /**
+      type: 'noProofPolicy';
+    };
+    signatureProofPolicy: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type: "signatureProofPolicy";
-            signature?: components["schemas"]["signature"];
-        };
-        /** @description additional ledger specific */
-        transactionDetails: {
-            /** @description The Transaction id on the underlying ledger */
-            transactionId: string;
-            /** @description The Operation id */
-            operationId?: string;
-        };
-        /** @enum {string} */
-        operationType: "issue" | "transfer" | "hold" | "release" | "redeem";
-        ledgerAssetInfo: {
-            ledgerIdentifier: components["schemas"]["ledgerAssetIdentifier"];
-            ledgerReference?: components["schemas"]["contractDetails"];
-        };
-        contractDetails: {
-            /**
+      type: 'signatureProofPolicy';
+      signature?: components['schemas']['signature'];
+    };
+    /** @description additional ledger specific */
+    transactionDetails: {
+      /** @description The Transaction id on the underlying ledger */
+      transactionId: string;
+      /** @description The Operation id */
+      operationId?: string;
+    };
+    /** @enum {string} */
+    operationType: 'issue' | 'transfer' | 'hold' | 'release' | 'redeem' | 'move';
+    ledgerAssetInfo: {
+      ledgerIdentifier: components['schemas']['ledgerAssetIdentifier'];
+      ledgerReference?: components['schemas']['contractDetails'];
+    };
+    contractDetails: {
+      /**
              * @description the type of the identifier (enum property replaced by openapi-typescript)
              * @enum {string}
              */
-            type: "contractDetails";
-            /** @description the address */
-            address: string;
-            /** @description The standard of the token (e.g., ERC20, ERC721) */
-            TokenStandard?: string;
-            additionalContractDetails?: components["schemas"]["finP2PEVMOperatorDetails"];
-        };
-        finP2PEVMOperatorDetails: {
-            /** @description The FinP2P Operator Contract Address */
-            FinP2POperatorContractAddress?: string;
-            /** @description Indicates if allowance is required */
-            allowanceRequired?: boolean;
-        };
-        ledgerAssetBinding: components["schemas"]["ledgerAssetIdentifier"];
-        AssetBalanceInfoRequest: {
-            account: components["schemas"]["assetBalanceAccount"];
-            asset: components["schemas"]["asset"];
-            marker?: components["schemas"]["balanceMarker"];
-        };
-        assetBalanceAccount: components["schemas"]["finIdAccountBase"];
-        /** @description marker of balance to denote the balance as of marker */
-        balanceMarker: components["schemas"]["balanceMarkerTimestamp"] | components["schemas"]["balanceMarkerTransactionBlock"];
-        balanceMarkerTimestamp: {
-            /**
+      type: 'contractDetails';
+      /** @description the address */
+      address: string;
+      /** @description The standard of the token (e.g., ERC20, ERC721) */
+      TokenStandard?: string;
+      additionalContractDetails?: components['schemas']['finP2PEVMOperatorDetails'];
+    };
+    finP2PEVMOperatorDetails: {
+      /** @description The FinP2P Operator Contract Address */
+      FinP2POperatorContractAddress?: string;
+      /** @description Indicates if allowance is required */
+      allowanceRequired?: boolean;
+    };
+    ledgerAssetBinding: components['schemas']['ledgerAssetIdentifier'];
+    AssetBalanceInfoRequest: {
+      account: components['schemas']['assetBalanceAccount'];
+      asset: components['schemas']['asset'];
+      marker?: components['schemas']['balanceMarker'];
+    };
+    assetBalanceAccount: components['schemas']['finIdAccountBase'];
+    /** @description marker of balance to denote the balance as of marker */
+    balanceMarker: components['schemas']['balanceMarkerTimestamp'] | components['schemas']['balanceMarkerTransactionBlock'];
+    balanceMarkerTimestamp: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type: "timestamp";
-            /**
+      type: 'timestamp';
+      /**
              * Format: int64
              * @description epoch timestamp in seconds
              */
-            timestamp: number;
-        };
-        balanceMarkerTransactionBlock: {
-            /**
+      timestamp: number;
+    };
+    balanceMarkerTransactionBlock: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type: "transactionBlock";
-            /** Format: int64 */
-            blockNumber: number;
-            transaction: string;
-        };
-        AssetBalanceInfoResponse: {
-            account: components["schemas"]["assetBalanceAccount"];
-            asset: components["schemas"]["asset"];
-            balanceInfo?: components["schemas"]["assetBalance"];
-        };
-        assetBalance: {
-            asset: components["schemas"]["asset"];
-            /**
+      type: 'transactionBlock';
+      /** Format: int64 */
+      blockNumber: number;
+      transaction: string;
+    };
+    AssetBalanceInfoResponse: {
+      account: components['schemas']['assetBalanceAccount'];
+      asset: components['schemas']['asset'];
+      balanceInfo?: components['schemas']['assetBalance'];
+    };
+    assetBalance: {
+      asset: components['schemas']['asset'];
+      /**
              * Format: ^-?\d+(\.\d+)?$
              * @description The total amount currently in or owed by the account
              */
-            current: string;
-            /**
+      current: string;
+      /**
              * Format: ^-?\d+(\.\d+)?$
              * @description The amount immediately usable from the account
              */
-            available: string;
-            /**
+      available: string;
+      /**
              * Format: ^-?\d+(\.\d+)?$
              * @description The amount pending or on hold within the account
              */
-            held: string;
-            /** @description list of receipt associated with the balance info */
-            receipts?: components["schemas"]["receipt"][];
-        };
-        ApproveExecutionPlanRequest: {
-            /** @description execution plan information */
-            executionPlan: {
-                /** @description execution plan id */
-                id: string;
-            };
-        };
-        pollingResultsStrategy: {
-            /**
+      held: string;
+      /** @description list of receipt associated with the balance info */
+      receipts?: components['schemas']['receipt'][];
+    };
+    ApproveExecutionPlanRequest: {
+      /** @description execution plan information */
+      executionPlan: {
+        /** @description execution plan id */
+        id: string;
+      };
+    };
+    randomPollingInterval: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type: "random";
-            polling: components["schemas"]["randomPollingInterval"] | components["schemas"]["absolutePollingInterval"] | components["schemas"]["relativePollingInterval"];
-        };
-        absolutePollingInterval: {
-            /**
+      type: 'random';
+    };
+    absolutePollingInterval: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type: "absolute";
-            /** @description absolute time as epoch time seconds */
-            time: number;
-        };
-        relativePollingInterval: {
-            /**
+      type: 'absolute';
+      /** @description absolute time as epoch time seconds */
+      time: number;
+    };
+    relativePollingInterval: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type: "relative";
-            /**
+      type: 'relative';
+      /**
              * @description ISO-8601 duration format
              * @example PT5M (5Min duration), P1DT30M (1 Day and 30 Minutes )
              */
-            duration: string;
-        };
-        randomPollingInterval: {
-            /**
+      duration: string;
+    };
+    pollingResultsStrategy: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type: "randomPollingInterval";
-        };
-        callbackEndpoint: {
-            /**
+      type: 'poll';
+      polling: components['schemas']['randomPollingInterval'] | components['schemas']['absolutePollingInterval'] | components['schemas']['relativePollingInterval'];
+    };
+    callbackEndpoint: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type: "endpoint";
-        };
-        callbackResultsStrategy: {
-            /**
+      type: 'endpoint';
+    };
+    callbackResultsStrategy: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type: "callback";
-            callback: components["schemas"]["callbackEndpoint"];
-        };
-        /** @description additional metadata regarding the operation */
-        OperationMetadata: {
-            /**
+      type: 'callback';
+      callback: components['schemas']['callbackEndpoint'];
+    };
+    /** @description additional metadata regarding the operation */
+    OperationMetadata: {
+      /**
              * @description denote the expected response strategy of the operation, i.e. how would completion and results of the operation should be handled
              *     optional, if not provided [polling strategy](#/components/schema/pollingResultsStrategy) will be use with [random interval](#/components/schema/randomPollingInterval)
              */
-            operationResponseStrategy?: components["schemas"]["pollingResultsStrategy"] | components["schemas"]["callbackResultsStrategy"];
-        };
-        OperationBase: {
-            /** @description unique correlation id which identify the operation */
-            cid: string;
-            /**
+      operationResponseStrategy?: components['schemas']['pollingResultsStrategy'] | components['schemas']['callbackResultsStrategy'];
+    };
+    OperationBase: {
+      /** @description unique correlation id which identify the operation */
+      cid: string;
+      /**
              * @description flag indicating if the operation completed, if true then error or response must be present (but not both)
              * @default false
              */
-            isCompleted: boolean;
-            operationMetadata?: components["schemas"]["OperationMetadata"];
-        };
-        PlanApproved: {
-            /**
+      isCompleted: boolean;
+      operationMetadata?: components['schemas']['OperationMetadata'];
+    };
+    PlanApproved: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            status: "approved";
-        };
-        ValidationFailure: {
-            /**
+      status: 'approved';
+    };
+    ValidationFailure: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            failureType: "validationFailure";
-            /**
+      failureType: 'validationFailure';
+      /**
              * Format: uint32
              * @description ledger error code for validation
              */
-            code: number;
-            message: string;
-        };
-        RegulationError: {
-            /** @description the type of regulation */
-            regulationType: string;
-            /** @description actionable details of the error */
-            details: string;
-        };
-        RegulationFailure: {
-            /**
+      code: number;
+      message: string;
+    };
+    RegulationError: {
+      /** @description the type of regulation */
+      regulationType: string;
+      /** @description actionable details of the error */
+      details: string;
+    };
+    RegulationFailure: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            failureType: "regulationFailure";
-            errors: components["schemas"]["RegulationError"][];
-        };
-        PlanRejected: {
-            /**
+      failureType: 'regulationFailure';
+      errors: components['schemas']['RegulationError'][];
+    };
+    PlanRejected: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            status: "rejected";
-            failure?: components["schemas"]["ValidationFailure"] | components["schemas"]["RegulationFailure"];
-        };
-        PlanApprovalResponse: {
-            approval?: components["schemas"]["PlanApproved"] | components["schemas"]["PlanRejected"];
-        };
-        ExecutionPlanApprovalOperation: components["schemas"]["OperationBase"] & components["schemas"]["PlanApprovalResponse"];
-        ApproveExecutionPlanResponse: components["schemas"]["ExecutionPlanApprovalOperation"];
-        executionPlanCancellationProposal: {
-            /**
+      status: 'rejected';
+      failure?: components['schemas']['ValidationFailure'] | components['schemas']['RegulationFailure'];
+    };
+    PlanApprovalResponse: {
+      approval?: components['schemas']['PlanApproved'] | components['schemas']['PlanRejected'];
+    };
+    ExecutionPlanApprovalOperation: components['schemas']['OperationBase'] & components['schemas']['PlanApprovalResponse'];
+    ApproveExecutionPlanResponse: components['schemas']['ExecutionPlanApprovalOperation'];
+    APIError: {
+      /** @description Error code indicating the specific failure - for more information see [API Errors](./api-error-codes-reference). */
+      code: number;
+      /** @description A descriptive message providing context about the error. */
+      message: string;
+    };
+    APIErrors: {
+      errors: components['schemas']['APIError'][];
+    };
+    executionPlanCancellationProposal: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            proposalType: "cancel";
-        };
-        executionPlanResetProposal: {
-            /**
+      proposalType: 'cancel';
+    };
+    executionPlanResetProposal: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            proposalType: "reset";
-            /**
+      proposalType: 'reset';
+      /**
              * Format: uint32
              * @description sequence number of the instruction to reset and retry in the execution plan
              */
-            proposedSequence: number;
-        };
-        executionPlanInstructionProposal: {
-            /**
+      proposedSequence: number;
+    };
+    executionPlanInstructionProposal: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            proposalType: "instruction";
-            /**
+      proposalType: 'instruction';
+      /**
              * Format: uint32
              * @description sequence number of the instruction completion event
              */
-            instructionSequence: number;
-        };
-        executionPlanProposalRequest: {
-            /** @description execution plan information */
-            executionPlan: {
-                /** @description execution plan id */
-                id: string;
-                /** @description type of proposal payload */
-                proposal: components["schemas"]["executionPlanCancellationProposal"] | components["schemas"]["executionPlanInstructionProposal"] | components["schemas"]["executionPlanResetProposal"];
-            };
-        };
-        /** @description provides status update on the agreement reached for a specific proposal */
-        executionPlanProposalStatusRequest: {
-            /** @enum {string} */
-            status: "approved" | "rejected";
-            request: components["schemas"]["executionPlanProposalRequest"];
-        };
-        /**
+      instructionSequence: number;
+    };
+    executionPlanProposalRequest: {
+      /** @description execution plan information */
+      executionPlan: {
+        /** @description execution plan id */
+        id: string;
+        /** @description type of proposal payload */
+        proposal: components['schemas']['executionPlanCancellationProposal'] | components['schemas']['executionPlanInstructionProposal'] | components['schemas']['executionPlanResetProposal'];
+      };
+    };
+    /** @description provides status update on the agreement reached for a specific proposal */
+    executionPlanProposalStatusRequest: {
+      /** @enum {string} */
+      status: 'approved' | 'rejected';
+      request: components['schemas']['executionPlanProposalRequest'];
+    };
+    /**
          * Format: finid
          * @description Existing owner hex representation of a secp256k1 public key 33 bytes compressed
          */
-        finId: string;
-        finp2pAssetWithType: {
-            /**
+    finId: string;
+    finp2pAssetWithType: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type: "finp2p";
-            /** @description unique resource ID of the FinP2P asset */
-            resourceId: string;
-        };
-        customAsset: {
-            /**
+      type: 'finp2p';
+      /** @description unique resource ID of the FinP2P asset */
+      resourceId: string;
+    };
+    customAsset: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type: "custom";
-        };
-        depositAsset: components["schemas"]["finp2pAssetWithType"] | components["schemas"]["customAsset"];
-        /**
+      type: 'custom';
+    };
+    depositAsset: components['schemas']['finp2pAssetWithType'] | components['schemas']['customAsset'];
+    /**
          * @description 32 bytes buffer (24 randomly generated bytes by the client + 8 bytes epoch timestamp seconds) encoded to hex:
          *
          *       const nonce = Buffer.alloc(32);
@@ -1001,828 +1282,1452 @@ export interface components {
          *       const t = BigInt(nowEpochSeconds);
          *       nonce.writeBigInt64BE(t, 24);
          */
-        nonce: string;
-        ibanAccountDetails: {
-            /**
+    nonce: string;
+    ibanAccountDetails: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type: "iban";
-            iban: string;
-        };
-        swiftAccountDetails: {
-            /**
+      type: 'iban';
+      iban: string;
+    };
+    swiftAccountDetails: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type: "swift";
-            swiftCode: string;
-            accountNumber: string;
-        };
-        sortCodeDetails: {
-            /**
+      type: 'swift';
+      swiftCode: string;
+      accountNumber: string;
+    };
+    sortCodeDetails: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type: "sortCode";
-            /** @description sort code has XX-XX-XX format */
-            code: string;
-            accountNumber: string;
-        };
-        wireDetails: components["schemas"]["ibanAccountDetails"] | components["schemas"]["swiftAccountDetails"] | components["schemas"]["sortCodeDetails"];
-        wireTransfer: {
-            /**
+      type: 'sortCode';
+      /** @description sort code has XX-XX-XX format */
+      code: string;
+      accountNumber: string;
+    };
+    wireDetails: components['schemas']['ibanAccountDetails'] | components['schemas']['swiftAccountDetails'] | components['schemas']['sortCodeDetails'];
+    wireTransfer: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type: "wireTransfer";
-            accountHolderName: string;
-            bankName: string;
-            wireDetails: components["schemas"]["wireDetails"];
-            line1?: string;
-            city?: string;
-            postalCode?: string;
-            country?: string;
-        };
-        wireTransferUSA: {
-            /**
+      type: 'wireTransfer';
+      accountHolderName: string;
+      bankName: string;
+      wireDetails: components['schemas']['wireDetails'];
+      line1?: string;
+      city?: string;
+      postalCode?: string;
+      country?: string;
+    };
+    wireTransferUSA: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type: "wireTransferUSA";
-            accountNumber: string;
-            routingNumber: string;
-            line1?: string;
-            city?: string;
-            postalCode?: string;
-            country?: string;
-            state?: string;
-        };
-        cryptoTransfer: {
-            /**
+      type: 'wireTransferUSA';
+      accountNumber: string;
+      routingNumber: string;
+      line1?: string;
+      city?: string;
+      postalCode?: string;
+      country?: string;
+      state?: string;
+    };
+    cryptoTransfer: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type: "cryptoTransfer";
-            network: string;
-            contractAddress: string;
-            walletAddress: string;
-        };
-        paymentInstructions: {
-            /**
+      type: 'cryptoTransfer';
+      network: string;
+      contractAddress: string;
+      walletAddress: string;
+    };
+    paymentInstructions: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type: "paymentInstructions";
-            instruction: string;
-        };
-        paymentMethod: {
-            description: string;
-            /** @description accepted currency for payment */
-            currency: string;
-            methodInstruction: components["schemas"]["wireTransfer"] | components["schemas"]["wireTransferUSA"] | components["schemas"]["cryptoTransfer"] | components["schemas"]["paymentInstructions"];
-        };
-        paymentMethods: components["schemas"]["paymentMethod"][];
-        /**
+      type: 'paymentInstructions';
+      instruction: string;
+    };
+    paymentMethod: {
+      description: string;
+      /** @description accepted currency for payment */
+      currency: string;
+      methodInstruction: components['schemas']['wireTransfer'] | components['schemas']['wireTransferUSA'] | components['schemas']['cryptoTransfer'] | components['schemas']['paymentInstructions'];
+    };
+    paymentMethods: components['schemas']['paymentMethod'][];
+    /**
          * @description finp2p resource id format
          * @example bank-x:101:9929ccaf-8967-4ba3-9198-a4b8e3128388
          */
-        resourceId: string;
-        "ledgerAssetIdentifierTypeCAIP-19": {
-            /**
+    resourceId: string;
+    'ledgerAssetIdentifierTypeCAIP-19': {
+      /**
              * @description Classification type standards (enum property replaced by openapi-typescript)
              * @enum {string}
              */
-            assetIdentifierType: "CAIP-19";
-            network: string;
-            tokenId: string;
-            standard: string;
-        };
-        ledgerAssetIdentifier: components["schemas"]["ledgerAssetIdentifierTypeCAIP-19"];
-        /** @description describes asset information */
-        finp2pAsset: {
-            id: components["schemas"]["resourceId"];
-            ledgerIdentifier: components["schemas"]["ledgerAssetIdentifier"];
-        };
-        finp2pAssetBase: {
-            /** @description unique resource ID of the FinP2P asset */
-            resourceId: string;
-        };
-        walletAccount: {
-            /**
+      assetIdentifierType: 'CAIP-19';
+      network?: string;
+      tokenId: string;
+      standard?: string;
+    };
+    ledgerAssetIdentifier: components['schemas']['ledgerAssetIdentifierTypeCAIP-19'];
+    /** @description describes asset information */
+    finp2pAsset: {
+      id: components['schemas']['resourceId'];
+      ledgerIdentifier: components['schemas']['ledgerAssetIdentifier'];
+    };
+    finp2pAssetBase: {
+      /** @description unique resource ID of the FinP2P asset */
+      resourceId: string;
+    };
+    walletAccount: {
+      /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type: "walletAccount";
-            /** @description address of the wallet */
-            address: string;
-        };
-        receiptExecutionContext: {
-            executionPlanId: string;
-            instructionSequenceNumber: number;
-        };
-        receiptTradeDetails: {
-            intentId?: string;
-            intentVersion?: string;
-            executionContext?: components["schemas"]["receiptExecutionContext"];
-        };
-        /** @description The name of the asset */
-        assetName: string;
-        /**
+      type: 'walletAccount';
+      /** @description address of the wallet */
+      address: string;
+    };
+    caip10Account: {
+      /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+      type: 'caip10Account';
+      /** @description CAIP-2 chain_id, e.g. "eip155:1", "solana:5eykt4...", "hedera:mainnet" (the same token used by the CAIP-19 asset identifier network) */
+      network: string;
+      /** @description CAIP-10 account_address (chain-native address) */
+      address: string;
+    };
+    custodialAccount: {
+      /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+      type: 'custodialAccount';
+      /** @description Custody provider discriminator, e.g. "fireblocks" */
+      provider: string;
+      /** @description Provider-internal account identifier (e.g. a Fireblocks vault account id) */
+      vaultAccountId: string;
+      /** @description Optional. Narrows the custodial account to a specific asset/chain. */
+      assetId?: string;
+    };
+    receiptExecutionContext: {
+      executionPlanId: string;
+      instructionSequenceNumber: number;
+    };
+    receiptTradeDetails: {
+      intentId?: string;
+      intentVersion?: string;
+      executionContext?: components['schemas']['receiptExecutionContext'];
+    };
+    /** @description The name of the asset */
+    assetName: string;
+    /**
          * @description Owner resource id
          * @example bank-x:101:511c1d7f-4ed8-410d-887c-a10e3e499a01
          */
-        ownerResourceId: string;
-        /**
+    ownerResourceId: string;
+    /**
          * @description Indicates how the asset is denominated
          * @enum {string}
          */
-        assetDenominationType: "finp2p" | "fiat" | "cryptocurrency";
-        assetDenomination: {
-            type: components["schemas"]["assetDenominationType"];
-            /** @description Unique code identifying the denomination asset type */
-            code: string;
-        };
+    assetDenominationType: 'finp2p' | 'fiat' | 'cryptocurrency';
+    assetDenomination: {
+      type: components['schemas']['assetDenominationType'];
+      /** @description Unique code identifying the denomination asset type */
+      code: string;
     };
-    responses: never;
-    parameters: never;
-    requestBodies: never;
-    headers: never;
-    pathItems: never;
+    noneAccount: Record<string, never>;
+    networkAccount: components['schemas']['walletAccount'] | components['schemas']['caip10Account'] | components['schemas']['custodialAccount'] | components['schemas']['noneAccount'];
+  };
+  responses: never;
+  parameters: never;
+  requestBodies: never;
+  headers: never;
+  pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-    approveExecutionPlan: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["ApproveExecutionPlanRequest"];
-            };
-        };
-        responses: {
-            /** @description successful operation */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ApproveExecutionPlanResponse"];
-                };
-            };
-            /** @description Invalid Input */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description System error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
+  approveExecutionPlan: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    executionPlanProposal: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["executionPlanProposalRequest"];
-            };
-        };
-        responses: {
-            /** @description successful operation */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ApproveExecutionPlanResponse"];
-                };
-            };
-            /** @description Invalid Input */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description System error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
+    requestBody?: {
+      content: {
+        'application/json': components['schemas']['ApproveExecutionPlanRequest'];
+      };
     };
-    executionPlanProposalStatus: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description successful operation */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["executionPlanProposalStatusRequest"];
-            };
+        content: {
+          'application/json': components['schemas']['ApproveExecutionPlanResponse'];
         };
-        responses: {
-            /** @description successful operation */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description successful operation */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Invalid Input */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description System error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 1002,
+                     *           "message": "Invalid request format"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 2202,
+                     *           "message": "Internal service failure"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
     };
-    depositInstruction: {
-        parameters: {
-            query?: never;
-            header: {
-                /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
-                "Idempotency-Key": string;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["DepositInstructionRequest"];
-            };
-        };
-        responses: {
-            /** @description successful operation */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DepositInstructionResponse"];
-                };
-            };
-            /** @description Invalid Input */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description System error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
+  };
+  executionPlanProposal: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    payout: {
-        parameters: {
-            query?: never;
-            header: {
-                /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
-                "Idempotency-Key": string;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["PayoutRequest"];
-            };
-        };
-        responses: {
-            /** @description successful operation */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PayoutResponse"];
-                };
-            };
-            /** @description Invalid Input */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description System error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
+    requestBody?: {
+      content: {
+        'application/json': components['schemas']['executionPlanProposalRequest'];
+      };
     };
-    getAssetBalance: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description successful operation */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["GetAssetBalanceRequest"];
-            };
+        content: {
+          'application/json': components['schemas']['ApproveExecutionPlanResponse'];
         };
-        responses: {
-            /** @description successful operation */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["GetAssetBalanceResponse"];
-                };
-            };
-            /** @description Owner not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description System error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 1002,
+                     *           "message": "Invalid request format"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 2202,
+                     *           "message": "Internal service failure"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
     };
-    createAsset: {
-        parameters: {
-            query?: never;
-            header: {
-                /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
-                "Idempotency-Key": string;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["CreateAssetRequest"];
-            };
-        };
-        responses: {
-            /** @description successful operation */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CreateAssetResponse"];
-                };
-            };
-            /** @description Invalid Input */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description System error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
+  };
+  executionPlanProposalStatus: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    issueAssets: {
-        parameters: {
-            query?: never;
-            header: {
-                /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
-                "Idempotency-Key": string;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["IssueAssetsRequest"];
-            };
-        };
-        responses: {
-            /** @description successful operation */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["IssueAssetsResponse"];
-                };
-            };
-            /** @description Invalid Input */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description System error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
+    requestBody?: {
+      content: {
+        'application/json': components['schemas']['executionPlanProposalStatusRequest'];
+      };
     };
-    redeemAssets: {
-        parameters: {
-            query?: never;
-            header: {
-                /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
-                "Idempotency-Key": string;
-            };
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description successful operation */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["RedeemAssetsRequest"];
-            };
+        content?: never;
+      };
+      /** @description successful operation */
+      204: {
+        headers: {
+          [name: string]: unknown;
         };
-        responses: {
-            /** @description successful operation */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RedeemAssetsResponse"];
-                };
-            };
-            /** @description Invalid Input */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description System error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
+        content?: never;
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 1002,
+                     *           "message": "Invalid request format"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 2202,
+                     *           "message": "Internal service failure"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
     };
-    transferAsset: {
-        parameters: {
-            query?: never;
-            header: {
-                /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
-                "Idempotency-Key": string;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["TransferAssetRequest"];
-            };
-        };
-        responses: {
-            /** @description successful operation */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["TransferAssetResponse"];
-                };
-            };
-            /** @description Invalid Input */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description System error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
+  };
+  depositInstruction: {
+    parameters: {
+      query?: never;
+      header: {
+        /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
+        'Idempotency-Key': string;
+      };
+      path?: never;
+      cookie?: never;
     };
-    getReceipt: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description ID of the asset transaction */
-                transactionId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description successful operation */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["GetReceiptResponse"];
-                };
-            };
-            /** @description Transaction not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description System error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
+    requestBody?: {
+      content: {
+        'application/json': components['schemas']['DepositInstructionRequest'];
+      };
     };
-    holdOperation: {
-        parameters: {
-            query?: never;
-            header: {
-                /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
-                "Idempotency-Key": string;
-            };
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description successful operation */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["HoldOperationRequest"];
-            };
+        content: {
+          'application/json': components['schemas']['DepositInstructionResponse'];
         };
-        responses: {
-            /** @description successful operation */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HoldOperationResponse"];
-                };
-            };
-            /** @description Invalid Input */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description System error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 1002,
+                     *           "message": "Invalid request format"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 2202,
+                     *           "message": "Internal service failure"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
     };
-    releaseOperation: {
-        parameters: {
-            query?: never;
-            header: {
-                /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
-                "Idempotency-Key": string;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["ReleaseOperationRequest"];
-            };
-        };
-        responses: {
-            /** @description successful operation */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ReleaseOperationResponse"];
-                };
-            };
-            /** @description Invalid Input */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description System error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
+  };
+  payout: {
+    parameters: {
+      query?: never;
+      header: {
+        /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
+        'Idempotency-Key': string;
+      };
+      path?: never;
+      cookie?: never;
     };
-    rollbackOperation: {
-        parameters: {
-            query?: never;
-            header: {
-                /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
-                "Idempotency-Key": string;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["RollbackOperationRequest"];
-            };
-        };
-        responses: {
-            /** @description successful operation */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RollbackOperationResponse"];
-                };
-            };
-            /** @description Invalid Input */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description System error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
+    requestBody?: {
+      content: {
+        'application/json': components['schemas']['PayoutRequest'];
+      };
     };
-    getOperation: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description correlation id of an operation */
-                cid: string;
-            };
-            cookie?: never;
+    responses: {
+      /** @description successful operation */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description successful operation */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["GetOperationStatusResponse"];
-                };
-            };
-            /** @description Transaction not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description System error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
+        content: {
+          'application/json': components['schemas']['PayoutResponse'];
         };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 1002,
+                     *           "message": "Invalid request format"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 2202,
+                     *           "message": "Internal service failure"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
     };
-    GetAssetBalanceInfo: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["AssetBalanceInfoRequest"];
-            };
-        };
-        responses: {
-            /** @description successful operation */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AssetBalanceInfoResponse"];
-                };
-            };
-            /** @description Owner not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description System error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
+  };
+  getAssetBalance: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    getHealth: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Service is healthy */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example ok */
-                        status?: string;
-                    };
-                };
-            };
-            /** @description Service is unavailable */
-            503: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example unavailable */
-                        status?: string;
-                    };
-                };
-            };
-        };
+    requestBody?: {
+      content: {
+        'application/json': components['schemas']['GetAssetBalanceRequest'];
+      };
     };
+    responses: {
+      /** @description successful operation */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['GetAssetBalanceResponse'];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 1002,
+                     *           "message": "Invalid request format"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 1100,
+                     *           "message": "Resource not found"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 2202,
+                     *           "message": "Internal service failure"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+    };
+  };
+  createAsset: {
+    parameters: {
+      query?: never;
+      header: {
+        /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
+        'Idempotency-Key': string;
+      };
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        'application/json': components['schemas']['CreateAssetRequest'];
+      };
+    };
+    responses: {
+      /** @description successful operation */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['CreateAssetResponse'];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 1002,
+                     *           "message": "Invalid request format"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 2202,
+                     *           "message": "Internal service failure"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+    };
+  };
+  issueAssets: {
+    parameters: {
+      query?: never;
+      header: {
+        /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
+        'Idempotency-Key': string;
+      };
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        'application/json': components['schemas']['IssueAssetsRequest'];
+      };
+    };
+    responses: {
+      /** @description successful operation */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['IssueAssetsResponse'];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 1002,
+                     *           "message": "Invalid request format"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 2202,
+                     *           "message": "Internal service failure"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+    };
+  };
+  redeemAssets: {
+    parameters: {
+      query?: never;
+      header: {
+        /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
+        'Idempotency-Key': string;
+      };
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        'application/json': components['schemas']['RedeemAssetsRequest'];
+      };
+    };
+    responses: {
+      /** @description successful operation */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['RedeemAssetsResponse'];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 1002,
+                     *           "message": "Invalid request format"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 2202,
+                     *           "message": "Internal service failure"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+    };
+  };
+  moveAssets: {
+    parameters: {
+      query?: never;
+      header: {
+        /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
+        'Idempotency-Key': string;
+      };
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        'application/json': components['schemas']['MoveAssetsRequest'];
+      };
+    };
+    responses: {
+      /** @description successful operation */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['MoveAssetsResponse'];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 1002,
+                     *           "message": "Invalid request format"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 2202,
+                     *           "message": "Internal service failure"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+    };
+  };
+  transferAsset: {
+    parameters: {
+      query?: never;
+      header: {
+        /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
+        'Idempotency-Key': string;
+      };
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        'application/json': components['schemas']['TransferAssetRequest'];
+      };
+    };
+    responses: {
+      /** @description successful operation */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['TransferAssetResponse'];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 1002,
+                     *           "message": "Invalid request format"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 2202,
+                     *           "message": "Internal service failure"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+    };
+  };
+  createAccount: {
+    parameters: {
+      query?: never;
+      header: {
+        /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
+        'Idempotency-Key': string;
+      };
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['CreateAccountRequest'];
+      };
+    };
+    responses: {
+      /** @description Challenge will be issued asynchronously; poll `/operations/status/{cid}`. */
+      202: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['AccountOperationAccepted'];
+        };
+      };
+      /** @description Challenge issued immediately as part of the response. */
+      207: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['AccountOperationChallenge'];
+        };
+      };
+    };
+  };
+  submitAccountProof: {
+    parameters: {
+      query?: never;
+      header: {
+        /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
+        'Idempotency-Key': string;
+      };
+      path: {
+        /** @description Correlation id of the account workflow. */
+        cid: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['SubmitAccountProofRequest'];
+      };
+    };
+    responses: {
+      /** @description Proof accepted; verification continues per response strategy. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['AccountOperationAccepted'];
+        };
+      };
+    };
+  };
+  removeAccount: {
+    parameters: {
+      query?: never;
+      header: {
+        /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
+        'Idempotency-Key': string;
+      };
+      path: {
+        /** @description LA-assigned account identifier. */
+        accountId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description successful operation */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['AccountOperationAccepted'];
+        };
+      };
+    };
+  };
+  getReceipt: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description ID of the asset transaction */
+        transactionId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description successful operation */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['GetReceiptResponse'];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 1100,
+                     *           "message": "Resource not found"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 2202,
+                     *           "message": "Internal service failure"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+    };
+  };
+  holdOperation: {
+    parameters: {
+      query?: never;
+      header: {
+        /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
+        'Idempotency-Key': string;
+      };
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        'application/json': components['schemas']['HoldOperationRequest'];
+      };
+    };
+    responses: {
+      /** @description successful operation */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HoldOperationResponse'];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 1002,
+                     *           "message": "Invalid request format"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 1100,
+                     *           "message": "Resource not found"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 2202,
+                     *           "message": "Internal service failure"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+    };
+  };
+  releaseOperation: {
+    parameters: {
+      query?: never;
+      header: {
+        /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
+        'Idempotency-Key': string;
+      };
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        'application/json': components['schemas']['ReleaseOperationRequest'];
+      };
+    };
+    responses: {
+      /** @description successful operation */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ReleaseOperationResponse'];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 1002,
+                     *           "message": "Invalid request format"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 2202,
+                     *           "message": "Internal service failure"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+    };
+  };
+  rollbackOperation: {
+    parameters: {
+      query?: never;
+      header: {
+        /** @description hex encoding of a 32-byte payload consisting of 24 random bytes + 8-byte epoch timestamp (seconds) */
+        'Idempotency-Key': string;
+      };
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        'application/json': components['schemas']['RollbackOperationRequest'];
+      };
+    };
+    responses: {
+      /** @description successful operation */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['RollbackOperationResponse'];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 1002,
+                     *           "message": "Invalid request format"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 2202,
+                     *           "message": "Internal service failure"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+    };
+  };
+  getOperation: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description correlation id of an operation */
+        cid: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description successful operation */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['GetOperationStatusResponse'];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 1100,
+                     *           "message": "Resource not found"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 2202,
+                     *           "message": "Internal service failure"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+    };
+  };
+  GetAssetBalanceInfo: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['AssetBalanceInfoRequest'];
+      };
+    };
+    responses: {
+      /** @description successful operation */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['AssetBalanceInfoResponse'];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 1002,
+                     *           "message": "Invalid request format"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 1100,
+                     *           "message": "Resource not found"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "code": 2202,
+                     *           "message": "Internal service failure"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+          'application/json': components['schemas']['APIErrors'];
+        };
+      };
+    };
+  };
+  getHealth: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Service is healthy */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            /** @example ok */
+            status?: string;
+          };
+        };
+      };
+      /** @description Service is unavailable */
+      503: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            /** @example unavailable */
+            status?: string;
+          };
+        };
+      };
+    };
+  };
 }

--- a/skeleton/src/routes/routes.ts
+++ b/skeleton/src/routes/routes.ts
@@ -12,6 +12,7 @@ import {
   Source,
   TokenService,
 } from '../models';
+import { NotSupportedNetworkAccountService } from '../services/accounts';
 import { Application } from 'express';
 import { errorHandler } from './errors';
 import {
@@ -49,7 +50,10 @@ export const register = (app: Application,
   healthService: HealthService,
   paymentService: PaymentService,
   planService: PlanApprovalService,
-  networkAccountService: NetworkAccountService,
+  // Defaulted so the account surface is opt-in: an existing adapter that does
+  // not pass one keeps compiling and its /accounts routes answer "not
+  // supported", instead of this patch bump breaking every out-of-repo caller.
+  networkAccountService: NetworkAccountService = new NotSupportedNetworkAccountService(),
   options?: RegisterOptions,
 ): void => {
   const { mappingConfig, mappingService } = options ?? {};

--- a/skeleton/src/routes/routes.ts
+++ b/skeleton/src/routes/routes.ts
@@ -5,6 +5,8 @@ import {
   EscrowService,
   HealthService,
   AccountMappingService,
+  NetworkAccountService,
+  NotSupportedError,
   PaymentService,
   PlanApprovalService,
   Source,
@@ -13,9 +15,11 @@ import {
 import { Application } from 'express';
 import { errorHandler } from './errors';
 import {
+  accountOperationToAPI,
   assetBindingOptFromAPI, assetDenominationOptFromAPI,
   assetFromAPI,
   balanceToAPI,
+  bindInfoOptFromAPI,
   createAssetOperationToAPI,
   depositAssetFromAPI,
   depositOperationToAPI,
@@ -33,6 +37,11 @@ import { AccountMappingConfig, registerMappingRoutes } from './operational';
 
 const basePath = 'api';
 
+export interface RegisterOptions {
+  mappingConfig?: AccountMappingConfig;
+  mappingService?: AccountMappingService;
+}
+
 export const register = (app: Application,
   tokenService: TokenService,
   escrowService: EscrowService,
@@ -40,9 +49,10 @@ export const register = (app: Application,
   healthService: HealthService,
   paymentService: PaymentService,
   planService: PlanApprovalService,
-  mappingConfig?: AccountMappingConfig,
-  mappingService?: AccountMappingService,
+  networkAccountService: NetworkAccountService,
+  options?: RegisterOptions,
 ): void => {
+  const { mappingConfig, mappingService } = options ?? {};
   if (mappingConfig && !mappingService) {
     throw new Error('mappingConfig requires a mappingService. Construct AccountMappingServiceImpl(store) and pass it in.');
   }
@@ -163,7 +173,7 @@ export const register = (app: Application,
       const ast = assetFromAPI(asset);
       const exCtx = executionContextOptFromAPI(executionContext);
 
-      const rsp = await tokenService.issue(ik, ast, destination.finId, quantity, exCtx);
+      const rsp = await tokenService.issue(ik, ast, destinationFromAPI(destination), quantity, exCtx);
 
       res.json(receiptOperationToAPI(rsp));
     });
@@ -197,7 +207,7 @@ export const register = (app: Application,
       const sgn = signatureFromAPI(signature);
       const exCtx = executionContextOptFromAPI(executionContext);
 
-      const rsp = await tokenService.redeem(ik, nonce, source.finId, ast, quantity, operationId, sgn, exCtx);
+      const rsp = await tokenService.redeem(ik, nonce, sourceFromAPI(source), ast, quantity, operationId, sgn, exCtx);
       res.json(receiptOperationToAPI(rsp));
     });
 
@@ -303,6 +313,37 @@ export const register = (app: Application,
         signatureOptFromAPI(signature),
       );
       res.json(receiptOperationToAPI(receiptOp));
+    });
+
+  app.post<{},
+  LedgerAPI['schemas']['AccountOperationAccepted'],
+  LedgerAPI['schemas']['CreateAccountRequest']>(
+    `/${basePath}/accounts/create`,
+    async (req, res) => {
+      const ik = req.headers['idempotency-key'] as string | undefined ?? '';
+      const { organizationId, assetId, finId, bindInfo } = req.body;
+
+      const op = await networkAccountService.createAccount(ik, organizationId, assetId, finId, bindInfoOptFromAPI(bindInfo));
+
+      res.status(202).json(accountOperationToAPI(op));
+    });
+
+  app.post(
+    `/${basePath}/accounts/:cid/proof`,
+    async () => {
+      throw new NotSupportedError('ownership challenges are not supported by this adapter');
+    });
+
+  app.delete<LedgerOperations['removeAccount']['parameters']['path'],
+  LedgerAPI['schemas']['AccountOperationAccepted'], {}>(
+    `/${basePath}/accounts/:accountId`,
+    async (req, res) => {
+      const ik = req.headers['idempotency-key'] as string | undefined ?? '';
+      const { accountId } = req.params;
+
+      const op = await networkAccountService.removeAccount(ik, accountId);
+
+      res.json(accountOperationToAPI(op));
     });
 
   app.get<LedgerOperations['getOperation']['parameters']['path'],

--- a/skeleton/src/services/accounts/index.ts
+++ b/skeleton/src/services/accounts/index.ts
@@ -1,0 +1,2 @@
+export * from './service';
+export * from './notSupported';

--- a/skeleton/src/services/accounts/notSupported.ts
+++ b/skeleton/src/services/accounts/notSupported.ts
@@ -1,0 +1,23 @@
+import {
+  AccountOperation,
+  BindInfo,
+  NetworkAccountService,
+  NotSupportedError,
+} from '../../models';
+
+/**
+ * Pass to `register()` when the adapter has no network-account support: every
+ * account endpoint answers 501 (mirroring the vanilla Go adapter's
+ * notImplemented).
+ */
+export class NotSupportedNetworkAccountService implements NetworkAccountService {
+
+  createAccount(_idempotencyKey: string, _organizationId: string, _assetId: string,
+    _finId: string, _bindInfo: BindInfo | undefined): Promise<AccountOperation> {
+    throw new NotSupportedError('network accounts are not supported by this adapter');
+  }
+
+  removeAccount(_idempotencyKey: string, _accountId: string): Promise<AccountOperation> {
+    throw new NotSupportedError('network accounts are not supported by this adapter');
+  }
+}

--- a/skeleton/src/services/accounts/service.ts
+++ b/skeleton/src/services/accounts/service.ts
@@ -1,0 +1,62 @@
+import { randomUUID } from 'crypto';
+import {
+  AccountOperation,
+  BindInfo,
+  NetworkAccountService,
+  NetworkAccountValidator,
+  NotSupportedError,
+  successfulAccountOperation,
+} from '../../models';
+import { NetworkAccountStore } from '../../storage';
+
+/**
+ * Sync trust-model implementation of investor account onboarding: the
+ * caller-supplied wallet is recorded as-is, without an ownership challenge —
+ * the same trust the old finId->wallet mapping API extended. Both methods are
+ * single-call and terminal, so instances may be wrapped in the workflow
+ * `createServiceProxy` like any other service.
+ *
+ * One binding per investor per (organizationId, assetId): a repeat create for
+ * the same finId replays the recorded binding — even with a different wallet
+ * in the request; changing wallets is remove + create. Replay-by-finId also
+ * keeps crash-recovery replays from minting duplicates. Different investors
+ * may still bind the same address (omnibus: one shared wallet, many investors).
+ */
+export class NetworkAccountServiceImpl implements NetworkAccountService {
+
+  constructor(
+    protected readonly store: NetworkAccountStore,
+    protected readonly validator?: NetworkAccountValidator,
+  ) {
+  }
+
+  async createAccount(idempotencyKey: string, organizationId: string, assetId: string,
+    finId: string, bindInfo: BindInfo | undefined): Promise<AccountOperation> {
+    if (!bindInfo) {
+      throw new NotSupportedError('create-new account mode is not supported by this adapter');
+    }
+    const { account } = bindInfo;
+    await this.validator?.validate(account);
+
+    const existing = await this.store.getByFinId(organizationId, assetId, finId);
+    if (existing) {
+      return successfulAccountOperation('', { id: existing.accountId, account: existing.account });
+    }
+
+    const row = await this.store.insert({
+      accountId: randomUUID(),
+      idempotencyKey: idempotencyKey || undefined,
+      organizationId, assetId, finId, account,
+    });
+    return successfulAccountOperation('', { id: row.accountId, account: row.account });
+  }
+
+  async removeAccount(_idempotencyKey: string, accountId: string): Promise<AccountOperation> {
+    const removed = await this.store.remove(accountId);
+    // idempotent: an absent row is a success so router retries don't fail
+    return successfulAccountOperation('', {
+      id: accountId,
+      account: removed?.account ?? { type: 'none' },
+    });
+  }
+}

--- a/skeleton/src/services/accounts/service.ts
+++ b/skeleton/src/services/accounts/service.ts
@@ -38,11 +38,9 @@ export class NetworkAccountServiceImpl implements NetworkAccountService {
     const { account } = bindInfo;
     await this.validator?.validate(account);
 
-    const existing = await this.store.getByFinId(organizationId, assetId, finId);
-    if (existing) {
-      return successfulAccountOperation('', { id: existing.accountId, account: existing.account });
-    }
-
+    // insert() is atomic and returns the pre-existing row when one is already
+    // bound for this (organization, asset, finId), which is what makes a repeat
+    // create replay the recorded binding rather than race or duplicate it.
     const row = await this.store.insert({
       accountId: randomUUID(),
       idempotencyKey: idempotencyKey || undefined,

--- a/skeleton/src/services/index.ts
+++ b/skeleton/src/services/index.ts
@@ -1,5 +1,6 @@
 export * from './proof';
 export * from './plan';
 export * from './payments';
+export * from './accounts';
 export * from './verify';
 export * from './mapping';

--- a/skeleton/src/storage/index.ts
+++ b/skeleton/src/storage/index.ts
@@ -2,3 +2,4 @@ export * from './config';
 export * from './interfaces';
 export * from './accounts';
 export * from './assets';
+export * from './networkAccounts';

--- a/skeleton/src/storage/interfaces.ts
+++ b/skeleton/src/storage/interfaces.ts
@@ -1,3 +1,5 @@
+import { NetworkAccount } from '../models';
+
 export interface Account {
   finId: string;
   fields: Record<string, string>;
@@ -22,4 +24,28 @@ export interface AccountStore {
 export interface AssetStore {
   getAsset(assetId: string): Promise<Asset | undefined>;
   saveAsset(asset: Omit<Asset, 'created_at' | 'updated_at'>): Promise<Asset>;
+}
+
+/**
+ * One binding per (organizationId, assetId, finId) — enforced by a unique
+ * index. The same address can still be bound many times (omnibus: one shared
+ * wallet whitelisted for many investors router-side); the finId tells the
+ * bindings apart per investor.
+ */
+export interface NetworkAccountRow {
+  /** LA-assigned account identifier (used by `DELETE /accounts/{accountId}`). */
+  accountId: string;
+  /** Idempotency-Key of the create request, kept for tracing only; replay
+   *  lookup is by finId. Undefined when the header was absent. */
+  idempotencyKey: string | undefined;
+  organizationId: string;
+  assetId: string;
+  finId: string;
+  account: NetworkAccount;
+}
+
+export interface NetworkAccountStore {
+  insert(row: NetworkAccountRow): Promise<NetworkAccountRow>;
+  getByFinId(organizationId: string, assetId: string, finId: string): Promise<NetworkAccountRow | undefined>;
+  remove(accountId: string): Promise<NetworkAccountRow | undefined>;
 }

--- a/skeleton/src/storage/interfaces.ts
+++ b/skeleton/src/storage/interfaces.ts
@@ -45,6 +45,11 @@ export interface NetworkAccountRow {
 }
 
 export interface NetworkAccountStore {
+  /**
+   * Insert the binding, or return the row that already exists for this
+   * (organization, asset, finId). Implementations must make this atomic —
+   * a read-then-insert races two concurrent creates for the same triple.
+   */
   insert(row: NetworkAccountRow): Promise<NetworkAccountRow>;
   getByFinId(organizationId: string, assetId: string, finId: string): Promise<NetworkAccountRow | undefined>;
   remove(accountId: string): Promise<NetworkAccountRow | undefined>;

--- a/skeleton/src/storage/networkAccounts.ts
+++ b/skeleton/src/storage/networkAccounts.ts
@@ -29,16 +29,37 @@ export class PgNetworkAccountStore implements NetworkAccountStore {
     this.schema = schemaName;
   }
 
+  /**
+   * Insert the binding, or return the existing one for this
+   * (organization, asset, finId).
+   *
+   * `ON CONFLICT DO NOTHING` rather than a read-then-insert: two concurrent
+   * creates for the same triple would both see no row and both insert, and the
+   * unique index would reject the loser with 23505 — surfacing as a 500. The
+   * conflict target is `network_accounts_org_asset_fin_id_idx`, so the loser
+   * gets no row back and re-selects the winner's instead. This is also one
+   * round-trip fewer on the happy path.
+   */
   async insert(row: NetworkAccountRow): Promise<NetworkAccountRow> {
     const { accountId, idempotencyKey, organizationId, assetId, finId, account } = row;
     const result = await this.pool.query(
       `INSERT INTO ${this.schema}.network_accounts
          (account_id, idempotency_key, organization_id, asset_id, fin_id, account)
        VALUES ($1, $2, $3, $4, $5, $6)
+       ON CONFLICT (organization_id, asset_id, fin_id) DO NOTHING
        RETURNING *`,
       [accountId, idempotencyKey ?? null, organizationId, assetId, finId, JSON.stringify(account)],
     );
-    return toRow(result.rows[0]);
+    if (result.rows.length > 0) {
+      return toRow(result.rows[0]);
+    }
+    const existing = await this.getByFinId(organizationId, assetId, finId);
+    if (!existing) {
+      // Only reachable if the conflicting row was deleted between the insert
+      // and this re-select.
+      throw new Error(`failed to insert or locate network account for ${organizationId}/${assetId}/${finId}`);
+    }
+    return existing;
   }
 
   async getByFinId(organizationId: string, assetId: string, finId: string): Promise<NetworkAccountRow | undefined> {

--- a/skeleton/src/storage/networkAccounts.ts
+++ b/skeleton/src/storage/networkAccounts.ts
@@ -1,0 +1,60 @@
+import { Pool } from 'pg';
+import { NetworkAccountRow, NetworkAccountStore } from './interfaces';
+import { assertValidSchemaName, DEFAULT_SCHEMA_NAME } from './config';
+import { NetworkAccount } from '../models';
+
+interface DbRow {
+  account_id: string;
+  idempotency_key: string | null;
+  organization_id: string;
+  asset_id: string;
+  fin_id: string;
+  account: NetworkAccount;
+}
+
+const toRow = (db: DbRow): NetworkAccountRow => ({
+  accountId: db.account_id,
+  idempotencyKey: db.idempotency_key ?? undefined,
+  organizationId: db.organization_id,
+  assetId: db.asset_id,
+  finId: db.fin_id,
+  account: db.account,
+});
+
+export class PgNetworkAccountStore implements NetworkAccountStore {
+  private readonly schema: string;
+
+  constructor(private pool: Pool, schemaName: string = DEFAULT_SCHEMA_NAME) {
+    assertValidSchemaName(schemaName);
+    this.schema = schemaName;
+  }
+
+  async insert(row: NetworkAccountRow): Promise<NetworkAccountRow> {
+    const { accountId, idempotencyKey, organizationId, assetId, finId, account } = row;
+    const result = await this.pool.query(
+      `INSERT INTO ${this.schema}.network_accounts
+         (account_id, idempotency_key, organization_id, asset_id, fin_id, account)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING *`,
+      [accountId, idempotencyKey ?? null, organizationId, assetId, finId, JSON.stringify(account)],
+    );
+    return toRow(result.rows[0]);
+  }
+
+  async getByFinId(organizationId: string, assetId: string, finId: string): Promise<NetworkAccountRow | undefined> {
+    const result = await this.pool.query(
+      `SELECT * FROM ${this.schema}.network_accounts
+       WHERE organization_id = $1 AND asset_id = $2 AND fin_id = $3`,
+      [organizationId, assetId, finId],
+    );
+    return result.rows.length > 0 ? toRow(result.rows[0]) : undefined;
+  }
+
+  async remove(accountId: string): Promise<NetworkAccountRow | undefined> {
+    const result = await this.pool.query(
+      `DELETE FROM ${this.schema}.network_accounts WHERE account_id = $1 RETURNING *`,
+      [accountId],
+    );
+    return result.rows.length > 0 ? toRow(result.rows[0]) : undefined;
+  }
+}

--- a/skeleton/src/workflows/service.ts
+++ b/skeleton/src/workflows/service.ts
@@ -13,6 +13,9 @@ import {
   EscrowService,
   PaymentService,
   failedDepositOperation,
+  NetworkAccountService,
+  pendingAccountOperation,
+  failedAccountOperation,
   OperationResponseStrategy,
   OperationMetadata,
 } from '../models';
@@ -76,6 +79,9 @@ const wrappedResponse = (methodName: string, opMetadata: OperationMetadata | und
       return pendingOrError(cid => pendingPlan(cid, opMetadata), (cid, code, message) => rejectedPlan(code, message));
     case compiletimeMethodName<PaymentService>('getDepositInstruction'):
       return pendingOrError(cid => pendingDepositOperation(cid, opMetadata), (cid, code, message) => failedDepositOperation(code, message));
+    case compiletimeMethodName<NetworkAccountService>('createAccount'):
+    case compiletimeMethodName<NetworkAccountService>('removeAccount'):
+      return pendingOrError(cid => pendingAccountOperation(cid, opMetadata), (cid, code, message) => failedAccountOperation(cid, code, message));
     default:
       throw new Error(`Unknown proxied method '${methodName}' — add it to wrappedResponse()`);
   }

--- a/skeleton/tests/workflows/network-accounts.test.ts
+++ b/skeleton/tests/workflows/network-accounts.test.ts
@@ -1,0 +1,156 @@
+import { migrateIfNeeded } from '../../src/workflows'
+import { PgNetworkAccountStore } from '../../src/storage'
+import { NetworkAccountServiceImpl } from '../../src/services/accounts'
+import { networkAccountFromAPI, bindInfoOptFromAPI } from '../../src/routes/mapping'
+import { AccountInvalidShapeError } from '../../src/models'
+import { Pool } from 'pg'
+
+describe("network accounts", () => {
+  let container: { connectionString: string, storageUser: string, cleanup: () => Promise<void> } = { connectionString: "", storageUser: "", cleanup: () => Promise.resolve() }
+  let pool: Pool;
+  let store: PgNetworkAccountStore;
+  let service: NetworkAccountServiceImpl;
+
+  const ORG = "bank-x";
+  const ASSET = "bank-x:102:asset-1";
+  const FIN = "02a1b2c3";
+  const wallet = (address: string) => ({ type: 'walletAccount' as const, address });
+
+  beforeEach(async () => {
+    // @ts-ignore
+    container = await global.startPostgresContainer();
+    await migrateIfNeeded({
+      connectionString: container.connectionString,
+      // @ts-ignore
+      gooseExecutablePath: await global.whichGoose(),
+      migrationListTableName: "finp2p_nodejs_skeleton_migrations",
+      storageUser: container.storageUser,
+    })
+    pool = new Pool({ connectionString: container.connectionString });
+    store = new PgNetworkAccountStore(pool);
+    service = new NetworkAccountServiceImpl(store);
+  })
+
+  afterEach(async () => {
+    await pool.end();
+    await container.cleanup();
+  });
+
+  test("bind records the account and returns an id", async () => {
+    const op = await service.createAccount("ik-1", ORG, ASSET, FIN, { account: wallet("0xAAA") });
+
+    if (op.type !== 'success') throw new Error(`expected success, got ${op.type}`);
+    expect(op.record.id).toBeTruthy();
+    expect(op.record.account).toEqual(wallet("0xAAA"));
+
+    const row = await store.getByFinId(ORG, ASSET, FIN);
+    expect(row?.account).toEqual(wallet("0xAAA"));
+  });
+
+  // The interface doc promises a repeat create replays the recorded binding.
+  // Nothing enforced that before, and the wallet in the second request is
+  // deliberately different to prove the stored one wins rather than being
+  // overwritten or duplicated.
+  test("repeat create replays the existing binding, ignoring a different wallet", async () => {
+    const first = await service.createAccount("ik-1", ORG, ASSET, FIN, { account: wallet("0xAAA") });
+    const second = await service.createAccount("ik-2", ORG, ASSET, FIN, { account: wallet("0xBBB") });
+
+    if (first.type !== 'success' || second.type !== 'success') throw new Error("expected success");
+    expect(second.record.id).toBe(first.record.id);
+    expect(second.record.account).toEqual(wallet("0xAAA"));
+
+    const row = await store.getByFinId(ORG, ASSET, FIN);
+    expect(row?.account).toEqual(wallet("0xAAA"));
+  });
+
+  // Two concurrent creates for the same (org, asset, finId) must not race the
+  // unique index into a 23505. Both should observe the same winning row.
+  test("concurrent creates for the same triple converge on one binding", async () => {
+    const [a, b] = await Promise.all([
+      service.createAccount("ik-a", ORG, ASSET, FIN, { account: wallet("0xAAA") }),
+      service.createAccount("ik-b", ORG, ASSET, FIN, { account: wallet("0xBBB") }),
+    ]);
+
+    if (a.type !== 'success' || b.type !== 'success') throw new Error("expected success");
+    expect(a.record.id).toBe(b.record.id);
+
+    const { rows } = await pool.query(
+      "SELECT count(*)::int AS n FROM ledger_adapter.network_accounts WHERE fin_id = $1", [FIN],
+    );
+    expect(rows[0].n).toBe(1);
+  });
+
+  test("the same wallet may be bound for different investors (omnibus)", async () => {
+    const a = await service.createAccount("ik-1", ORG, ASSET, "02aaaa", { account: wallet("0xSHARED") });
+    const b = await service.createAccount("ik-2", ORG, ASSET, "02bbbb", { account: wallet("0xSHARED") });
+
+    if (a.type !== 'success' || b.type !== 'success') throw new Error("expected success");
+    expect(a.record.id).not.toBe(b.record.id);
+  });
+
+  test("one binding per investor per (org, asset), but assets are independent", async () => {
+    await service.createAccount("ik-1", ORG, ASSET, FIN, { account: wallet("0xAAA") });
+    await service.createAccount("ik-2", ORG, "bank-x:102:asset-2", FIN, { account: wallet("0xCCC") });
+
+    expect((await store.getByFinId(ORG, ASSET, FIN))?.account).toEqual(wallet("0xAAA"));
+    expect((await store.getByFinId(ORG, "bank-x:102:asset-2", FIN))?.account).toEqual(wallet("0xCCC"));
+  });
+
+  test("remove deletes the binding", async () => {
+    const op = await service.createAccount("ik-1", ORG, ASSET, FIN, { account: wallet("0xAAA") });
+    if (op.type !== 'success') throw new Error("expected success");
+
+    await service.removeAccount("ik-2", op.record.id);
+    expect(await store.getByFinId(ORG, ASSET, FIN)).toBeUndefined();
+  });
+
+  // Removing something absent is a success so router retries don't fail.
+  test("remove of an absent account is a success", async () => {
+    const removed = await service.removeAccount("ik-1", "no-such-account");
+    if (removed.type !== 'success') throw new Error(`expected success, got ${removed.type}`);
+    expect(removed.record.account).toEqual({ type: 'none' });
+  });
+
+  describe("account type mapping", () => {
+    test("walletAccount maps through", () => {
+      expect(networkAccountFromAPI({ type: 'walletAccount', address: '0xAAA' }))
+        .toEqual(wallet('0xAAA'));
+    });
+
+    test("the empty object is noneAccount", () => {
+      expect(networkAccountFromAPI({})).toEqual({ type: 'none' });
+    });
+
+    // Regression: these used to fall through to { type: 'none' }, so a bind
+    // reported success while recording an empty account — and every later
+    // operation naming the real account failed 7351 AccountNotWhitelisted with
+    // nothing at bind time to explain it.
+    test("caip10Account is rejected, not degraded to none", () => {
+      expect(() => networkAccountFromAPI(
+        { type: 'caip10Account', network: 'eip155:1', address: '0xAAA' },
+      )).toThrow(AccountInvalidShapeError);
+    });
+
+    test("custodialAccount is rejected, not degraded to none", () => {
+      expect(() => networkAccountFromAPI(
+        { type: 'custodialAccount', provider: 'fireblocks', vaultAccountId: 'v7' },
+      )).toThrow(AccountInvalidShapeError);
+    });
+
+    // The router sends a bare hex hint with no template; it used to be dropped.
+    test("the raw ownership hint survives mapping", () => {
+      const bindInfo = bindInfoOptFromAPI({
+        networkAccount: { type: 'walletAccount', address: '0xAAA' },
+        ownershipSignature: { signature: 'deadbeef' },
+      } as any);
+      expect(bindInfo?.ownershipSignature).toBe('deadbeef');
+    });
+
+    test("an absent hint stays absent", () => {
+      const bindInfo = bindInfoOptFromAPI({
+        networkAccount: { type: 'walletAccount', address: '0xAAA' },
+      } as any);
+      expect(bindInfo?.ownershipSignature).toBeUndefined();
+    });
+  });
+});

--- a/vanilla-service/package-lock.json
+++ b/vanilla-service/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@owneraio/finp2p-vanilla-service",
-  "version": "0.28.6",
+  "version": "0.28.7-onboard.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-vanilla-service",
-      "version": "0.28.6",
+      "version": "0.28.7-onboard.1",
       "license": "TBD",
       "dependencies": {
-        "@owneraio/finp2p-client": "^0.28.12",
-        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.15",
+        "@owneraio/finp2p-client": "^0.28.22",
+        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.25-onboard.6",
         "bs58": "^6.0.0",
         "pg": "^8.15.6",
         "winston": "^3.18.3"
@@ -1408,9 +1408,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-client": {
-      "version": "0.28.12",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-client/0.28.12/24845c014328dc66358a33c890a7c7c0cf91b629",
-      "integrity": "sha512-ReaXR7zbrtlBECm+N+ZL/QUB3H5ptCyz3k+9Qz4uvsgKBVr3Q8NCvf3ikdbAb1f8JsM45feBiz3YdnV7GSmtrg==",
+      "version": "0.28.22",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-client/0.28.22/dcc20fa57426f112da194855269382211fc98441",
+      "integrity": "sha512-dZ7DaEPen5cu2RtZlg43eeB1V9SOxpSFOrIQeq5xBYx+DWzLDOHJPVfBJrsGImQy3z4JlXeV2KNz2wOTGkREjg==",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.12.2",
@@ -1420,9 +1420,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-nodejs-skeleton-adapter": {
-      "version": "0.28.15",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.15/990156ffae13b881f4066186b117d73927c5edd9",
-      "integrity": "sha512-YpIzwIHIqfgbgnpcyNN5YMGUZy5TotpndCsoTxNXx0+3/JNRbKBg2uCwzWWuu2DOQymMn8A4zMgbjwaVhJX0Dg==",
+      "version": "0.28.25-onboard.6",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.25-onboard.6/c99954cddeb614446d2fdfb76b652f173fb07e3d",
+      "integrity": "sha512-M0jZRMB8G+/w/qVLTlLid8xPCxx/zlQx+sNXdsaEBMyxp6rP8/2LoTbIiAwnwlVi2slTlksEZ4apxv8pdU/S1w==",
       "license": "TBD",
       "dependencies": {
         "axios": "1.11.0",

--- a/vanilla-service/package.json
+++ b/vanilla-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@owneraio/finp2p-vanilla-service",
-  "version": "0.28.6",
-  "description": "Vanilla DB ledger service for FinP2P adapters — per-investor balance segregation in PostgreSQL",
+  "version": "0.28.7",
+  "description": "Vanilla DB ledger service for FinP2P adapters \u2014 per-investor balance segregation in PostgreSQL",
   "main": "./dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
@@ -20,8 +20,8 @@
   "author": "",
   "license": "TBD",
   "dependencies": {
-    "@owneraio/finp2p-client": "^0.28.12",
-    "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.15",
+    "@owneraio/finp2p-client": "^0.28.23",
+    "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.25",
     "bs58": "^6.0.0",
     "pg": "^8.15.6",
     "winston": "^3.18.3"

--- a/vanilla-service/src/service.ts
+++ b/vanilla-service/src/service.ts
@@ -51,19 +51,18 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
   }
 
   async issue(
-    idempotencyKey: string, asset: Asset, destinationFinId: string,
+    idempotencyKey: string, asset: Asset, destination: Destination,
     quantity: string, exCtx: ExecutionContext | undefined,
   ): Promise<ReceiptOperation> {
-    getLogger().info(`Issuing ${quantity} of ${asset.assetId} to ${destinationFinId}`);
+    getLogger().info(`Issuing ${quantity} of ${asset.assetId} to ${destination.finId}`);
 
-    await this.storage.ensureAccount(destinationFinId, asset.assetId, asset.assetType);
-    const tx = await this.storage.credit(destinationFinId, quantity, asset.assetId, {
+    await this.storage.ensureAccount(destination.finId, asset.assetId, asset.assetType);
+    const tx = await this.storage.credit(destination.finId, quantity, asset.assetId, {
       idempotency_key: idempotencyKey,
       operation_type: 'issue',
       execution_context: exCtx ? { planId: exCtx.planId, sequence: exCtx.sequence } : undefined,
     }, asset.assetType);
 
-    const destination: Destination = { finId: destinationFinId };
     const receipt = buildReceipt(
       tx, asset, undefined, destination, quantity, 'issue', exCtx, undefined,
     );
@@ -121,11 +120,11 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
   }
 
   async redeem(
-    idempotencyKey: string, nonce: string, sourceFinId: string, asset: Asset,
+    idempotencyKey: string, nonce: string, source: Source, asset: Asset,
     quantity: string, operationId: string | undefined,
     signature: Signature, exCtx: ExecutionContext | undefined,
   ): Promise<ReceiptOperation> {
-    getLogger().info(`Redeeming ${quantity} of ${asset.assetId} from ${sourceFinId}`);
+    getLogger().info(`Redeeming ${quantity} of ${asset.assetId} from ${source.finId}`);
 
     const details = {
       idempotency_key: idempotencyKey,
@@ -135,11 +134,11 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
     };
 
     const tx = operationId
-      ? await this.storage.unlockAndDebit(sourceFinId, quantity, asset.assetId, details, asset.assetType)
-      : await this.storage.debit(sourceFinId, quantity, asset.assetId, details, asset.assetType);
+      ? await this.storage.unlockAndDebit(source.finId, quantity, asset.assetId, details, asset.assetType)
+      : await this.storage.debit(source.finId, quantity, asset.assetId, details, asset.assetType);
 
     const receipt = buildReceipt(
-      tx, asset, { finId: sourceFinId }, undefined, quantity, 'redeem', exCtx, operationId,
+      tx, asset, source, undefined, quantity, 'redeem', exCtx, operationId,
     );
     return successfulReceiptOperation(receipt);
   }

--- a/vanilla-service/src/service.ts
+++ b/vanilla-service/src/service.ts
@@ -477,11 +477,20 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
         getLogger().warn(`Skipping ${operationType} import — asset ${assetId} has no ledgerIdentifier`);
         return;
       }
+      // OSS reports CAIP-19 network/standard as nullable (only tokenId is
+      // non-null upstream), while the transaction-import API accepts
+      // `string | undefined`. Drop nulls here rather than forward them.
+      const { network, standard, tokenId } = ledgerIdentifier;
       const finp2pAccount = {
         account: { finId },
         asset: {
           id: assetId,
-          ledgerIdentifier: { assetIdentifierType: 'CAIP-19' as const, ...ledgerIdentifier },
+          ledgerIdentifier: {
+            assetIdentifierType: 'CAIP-19' as const,
+            tokenId,
+            ...(network ? { network } : {}),
+            ...(standard ? { standard } : {}),
+          },
         },
       };
       const tx = {


### PR DESCRIPTION
Rebases #227 (`feature/onboard`) onto master now that `@owneraio/finp2p-client@0.28.23` is published (#228). Supersedes #227 entirely — it can close once this lands.

## What this adds

**skeleton (0.28.24 → 0.28.25)**
- `NetworkAccountService` interface + `NetworkAccountServiceImpl`, plus `NotSupportedNetworkAccountService` for adapters without onboarding support
- `PgNetworkAccountStore` and the `network_accounts` migration
- `/accounts` routes, mapping, and error types
- `TokenService.issue` / `.redeem` now take `Destination` / `Source` instead of a bare finId, so the per-leg network account reaches implementations

**consumers**
- sample-adapter wires `NetworkAccountServiceImpl` over `PgNetworkAccountStore` (falling back to `NotSupportedNetworkAccountService` with no connection string) and moves to the new `createApp` signature
- vanilla-service (0.28.6 → 0.28.7) adopts the new `TokenService` signatures

**pins off release candidates**

| | before | after |
|---|---|---|
| skeleton → finp2p-client | `^0.28.23-onboard.3` | `^0.28.23` |
| sample-adapter → skeleton | `^0.28.25-onboard.6` | `^0.28.25` |
| vanilla-service → skeleton | `^0.28.25-onboard.6` | `^0.28.25` |
| consumers → finp2p-client | `^0.28.10` / `^0.28.22` | `^0.28.23` |

## What was dropped from #227, and why

All of its `finp2p-client` changes. #227 added **no client methods** — only a spec sync plus regenerated types — and master now carries that in a newer form. #227's specs predate core#2564, core#2573 and oss#557, so keeping them would have regressed master.

## Why skeleton and consumers are in one PR

I first split these (skeleton in #229, consumers in #230), on the assumption that CI builds consumers against the *published* skeleton. **That was wrong.** `ci.yml` runs `npm install ../skeleton` for adapter-tests, vanilla-service and sample-adapter, so they always compile against the working-tree skeleton regardless of their declared pin.

The skeleton-only revision failed CI at `vanilla-service build` for exactly that reason: master's `VanillaServiceImpl.issue/redeem` still take a bare finId while the local skeleton now expects `Destination`/`Source`. A breaking interface change therefore has to land together with its in-repo consumers. The `^0.28.25` pin only matters for real consumers installing from the registry.

The committed manifests still carry semver ranges, not `file:` references — which is the actual hazard when bundling.

## Two things reviewers should decide on

**1. The onboarding trust model here is synchronous.** `createAccount` records a caller-supplied account without issuing an ownership challenge — the same trust the finId→wallet mapping API it replaces extended. The challenge protocol in the OAS (`signatureTemplate` / `walletConnect` / `deposit` / `fireblocksApproval`) is **not** implemented, so `submitAccountProof` — shipped client-side in 0.28.23 — has no skeleton counterpart yet.

**2. `ownershipSignature` is incompatible with a current router.** This branch keeps #227's vendored `dlt-adapter-api.yaml`, where `BindInfo.ownershipSignature` is the full `signature` object (`{signature, template, hashFunc}`, all required). Core master sends `accountOwnershipSignature` = `{signature}` only — no template, no hash function, because there is nothing to template, only challenge bytes to sign. Against a current router this rejects or mis-parses bind requests.

I did **not** fix that here. Re-syncing the spec to core master breaks this branch in five places (nullable `Caip19Identifier.network`/`standard`, the `account` operation variant, `APIErrors`, and the signature shape at `mapping.ts:650`) — implementation work on the feature, not a rebase. Sequenced as a follow-up so the rebase stays reviewable, but **it is required before onboarding works end to end against router 0.28.**

## Verification

`tsc` clean and **35/35** skeleton tests pass locally, including the new migration. Worth noting: skeleton's local `node_modules` had finp2p-client 0.28.7 installed from May, stale enough to produce five phantom type errors — `npm install` was needed before the typecheck meant anything.

## Landing

1. Merge this
2. Tag `skeleton-v0.28.25` → publish
3. Close #227
4. Follow-up: re-sync skeleton's spec to core master and fix the `ownershipSignature` shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)
