### PR TITLE
sample-adapter, vanilla-service: consume skeleton 0.28.25

### DIFF
--- a/sample-adapter/package-lock.json
+++ b/sample-adapter/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@owneraio/finp2p-client": "^0.28.10",
-        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.15",
+        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.25-onboard.6",
         "axios": "1.11.0",
         "ethers": "^6.11.1",
         "express": "5.0.0",
@@ -2628,6 +2628,47 @@
         "express": "5.x.x"
       }
     },
+    "node_modules/@owneraio/adapter-tests/node_modules/@owneraio/finp2p-nodejs-skeleton-adapter": {
+      "version": "0.28.24",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.24/c082ab5ba91dc34958cf59e905a034109e440440",
+      "integrity": "sha512-tqLFl2uHynY6sAYdZ3olF0NnlrYFK085KKNVmTpFxVthIjn/vVJoeyEyNpqPA2UAhJw6mpL5FEpQfVKlRe+KEQ==",
+      "dev": true,
+      "license": "TBD",
+      "dependencies": {
+        "axios": "1.11.0",
+        "bs58": "^6.0.0",
+        "ethers": "^6.11.1",
+        "express": "5.0.0",
+        "express-validator": "^6.14.0",
+        "express-winston": "^4.2.0",
+        "keccak": "^3.0.2",
+        "secp256k1": "^3.7.1",
+        "winston": "^3.18.3"
+      },
+      "peerDependencies": {
+        "@owneraio/finp2p-client": "^0.28.6",
+        "pg": "^8.15.6"
+      }
+    },
+    "node_modules/@owneraio/adapter-tests/node_modules/@owneraio/finp2p-nodejs-skeleton-adapter/node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/@owneraio/adapter-tests/node_modules/@owneraio/finp2p-nodejs-skeleton-adapter/node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@owneraio/adapter-tests/node_modules/axios": {
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
@@ -2683,9 +2724,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-nodejs-skeleton-adapter": {
-      "version": "0.28.15",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.15/990156ffae13b881f4066186b117d73927c5edd9",
-      "integrity": "sha512-YpIzwIHIqfgbgnpcyNN5YMGUZy5TotpndCsoTxNXx0+3/JNRbKBg2uCwzWWuu2DOQymMn8A4zMgbjwaVhJX0Dg==",
+      "version": "0.28.25-onboard.6",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.25-onboard.6/c99954cddeb614446d2fdfb76b652f173fb07e3d",
+      "integrity": "sha512-M0jZRMB8G+/w/qVLTlLid8xPCxx/zlQx+sNXdsaEBMyxp6rP8/2LoTbIiAwnwlVi2slTlksEZ4apxv8pdU/S1w==",
       "license": "TBD",
       "dependencies": {
         "axios": "1.11.0",

--- a/sample-adapter/package.json
+++ b/sample-adapter/package.json
@@ -19,8 +19,8 @@
     "registry": "https://npm.pkg.github.com"
   },
   "dependencies": {
-    "@owneraio/finp2p-client": "^0.28.10",
-    "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.15",
+    "@owneraio/finp2p-client": "^0.28.23",
+    "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.25",
     "axios": "1.11.0",
     "ethers": "^6.11.1",
     "express": "5.0.0",

--- a/sample-adapter/src/app.ts
+++ b/sample-adapter/src/app.ts
@@ -11,6 +11,8 @@ import {
   PaymentsServiceImpl,
   ProofProvider,
   AccountMappingServiceImpl,
+  NetworkAccountServiceImpl,
+  NotSupportedNetworkAccountService,
   workflows,
   storage as skeletonStorage,
 } from '@owneraio/finp2p-nodejs-skeleton-adapter';
@@ -68,6 +70,7 @@ function createApp(orgId: string, finP2PClient: FinP2PClient | undefined, config
   let pool: Pool | undefined;
   let mappingService: routes.AccountMappingService | undefined;
   let mappingConfig: routes.AccountMappingConfig | undefined;
+  let networkAccountService: routes.NetworkAccountService = new NotSupportedNetworkAccountService();
 
   if (config?.connectionString) {
     pool = new Pool({ connectionString: config.connectionString });
@@ -105,6 +108,8 @@ function createApp(orgId: string, finP2PClient: FinP2PClient | undefined, config
 
     const accountStore = new skeletonStorage.PgAccountStore(pool, schemaName);
     mappingService = new AccountMappingServiceImpl(accountStore);
+    const networkAccountStore = new skeletonStorage.PgNetworkAccountStore(pool, schemaName);
+    networkAccountService = new NetworkAccountServiceImpl(networkAccountStore);
     mappingConfig = {
       fields: [
         {
@@ -124,8 +129,8 @@ function createApp(orgId: string, finP2PClient: FinP2PClient | undefined, config
     tokenService,
     paymentsService,
     planApprovalService,
-    mappingConfig,
-    mappingService,
+    networkAccountService,
+    { mappingConfig, mappingService },
   );
 
   return { app, pool };

--- a/sample-adapter/src/services/inmemory/tokens.ts
+++ b/sample-adapter/src/services/inmemory/tokens.ts
@@ -60,11 +60,10 @@ export class TokenServiceImpl extends CommonServiceImpl implements TokenService 
     return this.storage.getBalance(finId, asset.assetId);
   }
 
-  public async issue(idempotencyKey: string, asset: Asset, destinationFinId: string, quantity: string, exCtx: ExecutionContext | undefined): Promise<ReceiptOperation> {
-    logger.info(`Issuing ${quantity} of ${asset.assetId} to ${destinationFinId}`);
+  public async issue(idempotencyKey: string, asset: Asset, destination: Destination, quantity: string, exCtx: ExecutionContext | undefined): Promise<ReceiptOperation> {
+    logger.info(`Issuing ${quantity} of ${asset.assetId} to ${destination.finId}`);
 
-    this.storage.credit(destinationFinId, quantity, asset.assetId);
-    const destination: Destination = { finId: destinationFinId };
+    this.storage.credit(destination.finId, quantity, asset.assetId);
     const tx = new Transaction(quantity, asset, undefined, destination, exCtx, 'issue', undefined);
     this.storage.registerTransaction(tx);
     let receipt = tx.toReceipt();
@@ -90,12 +89,12 @@ export class TokenServiceImpl extends CommonServiceImpl implements TokenService 
     return successfulReceiptOperation(receipt);
   }
 
-  public async redeem(idempotencyKey: string, nonce: string, sourceFinId: string, asset: Asset, quantity: string, operationId: string | undefined,
+  public async redeem(idempotencyKey: string, nonce: string, source: Source, asset: Asset, quantity: string, operationId: string | undefined,
     signature: Signature, exCtx: ExecutionContext | undefined,
   ): Promise<ReceiptOperation> {
-    logger.info(`Redeeming ${quantity} of ${asset.assetId} from ${sourceFinId}`);
+    logger.info(`Redeeming ${quantity} of ${asset.assetId} from ${source.finId}`);
 
-    // if (!await verifySignature(signature, sourceFinId)) {
+    // if (!await verifySignature(signature, source.finId)) {
     //   return failedReceiptOperation(1, 'Signature verification failed');
     // }
 
@@ -107,10 +106,9 @@ export class TokenServiceImpl extends CommonServiceImpl implements TokenService 
       // do no movement, account is effected at hold time
       this.storage.removeHoldOperation(operationId);
     } else {
-      this.storage.debit(sourceFinId, quantity, asset.assetId);
+      this.storage.debit(source.finId, quantity, asset.assetId);
     }
 
-    const source: Source = { finId: sourceFinId };
     const tx = new Transaction(quantity, asset, source, undefined, exCtx, 'redeem', operationId);
     this.storage.registerTransaction(tx);
     let receipt = tx.toReceipt();

--- a/vanilla-service/package-lock.json
+++ b/vanilla-service/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@owneraio/finp2p-vanilla-service",
-  "version": "0.28.6",
+  "version": "0.28.7-onboard.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-vanilla-service",
-      "version": "0.28.6",
+      "version": "0.28.7-onboard.1",
       "license": "TBD",
       "dependencies": {
-        "@owneraio/finp2p-client": "^0.28.12",
-        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.15",
+        "@owneraio/finp2p-client": "^0.28.22",
+        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.25-onboard.6",
         "bs58": "^6.0.0",
         "pg": "^8.15.6",
         "winston": "^3.18.3"
@@ -1408,9 +1408,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-client": {
-      "version": "0.28.12",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-client/0.28.12/24845c014328dc66358a33c890a7c7c0cf91b629",
-      "integrity": "sha512-ReaXR7zbrtlBECm+N+ZL/QUB3H5ptCyz3k+9Qz4uvsgKBVr3Q8NCvf3ikdbAb1f8JsM45feBiz3YdnV7GSmtrg==",
+      "version": "0.28.22",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-client/0.28.22/dcc20fa57426f112da194855269382211fc98441",
+      "integrity": "sha512-dZ7DaEPen5cu2RtZlg43eeB1V9SOxpSFOrIQeq5xBYx+DWzLDOHJPVfBJrsGImQy3z4JlXeV2KNz2wOTGkREjg==",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.12.2",
@@ -1420,9 +1420,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-nodejs-skeleton-adapter": {
-      "version": "0.28.15",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.15/990156ffae13b881f4066186b117d73927c5edd9",
-      "integrity": "sha512-YpIzwIHIqfgbgnpcyNN5YMGUZy5TotpndCsoTxNXx0+3/JNRbKBg2uCwzWWuu2DOQymMn8A4zMgbjwaVhJX0Dg==",
+      "version": "0.28.25-onboard.6",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.25-onboard.6/c99954cddeb614446d2fdfb76b652f173fb07e3d",
+      "integrity": "sha512-M0jZRMB8G+/w/qVLTlLid8xPCxx/zlQx+sNXdsaEBMyxp6rP8/2LoTbIiAwnwlVi2slTlksEZ4apxv8pdU/S1w==",
       "license": "TBD",
       "dependencies": {
         "axios": "1.11.0",

--- a/vanilla-service/package.json
+++ b/vanilla-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@owneraio/finp2p-vanilla-service",
-  "version": "0.28.6",
-  "description": "Vanilla DB ledger service for FinP2P adapters — per-investor balance segregation in PostgreSQL",
+  "version": "0.28.7",
+  "description": "Vanilla DB ledger service for FinP2P adapters \u2014 per-investor balance segregation in PostgreSQL",
   "main": "./dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
@@ -20,8 +20,8 @@
   "author": "",
   "license": "TBD",
   "dependencies": {
-    "@owneraio/finp2p-client": "^0.28.12",
-    "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.15",
+    "@owneraio/finp2p-client": "^0.28.23",
+    "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.25",
     "bs58": "^6.0.0",
     "pg": "^8.15.6",
     "winston": "^3.18.3"

--- a/vanilla-service/src/service.ts
+++ b/vanilla-service/src/service.ts
@@ -51,19 +51,18 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
   }
 
   async issue(
-    idempotencyKey: string, asset: Asset, destinationFinId: string,
+    idempotencyKey: string, asset: Asset, destination: Destination,
     quantity: string, exCtx: ExecutionContext | undefined,
   ): Promise<ReceiptOperation> {
-    getLogger().info(`Issuing ${quantity} of ${asset.assetId} to ${destinationFinId}`);
+    getLogger().info(`Issuing ${quantity} of ${asset.assetId} to ${destination.finId}`);
 
-    await this.storage.ensureAccount(destinationFinId, asset.assetId, asset.assetType);
-    const tx = await this.storage.credit(destinationFinId, quantity, asset.assetId, {
+    await this.storage.ensureAccount(destination.finId, asset.assetId, asset.assetType);
+    const tx = await this.storage.credit(destination.finId, quantity, asset.assetId, {
       idempotency_key: idempotencyKey,
       operation_type: 'issue',
       execution_context: exCtx ? { planId: exCtx.planId, sequence: exCtx.sequence } : undefined,
     }, asset.assetType);
 
-    const destination: Destination = { finId: destinationFinId };
     const receipt = buildReceipt(
       tx, asset, undefined, destination, quantity, 'issue', exCtx, undefined,
     );
@@ -121,11 +120,11 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
   }
 
   async redeem(
-    idempotencyKey: string, nonce: string, sourceFinId: string, asset: Asset,
+    idempotencyKey: string, nonce: string, source: Source, asset: Asset,
     quantity: string, operationId: string | undefined,
     signature: Signature, exCtx: ExecutionContext | undefined,
   ): Promise<ReceiptOperation> {
-    getLogger().info(`Redeeming ${quantity} of ${asset.assetId} from ${sourceFinId}`);
+    getLogger().info(`Redeeming ${quantity} of ${asset.assetId} from ${source.finId}`);
 
     const details = {
       idempotency_key: idempotencyKey,
@@ -135,11 +134,11 @@ export class VanillaServiceImpl implements TokenService, EscrowService, CommonSe
     };
 
     const tx = operationId
-      ? await this.storage.unlockAndDebit(sourceFinId, quantity, asset.assetId, details, asset.assetType)
-      : await this.storage.debit(sourceFinId, quantity, asset.assetId, details, asset.assetType);
+      ? await this.storage.unlockAndDebit(source.finId, quantity, asset.assetId, details, asset.assetType)
+      : await this.storage.debit(source.finId, quantity, asset.assetId, details, asset.assetType);
 
     const receipt = buildReceipt(
-      tx, asset, { finId: sourceFinId }, undefined, quantity, 'redeem', exCtx, operationId,
+      tx, asset, source, undefined, quantity, 'redeem', exCtx, operationId,
     );
     return successfulReceiptOperation(receipt);
   }


### PR DESCRIPTION
Consumer half of the #227 rebase. **Stacked on #229** (base is `task/onboard-rebased`, not master) so the diff shows only the consumer changes.

## What this does

- **sample-adapter** — constructs `NetworkAccountServiceImpl` over `PgNetworkAccountStore`, falling back to `NotSupportedNetworkAccountService` when there's no connection string; moves to the new `createApp(..., networkAccountService, { mappingConfig, mappingService })` signature
- **vanilla-service** — adopts the `Source`/`Destination`-carrying `TokenService.issue` / `.redeem` signatures

## Pins moved off release candidates

| | before | after |
|---|---|---|
| skeleton | `^0.28.25-onboard.6` | `^0.28.25` |
| finp2p-client (sample-adapter) | `^0.28.10` | `^0.28.23` |
| finp2p-client (vanilla-service) | `^0.28.22` | `^0.28.23` |
| vanilla-service version | `0.28.7-onboard.1` | `0.28.7` |

## Merge order — this PR cannot go green yet

`^0.28.25` does not resolve until `skeleton-v0.28.25` is published. **CI here will fail until then, and that is expected**, not a broken branch.

1. Merge #229
2. Tag `skeleton-v0.28.25` → publish
3. Retarget this PR to `master` and merge

Splitting this way is what keeps `file:`-protocol references out of the consumer `package.json` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)