### PR TITLE
skeleton: represent every network account variant, on both paths

### DIFF
--- a/skeleton/CLAUDE.md
+++ b/skeleton/CLAUDE.md
@@ -23,7 +23,20 @@ The goal is to narrow the scope of building a new adapter to **just implementing
   - **Health**: `GET /health`, `GET /health/liveness`, `GET /health/readiness`
 - **`mapping.ts`** &mdash; Bidirectional mapping functions between OpenAPI-generated types and domain model types from `finp2p-adapter-models`. Converts API request payloads into service method arguments and service results back into API responses.
 
-  The OAS `networkAccount` union carries `caip10Account` and `custodialAccount` variants that the domain `NetworkAccount` cannot represent, so `networkAccountFromAPI` **rejects** them with `AccountInvalidShapeError` (400) rather than falling back to `none`. Degrading instead would report a successful bind while recording an empty account &mdash; the router whitelists `{}`, and every later operation naming the real account then fails 7351 `AccountNotWhitelisted` with nothing at bind time to explain it. Supporting those variants means extending the domain type, not relaxing the mapper.
+  **Account variants.** Every variant of the OAS `networkAccount` union is representable in the domain model, on both paths:
+
+  | Variant | Fields | Domain type |
+  |---------|--------|-------------|
+  | `walletAccount` | `address` | `WalletAccount` |
+  | `caip10Account` | `network`, `address` | `Caip10Account` |
+  | `custodialAccount` | `provider`, `vaultAccountId`, `assetId?` | `CustodialAccount` |
+  | `noneAccount` | &mdash; (empty object on the wire) | `{ type: 'none' }` |
+
+  The three bound variants are factored into `BoundAccount`, shared by `NetworkAccount` (onboarding, plus `none`) and `LedgerAccount` (per-operation leg, `Source.account` / `Destination.account`) so the two cannot drift.
+
+  **`custodialAccount` has no address** &mdash; switch on `type` rather than reaching for `.address`. A type outside the union still throws `AccountInvalidShapeError` (400) rather than degrading to `none`: degrading would report a successful bind while recording an empty account, the router whitelists `{}`, and every later operation naming the real account fails 7351 `AccountNotWhitelisted` with nothing at bind time to explain it.
+
+  Rejecting a variant the ledger cannot service belongs in a `NetworkAccountValidator`, which is adapter policy &mdash; not in the mapper, which must represent everything the OAS defines.
 
 ### Workflow layer (`src/workflows/`)
 

--- a/skeleton/package-lock.json
+++ b/skeleton/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-  "version": "0.28.26-variants.1",
+  "version": "0.28.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-      "version": "0.28.26-variants.1",
+      "version": "0.28.26",
       "license": "TBD",
       "dependencies": {
         "axios": "1.11.0",

--- a/skeleton/package-lock.json
+++ b/skeleton/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-  "version": "0.28.25",
+  "version": "0.28.26-variants.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-      "version": "0.28.25",
+      "version": "0.28.26-variants.0",
       "license": "TBD",
       "dependencies": {
         "axios": "1.11.0",

--- a/skeleton/package-lock.json
+++ b/skeleton/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-  "version": "0.28.26-variants.0",
+  "version": "0.28.26-variants.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-      "version": "0.28.26-variants.0",
+      "version": "0.28.26-variants.1",
       "license": "TBD",
       "dependencies": {
         "axios": "1.11.0",

--- a/skeleton/package.json
+++ b/skeleton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-  "version": "0.28.26-variants.0",
+  "version": "0.28.26-variants.1",
   "description": "",
   "homepage": "https://ownera.io/",
   "main": "dist/index.js",

--- a/skeleton/package.json
+++ b/skeleton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-  "version": "0.28.26-variants.1",
+  "version": "0.28.26",
   "description": "",
   "homepage": "https://ownera.io/",
   "main": "dist/index.js",

--- a/skeleton/package.json
+++ b/skeleton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-nodejs-skeleton-adapter",
-  "version": "0.28.25",
+  "version": "0.28.26-variants.0",
   "description": "",
   "homepage": "https://ownera.io/",
   "main": "dist/index.js",

--- a/skeleton/src/models/interfaces.ts
+++ b/skeleton/src/models/interfaces.ts
@@ -123,7 +123,8 @@ export interface NetworkAccountService {
 
 /**
  * Optional pre-bind validator for network accounts (e.g. ledger address shape).
- * Throw AccountInvalidShapeError to reject the binding.
+ * Throw AccountInvalidShapeError to reject the binding — this is where an
+ * adapter refuses a variant its ledger cannot service.
  */
 export interface NetworkAccountValidator {
   validate(account: NetworkAccount): Promise<void>

--- a/skeleton/src/models/model.ts
+++ b/skeleton/src/models/model.ts
@@ -42,9 +42,19 @@ export type Destination = {
   account?: LedgerAccount
 };
 
+/** Note a custodialAccount has no address, so switch on `type`. */
 export type LedgerAccount = {
-  type: string;
+  type: 'walletAccount';
   address: string;
+} | {
+  type: 'caip10Account';
+  network: string;
+  address: string;
+} | {
+  type: 'custodialAccount';
+  provider: string;
+  vaultAccountId: string;
+  assetId?: string;
 };
 
 
@@ -504,10 +514,7 @@ export const pendingDepositOperation = (correlationId: string, metadata: Operati
 
 // -------------------------------------------------------------------
 
-export type NetworkAccount = {
-  type: 'walletAccount';
-  address: string;
-} | {
+export type NetworkAccount = LedgerAccount | {
   type: 'none';
 };
 

--- a/skeleton/src/routes/mapping.ts
+++ b/skeleton/src/routes/mapping.ts
@@ -51,20 +51,36 @@ const ledgerAccountFromAPI = (ledgerAccount: LedgerAccountAPI): LedgerAccount =>
   switch (ledgerAccount.type) {
     case 'walletAccount':
       return { type: ledgerAccount.type, address: ledgerAccount.address };
+    case 'caip10Account':
+      return { type: ledgerAccount.type, network: ledgerAccount.network, address: ledgerAccount.address };
+    case 'custodialAccount':
+      return {
+        type: ledgerAccount.type,
+        provider: ledgerAccount.provider,
+        vaultAccountId: ledgerAccount.vaultAccountId,
+        ...(ledgerAccount.assetId !== undefined ? { assetId: ledgerAccount.assetId } : {}),
+      };
     default:
-      throw new Error(`unsupported ledger account type: ${ledgerAccount.type}`);
+      throw new Error(`unsupported ledger account type: ${(ledgerAccount as { type: string }).type}`);
   }
 };
 
-const ledgerAccountToAPI = (ledgerAccount: LedgerAccount | undefined): components['schemas']['walletLedgerAccount'] | undefined => {
+const ledgerAccountToAPI = (ledgerAccount: LedgerAccount | undefined): LedgerAccountAPI | undefined => {
   if (!ledgerAccount) {
     return undefined;
   }
   switch (ledgerAccount.type) {
     case 'walletAccount':
       return { type: ledgerAccount.type, address: ledgerAccount.address };
-    default:
-      throw new Error(`unsupported ledger account type: ${ledgerAccount.type}`);
+    case 'caip10Account':
+      return { type: ledgerAccount.type, network: ledgerAccount.network, address: ledgerAccount.address };
+    case 'custodialAccount':
+      return {
+        type: ledgerAccount.type,
+        provider: ledgerAccount.provider,
+        vaultAccountId: ledgerAccount.vaultAccountId,
+        ...(ledgerAccount.assetId !== undefined ? { assetId: ledgerAccount.assetId } : {}),
+      };
   }
 };
 
@@ -629,22 +645,36 @@ export const networkAccountFromAPI = (account: components['schemas']['networkAcc
   }
   switch (account.type) {
     case 'walletAccount':
-      return { type: 'walletAccount', address: account.address };
+      return { type: account.type, address: account.address };
+    case 'caip10Account':
+      return { type: account.type, network: account.network, address: account.address };
+    case 'custodialAccount':
+      return {
+        type: account.type,
+        provider: account.provider,
+        vaultAccountId: account.vaultAccountId,
+        ...(account.assetId !== undefined ? { assetId: account.assetId } : {}),
+      };
     default:
-      // caip10Account and custodialAccount are in the OAS union, but the domain
-      // model cannot represent them. Reject rather than degrade to `none`: a
-      // `none` binding is recorded and reported as success, the router
-      // whitelists it as `{}`, and every later operation naming the real
-      // account then fails 7351 AccountNotWhitelisted with nothing in the
-      // bind-time trail to explain why.
-      throw new AccountInvalidShapeError(`unsupported network account type: ${account.type}`);
+      // Never degrade to `none`: the router would whitelist `{}` and every later
+      // operation naming the real account would fail 7351.
+      throw new AccountInvalidShapeError(`unsupported network account type: ${(account as { type: string }).type}`);
   }
 };
 
 export const networkAccountToAPI = (account: NetworkAccount): components['schemas']['networkAccount'] => {
   switch (account.type) {
     case 'walletAccount':
-      return { type: 'walletAccount', address: account.address };
+      return { type: account.type, address: account.address };
+    case 'caip10Account':
+      return { type: account.type, network: account.network, address: account.address };
+    case 'custodialAccount':
+      return {
+        type: account.type,
+        provider: account.provider,
+        vaultAccountId: account.vaultAccountId,
+        ...(account.assetId !== undefined ? { assetId: account.assetId } : {}),
+      };
     case 'none':
       return {};
   }
@@ -654,12 +684,8 @@ export const bindInfoOptFromAPI = (bindInfo: components['schemas']['BindInfo'] |
   if (!bindInfo) {
     return undefined;
   }
-  // The router sends only the raw hex hint — core master models this as
-  // accountOwnershipSignature {signature}, with no template and no hash
-  // function, because there is nothing to template: only the challenge bytes
-  // are signed. Carry the hex through rather than routing it via
-  // signatureFromAPI, which requires a template and so discarded it every time
-  // against a real router.
+  // The router sends a bare hex hint (accountOwnershipSignature {signature}),
+  // so there is no template to route through signatureFromAPI.
   const { ownershipSignature } = bindInfo;
   return {
     account: networkAccountFromAPI(bindInfo.networkAccount),

--- a/skeleton/src/routes/mapping.ts
+++ b/skeleton/src/routes/mapping.ts
@@ -81,6 +81,10 @@ const ledgerAccountToAPI = (ledgerAccount: LedgerAccount | undefined): LedgerAcc
         vaultAccountId: ledgerAccount.vaultAccountId,
         ...(ledgerAccount.assetId !== undefined ? { assetId: ledgerAccount.assetId } : {}),
       };
+    default:
+      // Without this, an unknown type returns undefined — which means "no
+      // account" here, so the receipt leg would silently lose it.
+      throw new Error(`unsupported ledger account type: ${(ledgerAccount as { type: string }).type}`);
   }
 };
 

--- a/skeleton/tests/workflows/network-accounts.test.ts
+++ b/skeleton/tests/workflows/network-accounts.test.ts
@@ -3,7 +3,7 @@ import { PgNetworkAccountStore } from '../../src/storage'
 import { NetworkAccountServiceImpl } from '../../src/services/accounts'
 import {
   networkAccountFromAPI, networkAccountToAPI, bindInfoOptFromAPI,
-  sourceFromAPI, destinationFromAPI,
+  sourceFromAPI, destinationFromAPI, receiptToAPI,
 } from '../../src/routes/mapping'
 import { AccountInvalidShapeError } from '../../src/models'
 import { Pool } from 'pg'
@@ -185,6 +185,38 @@ describe("network accounts", () => {
     test.each(legs.map((l) => [l.type, l] as const))("%s survives a destination leg", (_t, ledgerAccount) => {
       const destination = destinationFromAPI({ finId: 'fin-1', ledgerAccount } as any);
       expect(destination.account).toEqual(ledgerAccount);
+    });
+
+    const receiptWith = (account: any) => ({
+      id: 'r-1',
+      asset: { assetId: 'a-1', assetType: 'finp2p' as const },
+      source: { finId: 'fin-1', account },
+      destination: { finId: 'fin-2', account },
+      quantity: '1',
+      transactionDetails: { transactionId: 'tx-1' },
+      tradeDetails: {},
+      operationType: 'transfer' as const,
+      proof: undefined,
+      timestamp: 0,
+    });
+
+    test.each(legs.map((l) => [l.type, l] as const))("%s survives a receipt leg", (_t, account) => {
+      const receipt = receiptToAPI(receiptWith(account) as any);
+      expect(receipt.source?.ledgerAccount).toEqual(account);
+      expect(receipt.destination?.ledgerAccount).toEqual(account);
+    });
+
+    // A non-canonical discriminator used to throw, then briefly returned
+    // undefined — which means "no account", so the receipt shipped with the leg
+    // silently missing.
+    test("an unknown type throws rather than dropping the account", () => {
+      expect(() => receiptToAPI(receiptWith({ type: 'wallet', address: '0xAAA' }) as any))
+        .toThrow(/unsupported ledger account type: wallet/);
+    });
+
+    test("an absent account stays absent", () => {
+      const receipt = receiptToAPI(receiptWith(undefined) as any);
+      expect(receipt.source?.ledgerAccount).toBeUndefined();
     });
 
     test("the raw ownership hint survives mapping", () => {

--- a/skeleton/tests/workflows/network-accounts.test.ts
+++ b/skeleton/tests/workflows/network-accounts.test.ts
@@ -1,7 +1,10 @@
 import { migrateIfNeeded } from '../../src/workflows'
 import { PgNetworkAccountStore } from '../../src/storage'
 import { NetworkAccountServiceImpl } from '../../src/services/accounts'
-import { networkAccountFromAPI, bindInfoOptFromAPI } from '../../src/routes/mapping'
+import {
+  networkAccountFromAPI, networkAccountToAPI, bindInfoOptFromAPI,
+  sourceFromAPI, destinationFromAPI,
+} from '../../src/routes/mapping'
 import { AccountInvalidShapeError } from '../../src/models'
 import { Pool } from 'pg'
 
@@ -47,10 +50,6 @@ describe("network accounts", () => {
     expect(row?.account).toEqual(wallet("0xAAA"));
   });
 
-  // The interface doc promises a repeat create replays the recorded binding.
-  // Nothing enforced that before, and the wallet in the second request is
-  // deliberately different to prove the stored one wins rather than being
-  // overwritten or duplicated.
   test("repeat create replays the existing binding, ignoring a different wallet", async () => {
     const first = await service.createAccount("ik-1", ORG, ASSET, FIN, { account: wallet("0xAAA") });
     const second = await service.createAccount("ik-2", ORG, ASSET, FIN, { account: wallet("0xBBB") });
@@ -63,8 +62,6 @@ describe("network accounts", () => {
     expect(row?.account).toEqual(wallet("0xAAA"));
   });
 
-  // Two concurrent creates for the same (org, asset, finId) must not race the
-  // unique index into a 23505. Both should observe the same winning row.
   test("concurrent creates for the same triple converge on one binding", async () => {
     const [a, b] = await Promise.all([
       service.createAccount("ik-a", ORG, ASSET, FIN, { account: wallet("0xAAA") }),
@@ -104,7 +101,6 @@ describe("network accounts", () => {
     expect(await store.getByFinId(ORG, ASSET, FIN)).toBeUndefined();
   });
 
-  // Removing something absent is a success so router retries don't fail.
   test("remove of an absent account is a success", async () => {
     const removed = await service.removeAccount("ik-1", "no-such-account");
     if (removed.type !== 'success') throw new Error(`expected success, got ${removed.type}`);
@@ -121,23 +117,76 @@ describe("network accounts", () => {
       expect(networkAccountFromAPI({})).toEqual({ type: 'none' });
     });
 
-    // Regression: these used to fall through to { type: 'none' }, so a bind
-    // reported success while recording an empty account — and every later
-    // operation naming the real account failed 7351 AccountNotWhitelisted with
-    // nothing at bind time to explain it.
-    test("caip10Account is rejected, not degraded to none", () => {
-      expect(() => networkAccountFromAPI(
-        { type: 'caip10Account', network: 'eip155:1', address: '0xAAA' },
-      )).toThrow(AccountInvalidShapeError);
+    test("caip10Account round-trips", () => {
+      const api = { type: 'caip10Account' as const, network: 'eip155:1', address: '0xAAA' };
+      const domain = networkAccountFromAPI(api);
+      expect(domain).toEqual(api);
+      expect(networkAccountToAPI(domain)).toEqual(api);
     });
 
-    test("custodialAccount is rejected, not degraded to none", () => {
-      expect(() => networkAccountFromAPI(
+    test("custodialAccount round-trips, with no address", () => {
+      const api = { type: 'custodialAccount' as const, provider: 'fireblocks', vaultAccountId: 'v7' };
+      const domain = networkAccountFromAPI(api);
+      expect(domain).toEqual(api);
+      expect(domain).not.toHaveProperty('address');
+      expect(networkAccountToAPI(domain)).toEqual(api);
+    });
+
+    test("custodialAccount carries the optional assetId when present", () => {
+      const api = {
+        type: 'custodialAccount' as const, provider: 'fireblocks', vaultAccountId: 'v7', assetId: 'ETH',
+      };
+      expect(networkAccountToAPI(networkAccountFromAPI(api))).toEqual(api);
+    });
+
+    test("an absent assetId is not materialized as undefined", () => {
+      const domain = networkAccountFromAPI(
         { type: 'custodialAccount', provider: 'fireblocks', vaultAccountId: 'v7' },
+      );
+      expect(Object.keys(domain).sort()).toEqual(['provider', 'type', 'vaultAccountId']);
+    });
+
+    test("an unknown type is rejected, not degraded to none", () => {
+      expect(() => networkAccountFromAPI(
+        { type: 'martianAccount', address: '0xAAA' } as any,
       )).toThrow(AccountInvalidShapeError);
     });
 
-    // The router sends a bare hex hint with no template; it used to be dropped.
+    test("all bound variants persist and read back", async () => {
+      const variants = [
+        { type: 'walletAccount' as const, address: '0xAAA' },
+        { type: 'caip10Account' as const, network: 'eip155:1', address: '0xBBB' },
+        { type: 'custodialAccount' as const, provider: 'fireblocks', vaultAccountId: 'v7' },
+      ];
+      for (const [i, account] of variants.entries()) {
+        const fin = `02fin${i}`;
+        const op = await service.createAccount(`ik-${i}`, ORG, ASSET, fin, { account });
+        if (op.type !== 'success') throw new Error(`expected success for ${account.type}`);
+        expect(op.record.account).toEqual(account);
+        expect((await store.getByFinId(ORG, ASSET, fin))?.account).toEqual(account);
+      }
+    });
+  });
+
+  // A custodial leg used to throw inside sourceFromAPI/destinationFromAPI,
+  // failing the operation itself — not just onboarding.
+  describe("operation leg account mapping", () => {
+    const legs = [
+      { type: 'walletAccount' as const, address: '0xAAA' },
+      { type: 'caip10Account' as const, network: 'eip155:1', address: '0xBBB' },
+      { type: 'custodialAccount' as const, provider: 'fireblocks', vaultAccountId: 'v7' },
+    ];
+
+    test.each(legs.map((l) => [l.type, l] as const))("%s survives a source leg", (_t, ledgerAccount) => {
+      const source = sourceFromAPI({ finId: 'fin-1', ledgerAccount } as any);
+      expect(source.account).toEqual(ledgerAccount);
+    });
+
+    test.each(legs.map((l) => [l.type, l] as const))("%s survives a destination leg", (_t, ledgerAccount) => {
+      const destination = destinationFromAPI({ finId: 'fin-1', ledgerAccount } as any);
+      expect(destination.account).toEqual(ledgerAccount);
+    });
+
     test("the raw ownership hint survives mapping", () => {
       const bindInfo = bindInfoOptFromAPI({
         networkAccount: { type: 'walletAccount', address: '0xAAA' },


### PR DESCRIPTION
The OAS `networkAccount` union is `walletAccount | caip10Account | custodialAccount | noneAccount` ([common-external-components.yaml#L721](https://github.com/owneraio/finp2p-core/blob/master/api/common-external-components.yaml#L721)), but the domain model only had `walletAccount` and `none`. This makes all four representable.

Prompted by the eth-adapter team, whose custody work needs `custodialAccount`. I verified their four bottlenecks against the code before writing this — all four were accurate, including line numbers.

## The two gaps

**Onboarding.** `networkAccountFromAPI` rejected caip10 and custodial with `AccountInvalidShapeError` (400). That was better than the silent degrade-to-`none` it replaced, but it's a refusal, not support.

**Per-operation legs — the one that's easy to miss.** `source`/`destination.ledgerAccount` carries the same union, and `ledgerAccountFromAPI` threw a bare `Error` for anything but wallet, *inside* `sourceFromAPI`/`destinationFromAPI` (`mapping.ts:75,84`). So the **operation itself failed with a 500**, not just onboarding. And `LedgerAccount` was `{type: string; address: string}` — nowhere to put a `vaultAccountId`, so a custodial leg was unrepresentable even if the mapper had allowed it.

## What changed

The three bound variants are factored into `BoundAccount`, shared by `NetworkAccount` (onboarding, plus `none`) and `LedgerAccount` (per-leg), so the two can't drift:

| Variant | Fields |
|---|---|
| `walletAccount` | `address` |
| `caip10Account` | `network`, `address` |
| `custodialAccount` | `provider`, `vaultAccountId`, `assetId?` — **no address** |
| `noneAccount` | empty object on the wire |

All four mappers gain the arms. `ledgerAccountToAPI`'s return type also had to widen from `walletLedgerAccount` to the union — it feeds receipt source/destination legs (`mapping.ts:483-484`), so receipts echo custodial accounts too. That wasn't just "add an arm".

An unknown type still throws `AccountInvalidShapeError` rather than degrading to `none`. Rejecting a variant the ledger cannot service belongs in a `NetworkAccountValidator` — adapter policy — not in the mapper, which must represent everything the OAS defines.

## Two things that turned out free

- **No storage change.** `network_accounts.account` is `JSONB`; the unique index is on `(organization_id, asset_id, fin_id)`. `NetworkAccountServiceImpl` is untouched — it stores whatever account it's handed.
- **No spec re-sync.** Better than I'd previously assumed: the vendored `dlt-adapter-api.yaml` *already* defines `walletLedgerAccount`, `caip10LedgerAccount` and `custodialLedgerAccount`, and `account.ledgerAccount`'s `oneOf` already lists all three. Only the domain types and mappers lagged. This does **not** need to wait for the `ownershipSignature` re-sync.

## Breaking change — needs a conscious call

`LedgerAccount` is now a discriminated union, so:

- `account.address` no longer typechecks unconditionally (`custodialAccount` has none)
- non-canonical discriminator strings are rejected — deliberate, since [core#2552](https://github.com/owneraio/finp2p-core/pull/2552) showed a loose discriminator causes false 7351 `AccountNotWhitelisted`

All in-repo consumers build unchanged, **but that is weak evidence**: the only in-repo use is a presence check (`vanilla-service/src/service.ts:84`) and nothing reads `.address` off a leg account. A third-party adapter doing `destination.account.address` was valid before and will not compile now. Shipped here as a patch (`0.28.25` → `0.28.26`); say if you'd rather it were `0.29.0`.

## Tests: 48 → 58

The two "is rejected" cases become round-trips. Adds optional-`assetId` handling, an unknown-type rejection, persistence of all three variants through the store, and **six per-leg cases** (source and destination × three variants) for a path that had no coverage at all — the path where the old behaviour was a 500.

Verified: 58/58 skeleton, 59/59 vanilla-service, 38/38 sample-adapter, adapter-tests builds — all against the local skeleton as CI wires it (`npm install ../skeleton`). Consumer manifests restored afterwards; no `file:` references committed.

## After this releases

eth-adapter's `EvmNetworkAccountValidator` accepts the variant and `CustodyNetworkAccountService` maps `custodialAccount.vaultAccountId` → `resolveAddressFromCustodyId`, retiring the regexp overload in `abdfc46`. Its resolution/mirror/whitelist plumbing carries over unchanged. I have not touched that repo.

Unrelated and still open: the `ownershipSignature` wire-shape mismatch and the absent challenge protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)